### PR TITLE
Fix Ironsmith parse failure: Increasing Confusion

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry/subject_verb_followups.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry/subject_verb_followups.rs
@@ -1039,6 +1039,10 @@ fn post_rule_future_zone_and_self_replacement(
         {
             let (default_effects, carried_player) =
                 default_effects_for_self_replacement(state.effects, previous);
+            if let Some(mill_count) = default_effects.iter().rev().find_map(mill_count_from_effect)
+            {
+                replace_mill_event_amounts_with_value(&mut if_true, &mill_count);
+            }
             if let Some(player) = carried_player {
                 bind_that_player_subjects_in_effects(&mut if_true, player);
             }
@@ -1116,6 +1120,54 @@ fn bind_that_player_subjects(effect: &mut EffectAst, player: PlayerAst) {
 fn bind_that_player_subjects_in_effects(effects: &mut [EffectAst], player: PlayerAst) {
     for effect in effects {
         bind_that_player_subjects(effect, player);
+    }
+}
+
+fn mill_count_from_effect(effect: &EffectAst) -> Option<Value> {
+    match effect {
+        EffectAst::SubjectVerb(SubjectVerbEffectAst {
+            action: SubjectVerbActionAst::Mill { count },
+            ..
+        }) => Some(count.clone()),
+        _ => None,
+    }
+}
+
+fn replace_event_amount_with_value(value: &mut Value, replacement: &Value) {
+    match value {
+        Value::EventValue(crate::effect::EventValueSpec::Amount) => {
+            *value = replacement.clone();
+        }
+        Value::EventValueOffset(crate::effect::EventValueSpec::Amount, offset) => {
+            *value = Value::Add(Box::new(replacement.clone()), Box::new(Value::Fixed(*offset)));
+        }
+        Value::Add(left, right) | Value::Min(left, right) => {
+            replace_event_amount_with_value(left, replacement);
+            replace_event_amount_with_value(right, replacement);
+        }
+        Value::Scaled(inner, _)
+        | Value::DividedRoundedDown(inner, _)
+        | Value::HalfRoundedDown(inner)
+        | Value::SurfaceHinted { value: inner, .. } => {
+            replace_event_amount_with_value(inner, replacement);
+        }
+        _ => {}
+    }
+}
+
+fn replace_mill_event_amounts_with_value(effects: &mut [EffectAst], replacement: &Value) {
+    for effect in effects {
+        if let EffectAst::SubjectVerb(SubjectVerbEffectAst {
+            action: SubjectVerbActionAst::Mill { count },
+            ..
+        }) = effect
+        {
+            replace_event_amount_with_value(count, replacement);
+        }
+
+        for_each_nested_effects_mut(effect, true, |nested| {
+            replace_mill_event_amounts_with_value(nested, replacement);
+        });
     }
 }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/misc_actions.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/misc_actions.rs
@@ -37,6 +37,7 @@ const SIDED_WORD_PATTERN: ClauseShape<'static> = clause_shape!(exact & ["sided"]
 const DIE_WORD_PATTERN: ClauseShape<'static> = clause_shape!(exact_any & [&["die"], &["dice"]]);
 const CARD_OR_CARDS_PATTERN: ClauseShape<'static> =
     clause_shape!(exact_any & [&["card"], &["cards"]]);
+const INSTEAD_WORD_PATTERN: ClauseShape<'static> = clause_shape!(exact & ["instead"]);
 const FOR_EACH_PREFIX_PATTERN: ClauseShape<'static> =
     clause_shape!(prefix_any & [&["for", "each"], &["each"]]);
 const ON_WORD_PATTERN: ClauseShape<'static> = clause_shape!(exact & ["on"]);
@@ -607,7 +608,10 @@ pub(crate) fn parse_mill(
             .filter_map(OwnedLexToken::as_word)
             .collect();
         if !trailing_words.is_empty() {
-            if matches!(count, Value::Fixed(1))
+            if INSTEAD_WORD_PATTERN.matches_words(&trailing_words) {
+                // Conditional self-replacement lowering consumes the semantic
+                // role of "instead" after the mill effect parses.
+            } else if matches!(count, Value::Fixed(1))
                 && let Some(for_each_count) = parse_trailing_for_each_count(trailing_count_tokens)
             {
                 count = for_each_count;
@@ -643,7 +647,10 @@ pub(crate) fn parse_mill(
             .filter_map(OwnedLexToken::as_word)
             .collect();
         if !trailing_words.is_empty() {
-            if matches!(count, Value::Fixed(1))
+            if INSTEAD_WORD_PATTERN.matches_words(&trailing_words) {
+                // Conditional self-replacement lowering consumes the semantic
+                // role of "instead" after the mill effect parses.
+            } else if matches!(count, Value::Fixed(1))
                 && let Some(for_each_count) = parse_trailing_for_each_count(trailing_count_tokens)
             {
                 count = for_each_count;

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -9666,6 +9666,43 @@ fn test_parse_sevinnes_reclamation_flashback_copy_clause() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn increasing_confusion_strict_parse_renders_mill_self_replacement() {
+    assert_oracle_card_parses_strict("Increasing Confusion");
+
+    let def = parse_oracle_card_definition("Increasing Confusion");
+    let debug = format!("{:#?}", def.spell_effect);
+    assert!(
+        debug.contains("SelfReplacementBranch") && debug.contains("MillEffect"),
+        "Increasing Confusion should lower the flashback clause to a mill self-replacement, got {debug}"
+    );
+    assert!(
+        debug.contains("ThisSpellWasCastFromZone") && debug.contains("Graveyard"),
+        "Increasing Confusion replacement should be gated on being cast from a graveyard, got {debug}"
+    );
+    assert!(
+        debug.contains("XTimes(2)") || debug.contains("Scaled"),
+        "Increasing Confusion replacement should mill twice the default X count, got {debug}"
+    );
+
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+    assert!(
+        rendered.contains("Target player mills X cards"),
+        "Increasing Confusion should render the base target-player mill clause, got {rendered}"
+    );
+    assert!(
+        rendered.contains(
+            "If this spell was cast from a graveyard, that player mills twice that many cards instead"
+        ),
+        "Increasing Confusion should render the shared-target twice-that-many replacement, got {rendered}"
+    );
+    assert!(
+        rendered.contains("Flashback"),
+        "Increasing Confusion should render flashback, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_the_sixth_doctor_copy_clause_keeps_legendary_exception() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(81_601), "The Sixth Doctor")
         .mana_cost(ManaCost::from_pips(vec![

--- a/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
@@ -617,6 +617,15 @@ fn describe_single_self_replacement_segment(
     ) {
         return Some(count_override_text);
     }
+    if let Some(mill_override_text) = describe_mill_count_override_self_replacement(
+        &segment.default_effects,
+        &branch.replacement_effects,
+        &default_text,
+        &replacement_text,
+        &condition_text,
+    ) {
+        return Some(mill_override_text);
+    }
     if let Some(draw_discard_text) = describe_target_player_draw_discard_self_replacement(
         &segment.default_effects,
         &branch.replacement_effects,
@@ -900,6 +909,20 @@ fn rewrite_self_replacement_referent_phrase(default_text: &str, replacement_text
     {
         replacement = replacement.replacen("target creature", "that creature", 1);
     }
+    if default_text
+        .to_ascii_lowercase()
+        .contains("target player")
+        && replacement.starts_with("target player ")
+    {
+        replacement = replacement.replacen("target player", "that player", 1);
+    }
+    if default_text
+        .to_ascii_lowercase()
+        .contains("target opponent")
+        && replacement.starts_with("target opponent ")
+    {
+        replacement = replacement.replacen("target opponent", "that opponent", 1);
+    }
     let default_lower = default_text.to_ascii_lowercase();
     if default_lower.contains("counter target")
         && default_lower.contains("spell unless")
@@ -979,6 +1002,64 @@ fn describe_rendered_count_override_self_replacement(
         "{default_intro}. {default_choice}. If {condition_text}, {} instead. {default_rest}",
         super::normalize_common::lowercase_first(replacement_choice)
     ))
+}
+
+fn describe_mill_count_override_self_replacement(
+    default_effects: &[Effect],
+    replacement_effects: &[Effect],
+    default_text: &str,
+    replacement_text: &str,
+    condition_text: &str,
+) -> Option<String> {
+    let default_mill = single_mill_effect(default_effects)?;
+    let replacement_mill = single_mill_effect(replacement_effects)?;
+    if default_mill.player != replacement_mill.player {
+        return None;
+    }
+    if !mill_count_is_twice_default(&default_mill.count, &replacement_mill.count) {
+        return None;
+    }
+
+    let replacement_count = super::normalize_common::describe_value(&replacement_mill.count);
+    let mut replacement = rewrite_self_replacement_referent_phrase(default_text, replacement_text);
+    replacement = replacement
+        .trim_end_matches('.')
+        .replace(&format!("{replacement_count} cards"), "twice that many cards");
+    Some(format!("{default_text}. If {condition_text}, {replacement} instead"))
+}
+
+fn mill_count_is_twice_default(default_count: &Value, replacement_count: &Value) -> bool {
+    matches!(replacement_count, Value::Scaled(inner, 2) if inner.as_ref() == default_count)
+        || matches!((default_count, replacement_count), (Value::X, Value::XTimes(2)))
+}
+
+fn single_mill_effect(effects: &[Effect]) -> Option<&crate::effects::MillEffect> {
+    let mut found = None;
+    for effect in effects {
+        let Some(mill) = unwrap_basic_render_wrapper(effect)
+            .downcast_ref::<crate::effects::MillEffect>()
+        else {
+            continue;
+        };
+        if found.is_some() {
+            return None;
+        }
+        found = Some(mill);
+    }
+    found
+}
+
+fn unwrap_basic_render_wrapper(effect: &Effect) -> &Effect {
+    if let Some(with_id) = effect.downcast_ref::<crate::effects::WithIdEffect>() {
+        return unwrap_basic_render_wrapper(&with_id.effect);
+    }
+    if let Some(tag_all) = effect.downcast_ref::<crate::effects::TagAllEffect>() {
+        return unwrap_basic_render_wrapper(&tag_all.effect);
+    }
+    if let Some(tagged) = effect.downcast_ref::<crate::effects::TaggedEffect>() {
+        return unwrap_basic_render_wrapper(&tagged.effect);
+    }
+    effect
 }
 
 fn target_player_draw_discard_counts(effects: &[Effect]) -> Option<(&Value, &Value)> {

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -37099,6 +37099,144 @@ fn test_flashback_exiles_after_resolution() {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn increasing_confusion_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(262_860), "Increasing Confusion")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::X],
+            vec![ManaSymbol::Blue],
+        ]))
+        .card_types(vec![CardType::Sorcery])
+        .parse_text(
+            "Target player mills X cards. If this spell was cast from a graveyard, that player mills twice that many cards instead.\n\
+             Flashback {X}{U}",
+        )
+        .expect("Increasing Confusion should parse for runtime tests")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn add_filler_cards_to_library(game: &mut GameState, player: PlayerId, count: usize) {
+    let filler = crate::cards::definitions::basic_island();
+    for _ in 0..count {
+        game.create_object_from_definition(&filler, player, Zone::Library);
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn put_increasing_confusion_on_stack(
+    game: &mut GameState,
+    controller: PlayerId,
+    target: PlayerId,
+    x_value: u32,
+    casting_method: CastingMethod,
+) -> ObjectId {
+    let def = increasing_confusion_definition();
+    let (flashback_index, flashback) = def
+        .alternative_casts
+        .iter()
+        .enumerate()
+        .find(|method| {
+            matches!(
+                method.1,
+                crate::alternative_cast::AlternativeCastingMethod::Flashback { .. }
+            )
+        })
+        .expect("Increasing Confusion should expose flashback");
+    assert_eq!(
+        flashback_index, 0,
+        "flashback should be first because this test uses Alternative(0)"
+    );
+    assert_eq!(
+        flashback.cast_from_zone(),
+        Zone::Graveyard,
+        "Increasing Confusion flashback should cast from the graveyard"
+    );
+    assert!(
+        flashback.mana_cost().is_some(),
+        "Increasing Confusion flashback should have a mana cost"
+    );
+    let flashback_debug = format!("{flashback:?}");
+    assert!(
+        flashback_debug.contains("X") && flashback_debug.contains("Blue"),
+        "Increasing Confusion flashback should preserve {{X}}{{U}}, got {flashback_debug}"
+    );
+
+    let spell_id = game.create_object_from_definition(&def, controller, Zone::Stack);
+    game.object_mut(spell_id)
+        .expect("Increasing Confusion on stack")
+        .x_value = Some(x_value);
+    game.push_to_stack(
+        StackEntry::new(spell_id, controller)
+            .with_x(x_value)
+            .with_targets(vec![Target::Player(target)])
+            .with_casting_method(casting_method),
+    );
+    spell_id
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn increasing_confusion_normal_cast_mills_only_x_cards() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    add_filler_cards_to_library(&mut game, bob, 5);
+
+    put_increasing_confusion_on_stack(&mut game, alice, bob, 3, CastingMethod::Normal);
+    resolve_stack_entry(&mut game).expect("Increasing Confusion should resolve normally");
+
+    assert_eq!(
+        game.player(bob).expect("bob exists").graveyard.len(),
+        3,
+        "normal cast should mill exactly X cards"
+    );
+    assert_eq!(
+        game.player(bob).expect("bob exists").library.len(),
+        2,
+        "normal cast should leave the un-milled cards in the target player's library"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn increasing_confusion_flashback_mills_twice_x_and_exiles_spell() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    add_filler_cards_to_library(&mut game, bob, 8);
+
+    let spell_id = put_increasing_confusion_on_stack(
+        &mut game,
+        alice,
+        bob,
+        3,
+        CastingMethod::Alternative(0),
+    );
+    let spell_stable = game
+        .object(spell_id)
+        .expect("Increasing Confusion on stack")
+        .stable_id;
+    resolve_stack_entry(&mut game).expect("Increasing Confusion should resolve with flashback");
+
+    assert_eq!(
+        game.player(bob).expect("bob exists").graveyard.len(),
+        6,
+        "flashback cast should mill twice X cards"
+    );
+    assert_eq!(
+        game.player(bob).expect("bob exists").library.len(),
+        2,
+        "flashback cast should leave only the cards not milled by twice X"
+    );
+    let resolved_spell = game
+        .find_object_by_stable_id(spell_stable)
+        .expect("resolved Increasing Confusion should still be tracked");
+    assert!(
+        game.exile.contains(&resolved_spell),
+        "flashback cast should exile Increasing Confusion after resolution"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn the_sixth_doctor_copies_historic_spells_without_legendary_and_only_once_each_turn() {
     use crate::PriorityResponse;


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Increasing Confusion
Initial parse error:
```
unsupported trailing mill clause (clause: 'twice that many cards instead'); oracle-only fallback also failed: unsupported trailing mill clause (clause: 'twice that many cards instead')
```

Current worker: i-06fe184e7a1a4ccc9
Branch: codex/aws-card-fix-increasing-confusion
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260604T121212Z-controller-dev-loop-wave0013
