### PR TITLE
Fix Ironsmith parse failure: Samite Blessing

### DIFF
--- a/crates/ironsmith-compiler/src/model/parse_types.rs
+++ b/crates/ironsmith-compiler/src/model/parse_types.rs
@@ -153,10 +153,11 @@ pub enum RedirectNextTimeDamageDestinationAst {
     SourceController,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum PreventNextTimeDamageTargetAst {
     AnyTarget,
     You,
+    Target(TargetAst),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
@@ -1565,12 +1565,20 @@ fn compile_subject_verb_effect(
                     )?)
                 }
             };
-            let target_spec = match target {
+            let (target_spec, mut choices) = match target {
                 PreventNextTimeDamageTargetAst::AnyTarget => {
-                    crate::effects::PreventNextTimeDamageTarget::AnyTarget
+                    (crate::effects::PreventNextTimeDamageTarget::AnyTarget, Vec::new())
                 }
                 PreventNextTimeDamageTargetAst::You => {
-                    crate::effects::PreventNextTimeDamageTarget::You
+                    (crate::effects::PreventNextTimeDamageTarget::You, Vec::new())
+                }
+                PreventNextTimeDamageTargetAst::Target(target) => {
+                    let (spec, choices) =
+                        resolve_target_spec_with_choices(target, &current_reference_env(ctx))?;
+                    (
+                        crate::effects::PreventNextTimeDamageTarget::Target(spec),
+                        choices,
+                    )
                 }
             };
             let mut effect = crate::effects::PreventNextTimeDamageEffect::new(
@@ -1595,7 +1603,8 @@ fn compile_subject_verb_effect(
             if *reflect_damage_to_source_controller {
                 effect = effect.reflecting_to_source_controller();
             }
-            Ok((vec![Effect::new(effect)], follow_up_choices))
+            choices.extend(follow_up_choices);
+            Ok((vec![Effect::new(effect)], choices))
         }
         SubjectVerbActionAst::PreventDamage {
             amount,

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_pattern_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_pattern_helpers.rs
@@ -1793,6 +1793,8 @@ pub(crate) fn parse_prevent_next_time_damage_sentence(
         PreventNextTimeDamageTargetAst::You
     } else if CLAUSE_ANY_TARGET_PATTERN.matches(target_clause) {
         PreventNextTimeDamageTargetAst::AnyTarget
+    } else if !target_clause.is_empty() {
+        PreventNextTimeDamageTargetAst::Target(parse_target_phrase(target_clause.tokens())?)
     } else {
         return Err(CardTextError::ParseError(format!(
             "unsupported prevent-next-time damage target scope (clause: '{}')",

--- a/crates/ironsmith-core/src/effect.rs
+++ b/crates/ironsmith-core/src/effect.rs
@@ -112,6 +112,7 @@ pub enum PreventNextTimeDamageSource {
 pub enum PreventNextTimeDamageTarget {
     AnyTarget,
     You,
+    Target(crate::target_model::ChooseSpec),
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/crates/ironsmith-runtime/src/cards/builders.rs
+++ b/crates/ironsmith-runtime/src/cards/builders.rs
@@ -1091,6 +1091,7 @@ pub(crate) enum RedirectNextTimeDamageDestinationAst {
 pub(crate) enum PreventNextTimeDamageTargetAst {
     AnyTarget,
     You,
+    Target(TargetAst),
 }
 
 #[cfg(any(test, ironsmith_runtime_parser_tests))]

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -18469,15 +18469,33 @@ fn samite_blessing_runtime_prevents_next_chosen_source_damage_to_target_creature
                 .then_some(activated)
         })
         .expect("Samite Blessing should grant the enchanted creature the prevention ability");
+    let target_spec = activated
+        .effects
+        .flattened_default_effects()
+        .iter()
+        .find_map(|effect| effect.0.get_target_spec())
+        .expect("Samite Blessing granted ability should require a target");
+    let ChooseSpec::Object(target_filter) = target_spec.base() else {
+        panic!(
+            "Samite Blessing granted ability should target a creature object, got {target_spec:?}"
+        );
+    };
+    let target_filter_ctx = crate::filter::FilterContext::new(alice).with_source(enchanted_id);
     assert!(
-        activated.effects.flattened_default_effects().iter().any(|effect| {
-            effect
-                .0
-                .get_target_spec()
-                .is_some_and(|spec| format!("{spec:?}").contains("Creature"))
-        }),
-        "granted Samite Blessing ability should require a target creature, got {:?}",
-        activated.effects
+        game.object(protected_id).is_some_and(|object| target_filter.matches(
+            object,
+            &target_filter_ctx,
+            &game
+        )),
+        "Samite Blessing should allow a creature as the prevention target"
+    );
+    assert!(
+        game.object(blessing_id).is_some_and(|object| !target_filter.matches(
+            object,
+            &target_filter_ctx,
+            &game
+        )),
+        "Samite Blessing should not allow a noncreature permanent as the prevention target"
     );
 
     let mut dm = ChooseNamedSourceDecisionMaker {

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -18356,6 +18356,203 @@ fn cho_arrim_alchemist_runtime_prevents_chosen_source_to_you_and_gains_that_life
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn samite_blessing_strict_parse_and_compiled_text_regression() {
+    assert_oracle_card_parses_strict("Samite Blessing");
+    let def = parse_oracle_card_definition("Samite Blessing");
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+    let rendered_lower = rendered.to_ascii_lowercase();
+    assert!(
+        rendered_lower.contains("enchant creature"),
+        "Samite Blessing should keep its Aura enchant line, got {rendered}"
+    );
+    assert!(
+        rendered.contains("Enchanted creature has {T}: The next time a source of your choice would deal damage to target creature this turn, prevent that damage")
+            || rendered.contains("Enchanted creature has \"{T}: The next time a source of your choice would deal damage to target creature this turn, prevent that damage.\""),
+        "Samite Blessing should render the granted target-creature prevention ability, got {rendered}"
+    );
+    assert!(
+        !rendered_lower.contains("unsupported"),
+        "Samite Blessing should parse strictly without unsupported markers, got {rendered}"
+    );
+
+    let debug = format!("{:#?}", def.abilities);
+    assert!(
+        debug.contains("AttachedAbilityGrant")
+            && debug.contains("PreventNextTimeDamageEffect")
+            && debug.contains("Target(Object"),
+        "Samite Blessing should structurally grant a targeted prevention ability, got {debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn samite_blessing_runtime_prevents_next_chosen_source_damage_to_target_creature_only() {
+    struct ChooseNamedSourceDecisionMaker {
+        source_name: &'static str,
+    }
+
+    impl crate::decision::DecisionMaker for ChooseNamedSourceDecisionMaker {
+        fn decide_objects(
+            &mut self,
+            game: &crate::game_state::GameState,
+            ctx: &crate::decisions::context::SelectObjectsContext,
+        ) -> Vec<ObjectId> {
+            if let Some(chosen) = ctx.candidates.iter().find_map(|candidate| {
+                if !candidate.legal {
+                    return None;
+                }
+                game.object(candidate.id)
+                    .is_some_and(|object| object.name == self.source_name)
+                    .then_some(candidate.id)
+            }) {
+                vec![chosen]
+            } else {
+                crate::decision::AutoPassDecisionMaker.decide_objects(game, ctx)
+            }
+        }
+    }
+
+    let blessing = parse_oracle_card_definition("Samite Blessing");
+    let mut game =
+        crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let enchanted = CardDefinitionBuilder::new(CardId::from_raw(91_301), "Blessed Creature")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .build();
+    let protected = CardDefinitionBuilder::new(CardId::from_raw(91_302), "Protected Creature")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    let other_target = CardDefinitionBuilder::new(CardId::from_raw(91_303), "Other Creature")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    let chosen_source = CardDefinitionBuilder::new(CardId::from_raw(91_304), "Chosen Source")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(3, 3))
+        .build();
+    let other_source = CardDefinitionBuilder::new(CardId::from_raw(91_305), "Other Source")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(3, 3))
+        .build();
+
+    let enchanted_id = game.create_object_from_definition(&enchanted, alice, Zone::Battlefield);
+    let protected_id = game.create_object_from_definition(&protected, alice, Zone::Battlefield);
+    let other_target_id =
+        game.create_object_from_definition(&other_target, alice, Zone::Battlefield);
+    let chosen_source_id =
+        game.create_object_from_definition(&chosen_source, bob, Zone::Battlefield);
+    let other_source_id = game.create_object_from_definition(&other_source, bob, Zone::Battlefield);
+    let blessing_id = game.create_object_from_definition(&blessing, alice, Zone::Battlefield);
+    game.object_mut(blessing_id)
+        .expect("Samite Blessing should exist")
+        .attached_to = Some(crate::object::AttachmentTarget::Object(enchanted_id));
+    game.object_mut(enchanted_id)
+        .expect("enchanted creature should exist")
+        .attachments
+        .push(blessing_id);
+
+    let enchanted_chars = game
+        .calculated_characteristics(enchanted_id)
+        .expect("enchanted creature should have calculated characteristics");
+    let activated = enchanted_chars
+        .abilities
+        .iter()
+        .find_map(|ability| {
+            let AbilityKind::Activated(activated) = &ability.kind else {
+                return None;
+            };
+            format!("{:?}", activated.effects)
+                .contains("PreventNextTimeDamageEffect")
+                .then_some(activated)
+        })
+        .expect("Samite Blessing should grant the enchanted creature the prevention ability");
+    assert!(
+        activated.effects.flattened_default_effects().iter().any(|effect| {
+            effect
+                .0
+                .get_target_spec()
+                .is_some_and(|spec| format!("{spec:?}").contains("Creature"))
+        }),
+        "granted Samite Blessing ability should require a target creature, got {:?}",
+        activated.effects
+    );
+
+    let mut dm = ChooseNamedSourceDecisionMaker {
+        source_name: "Chosen Source",
+    };
+    let mut ctx = crate::effects::ExecutionContext::new(enchanted_id, alice, &mut dm)
+        .with_targets(vec![crate::effects::ResolvedTarget::Object(protected_id)]);
+    for effect in activated.effects.flattened_default_effects() {
+        effect
+            .0
+            .execute(&mut game, &mut ctx)
+            .expect("Samite Blessing granted ability should resolve");
+    }
+
+    let (damage_to_other_target, prevented_other_target) =
+        crate::events::processing::process_damage_with_event(
+            &mut game,
+            chosen_source_id,
+            crate::events::DamageTarget::Object(other_target_id),
+            3,
+            false,
+            crate::events::cause::EventCause::effect(),
+        );
+    assert_eq!(
+        damage_to_other_target, 3,
+        "chosen source damage to a non-target creature should not be prevented"
+    );
+    assert!(!prevented_other_target);
+
+    let (damage_from_other_source, prevented_other_source) =
+        crate::events::processing::process_damage_with_event(
+            &mut game,
+            other_source_id,
+            crate::events::DamageTarget::Object(protected_id),
+            3,
+            false,
+            crate::events::cause::EventCause::effect(),
+        );
+    assert_eq!(
+        damage_from_other_source, 3,
+        "nonchosen source damage to the target creature should not be prevented"
+    );
+    assert!(!prevented_other_source);
+
+    let (prevented_damage, prevented) = crate::events::processing::process_damage_with_event(
+        &mut game,
+        chosen_source_id,
+        crate::events::DamageTarget::Object(protected_id),
+        3,
+        false,
+        crate::events::cause::EventCause::effect(),
+    );
+    assert_eq!(
+        prevented_damage, 0,
+        "chosen source damage to the target creature should be prevented"
+    );
+    assert!(prevented);
+
+    let (second_damage, second_prevented) = crate::events::processing::process_damage_with_event(
+        &mut game,
+        chosen_source_id,
+        crate::events::DamageTarget::Object(protected_id),
+        3,
+        false,
+        crate::events::cause::EventCause::effect(),
+    );
+    assert_eq!(
+        second_damage, 3,
+        "Samite Blessing should prevent only the next matching damage event"
+    );
+    assert!(!second_prevented);
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_target_opponent_chooses_creature_then_other_cant_block() {
     let def = CardDefinitionBuilder::new(CardId::new(), "Eunuchs Variant")
             .parse_text(

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -33242,9 +33242,10 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
                 }
             }
         };
-        let target_text = match prevent_next_time.target {
+        let target_text = match &prevent_next_time.target {
             crate::effects::PreventNextTimeDamageTarget::AnyTarget => "any target".to_string(),
             crate::effects::PreventNextTimeDamageTarget::You => "you".to_string(),
+            crate::effects::PreventNextTimeDamageTarget::Target(spec) => describe_choose_spec(spec),
         };
         let mut rendered = format!(
             "The next time {source_text} would deal damage to {target_text} this turn, prevent that damage"

--- a/crates/ironsmith-runtime/src/effect_model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/effect_model_interpreter.rs
@@ -953,12 +953,15 @@ where
                 crate::effects::PreventNextTimeDamageSource::Filter(filter.clone())
             }
         };
-        let target = match payload.target {
+        let target = match &payload.target {
             ironsmith_core::PreventNextTimeDamageTarget::AnyTarget => {
                 crate::effects::PreventNextTimeDamageTarget::AnyTarget
             }
             ironsmith_core::PreventNextTimeDamageTarget::You => {
                 crate::effects::PreventNextTimeDamageTarget::You
+            }
+            ironsmith_core::PreventNextTimeDamageTarget::Target(spec) => {
+                crate::effects::PreventNextTimeDamageTarget::Target(spec.clone())
             }
         };
         let mut effect = crate::effects::PreventNextTimeDamageEffect::new(source, target);

--- a/crates/ironsmith-runtime/src/effects/damage/prevent_next_time_damage.rs
+++ b/crates/ironsmith-runtime/src/effects/damage/prevent_next_time_damage.rs
@@ -8,6 +8,7 @@ use crate::Value;
 use crate::effect::{Effect, EffectOutcome, EventValueSpec};
 use crate::effects::DealDamageEffect;
 use crate::effects::EffectExecutor;
+use crate::effects::helpers::{resolve_objects_for_effect, resolve_players_from_spec};
 use crate::effects::{ExecutionContext, ExecutionError};
 use crate::events::damage::matchers::{
     DamageSourceConstraint, DamageTargetConstraint, PreventableDamageConstraintMatcher,
@@ -32,6 +33,8 @@ pub enum PreventNextTimeDamageTarget {
     AnyTarget,
     /// Only damage that would be dealt to you.
     You,
+    /// Only damage that would be dealt to a target chosen as this resolves.
+    Target(ChooseSpec),
 }
 
 /// Register a one-shot replacement effect that prevents the next damage event matching constraints.
@@ -72,9 +75,22 @@ impl EffectExecutor for PreventNextTimeDamageEffect {
         game: &mut GameState,
         ctx: &mut ExecutionContext,
     ) -> Result<EffectOutcome, ExecutionError> {
-        let target_constraint = match self.target {
+        let target_constraint = match &self.target {
             PreventNextTimeDamageTarget::AnyTarget => DamageTargetConstraint::Any,
             PreventNextTimeDamageTarget::You => DamageTargetConstraint::Player(ctx.controller),
+            PreventNextTimeDamageTarget::Target(spec) => {
+                if let Ok(objects) = resolve_objects_for_effect(game, ctx, spec)
+                    && let Some(object_id) = objects.first()
+                {
+                    DamageTargetConstraint::Object(*object_id)
+                } else if let Ok(players) = resolve_players_from_spec(game, spec, ctx)
+                    && let Some(player_id) = players.first()
+                {
+                    DamageTargetConstraint::Player(*player_id)
+                } else {
+                    return Err(ExecutionError::InvalidTarget);
+                }
+            }
         };
 
         let mut chosen_source = None;
@@ -159,6 +175,17 @@ impl EffectExecutor for PreventNextTimeDamageEffect {
             .replacement_effects
             .add_one_shot_effect(replacement);
         Ok(EffectOutcome::resolved())
+    }
+
+    fn get_target_spec(&self) -> Option<&ChooseSpec> {
+        match &self.target {
+            PreventNextTimeDamageTarget::Target(spec) => Some(spec),
+            _ => None,
+        }
+    }
+
+    fn target_description(&self) -> &'static str {
+        "damage prevention target"
     }
 }
 

--- a/crates/ironsmith-runtime/src/events/damage/matchers.rs
+++ b/crates/ironsmith-runtime/src/events/damage/matchers.rs
@@ -561,6 +561,8 @@ pub enum DamageTargetConstraint {
     Any,
     /// Damage is dealt to a specific player.
     Player(PlayerId),
+    /// Damage is dealt to a specific object.
+    Object(ObjectId),
 }
 
 /// Matches preventable damage events with optional source/target constraints.
@@ -637,6 +639,14 @@ impl ReplacementMatcher for PreventableDamageConstraintMatcher {
                     }
                 }
                 DamageTarget::Object(_) => return false,
+            },
+            DamageTargetConstraint::Object(object_id) => match damage.target {
+                DamageTarget::Object(id) => {
+                    if &id != object_id {
+                        return false;
+                    }
+                }
+                DamageTarget::Player(_) => return false,
             },
         }
 


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Samite Blessing
Initial parse error:
```
unsupported prevent-next-time damage target scope (clause: 'the next time a source of your choice would deal damage to target creature this turn prevent that damage'); oracle-only fallback also failed: unsupported prevent-next-time damage target scope (clause: 'the next time a source of your choice would deal damage to target creature this turn prevent that damage')
```

Current worker: i-09308e332ff60d506
Branch: codex/aws-card-fix-samite-blessing
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260604T121212Z-controller-dev-loop-wave0013
