### PR TITLE
Fix Ironsmith parse failure: Aligned Heart

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/creation_handlers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/creation_handlers.rs
@@ -15,17 +15,18 @@ use super::super::grammar::primitives as grammar;
 use super::super::grammar::structure::parse_who_player_predicate_lexed;
 use super::super::keyword_static::parse_value_binding_clause;
 use super::super::lexer::{
-    LexedClause, render_token_slice, token_slice_at_is, token_slice_first_is, token_word_refs,
+    LexedClause, render_token_slice, synthetic_word_tokens, token_slice_at_is,
+    token_slice_first_is, token_word_refs,
 };
 use super::super::object_filters::parse_object_filter;
 use super::super::token_primitives::{
     find_index as find_token_index, str_split_once_char, str_starts_with_char,
 };
 use super::super::util::{
-    is_article, parse_card_type, parse_color, parse_counter_type_word, parse_number,
-    parse_subtype_flexible, parse_target_phrase, parse_value, source_choose_spec_for_surface,
-    source_reference_surface_for_words, token_index_for_word_index, trim_commas,
-    value_contains_unbound_x,
+    is_article, parse_card_type, parse_color, parse_counter_type_from_tokens,
+    parse_counter_type_word, parse_number, parse_subtype_flexible, parse_target_phrase,
+    parse_value, source_choose_spec_for_surface, source_reference_surface_for_words,
+    token_index_for_word_index, trim_commas, value_contains_unbound_x,
 };
 use super::clause_pattern_helpers::{ClauseShape, clause_shape, extract_subject_player};
 use super::conditionals::parse_subtype_word;
@@ -1359,12 +1360,29 @@ fn parse_create_for_each_counter_count(tokens: &[OwnedLexToken]) -> Option<Value
         idx += 1;
     }
 
-    let counter_type = words
+    let counter_type = if words
         .get(idx)
-        .and_then(|word| parse_counter_type_word(word));
-    if counter_type.is_some() {
-        idx += 1;
-    }
+        .is_some_and(|word| CREATE_COUNTER_OR_COUNTERS_WORD_PATTERN.matches_word(word))
+    {
+        None
+    } else if words
+        .get(idx + 1)
+        .is_some_and(|word| CREATE_COUNTER_OR_COUNTERS_WORD_PATTERN.matches_word(word))
+    {
+        let descriptor_tokens = synthetic_word_tokens(&words[idx..idx + 2]);
+        let parsed_counter_type = parse_counter_type_from_tokens(&descriptor_tokens)
+            .or_else(|| words.get(idx).and_then(|word| parse_counter_type_word(word)));
+        if parsed_counter_type.is_some() {
+            idx += 1;
+        }
+        parsed_counter_type
+    } else {
+        let parsed_counter_type = words.get(idx).and_then(|word| parse_counter_type_word(word));
+        if parsed_counter_type.is_some() {
+            idx += 1;
+        }
+        parsed_counter_type
+    };
 
     if !words
         .get(idx)

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -140,6 +140,30 @@ fn last_rites_strict_parser_compiled_text_and_model_regression() {
 }
 
 #[test]
+fn aligned_heart_strict_parser_compiled_text_and_model_regression() {
+    assert_oracle_card_parses_strict("Aligned Heart");
+
+    let def = parse_oracle_card_definition("Aligned Heart");
+    let rendered = compiled_text_lines(&def).join(" ");
+    let ability_debug = format!("{:#?}", def.abilities);
+
+    assert!(
+        rendered.contains(
+            "Whenever you cast your second spell each turn, put a rally counter on this enchantment, then create a 1/1 white Monk creature token with prowess for each rally counter on it"
+        ),
+        "Aligned Heart should render the rally-counter token count with token prowess inline, got {rendered}"
+    );
+    assert!(
+        ability_debug.contains("SpellCast")
+            && ability_debug.contains("exact_spells_this_turn: Some")
+            && ability_debug.contains("rally")
+            && ability_debug.contains("CountersOnSource")
+            && ability_debug.contains("CreateTokenEffect"),
+        "Aligned Heart should lower flurry into a second-spell trigger that puts a named rally counter and creates tokens from that counter count, got {ability_debug}"
+    );
+}
+
+#[test]
 fn kodama_of_the_center_tree_strict_parser_compiled_text_and_model_regression() {
     assert_oracle_card_parses_strict("Kodama of the Center Tree");
 

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -700,6 +700,10 @@ pub(super) fn describe_token_blueprint(token: &CardDefinition) -> String {
                 ));
             }
             AbilityKind::Triggered(triggered) => {
+                if let Some(keyword) = describe_structural_prowess_keyword(triggered) {
+                    keyword_texts.push(keyword.to_ascii_lowercase());
+                    continue;
+                }
                 if has_decayed_marker && is_decayed_sacrifice_trigger(triggered) {
                     continue;
                 }

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -41053,7 +41053,7 @@ fn describe_structural_exalted_keyword(
     }
 }
 
-fn describe_structural_prowess_keyword(
+pub(super) fn describe_structural_prowess_keyword(
     triggered: &crate::ability::TriggeredAbility,
 ) -> Option<String> {
     if triggered.intervening_if.is_some()

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -38,6 +38,36 @@ fn setup_three_player_game() -> GameState {
     )
 }
 
+#[cfg(ironsmith_runtime_parser_tests)]
+fn aligned_heart_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(836_968_406), "Aligned Heart")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(2)],
+            vec![ManaSymbol::White],
+        ]))
+        .card_types(vec![CardType::Enchantment])
+        .parse_text(
+            "Flurry — Whenever you cast your second spell each turn, put a rally counter on this enchantment. Then create a 1/1 white Monk creature token with prowess for each rally counter on it.",
+        )
+        .expect("Aligned Heart should parse for runtime tests")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn aligned_heart_monk_tokens(game: &GameState, controller: PlayerId) -> Vec<ObjectId> {
+    game.battlefield
+        .iter()
+        .copied()
+        .filter(|id| {
+            game.object(*id).is_some_and(|object| {
+                object.kind == ObjectKind::Token
+                    && game.controller_of(object) == controller
+                    && object.card_types.contains(&CardType::Creature)
+                    && object.subtypes.contains(&Subtype::Monk)
+            })
+        })
+        .collect()
+}
+
 fn component_pouch_definition() -> crate::cards::CardDefinition {
     CardDefinitionBuilder::new(CardId::from_raw(900_071), "Component Pouch")
         .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(3)]]))
@@ -8063,6 +8093,146 @@ fn queue_nymris_spell_cast(
     );
     queue_triggers_from_event(game, trigger_queue, event, false);
     spell_id
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn queue_aligned_heart_spell_cast(
+    game: &mut GameState,
+    caster: PlayerId,
+    card_types: Vec<CardType>,
+    trigger_queue: &mut TriggerQueue,
+) -> ObjectId {
+    let mut builder = CardBuilder::new(CardId::new(), "Aligned Heart Trigger Probe Spell")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Blue]]))
+        .card_types(card_types.clone());
+    if card_types.contains(&CardType::Creature) {
+        builder = builder.power_toughness(PowerToughness::fixed(1, 1));
+    }
+    let spell_id = game.create_object_from_card(&builder.build(), caster, Zone::Stack);
+    let event = TriggerEvent::new_with_provenance(
+        SpellCastEvent::new(spell_id, caster, Zone::Hand),
+        crate::provenance::ProvNodeId::default(),
+    );
+    queue_triggers_from_event(game, trigger_queue, event, false);
+    spell_id
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn aligned_heart_triggers_only_on_second_spell_and_token_prowess_branches() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+
+    let aligned_heart = aligned_heart_definition();
+    let source = game.create_object_from_definition(&aligned_heart, alice, Zone::Battlefield);
+
+    let mut first_queue = TriggerQueue::new();
+    queue_aligned_heart_spell_cast(&mut game, alice, vec![CardType::Instant], &mut first_queue);
+    assert_eq!(
+        first_queue.entries.len(),
+        0,
+        "Aligned Heart should not trigger for your first spell each turn"
+    );
+
+    let mut second_queue = TriggerQueue::new();
+    queue_aligned_heart_spell_cast(&mut game, alice, vec![CardType::Instant], &mut second_queue);
+    assert_eq!(
+        second_queue.entries.len(),
+        1,
+        "Aligned Heart should trigger for your second spell each turn"
+    );
+    let mut dm = SelectFirstDecisionMaker;
+    put_triggers_on_stack_with_dm(&mut game, &mut second_queue, &mut dm)
+        .expect("Aligned Heart trigger should go on the stack");
+    resolve_stack_entry_with(&mut game, &mut dm).expect("Aligned Heart trigger should resolve");
+
+    assert_eq!(
+        game.counter_count(source, crate::object::CounterType::Named("rally")),
+        1,
+        "Aligned Heart should put one rally counter on itself"
+    );
+    let monks = aligned_heart_monk_tokens(&game, alice);
+    assert_eq!(
+        monks.len(),
+        1,
+        "one rally counter should create one Monk token"
+    );
+    let monk = monks[0];
+    assert_eq!(game.calculated_power(monk), Some(1));
+    assert_eq!(game.calculated_toughness(monk), Some(1));
+
+    let mut third_creature_queue = TriggerQueue::new();
+    queue_aligned_heart_spell_cast(
+        &mut game,
+        alice,
+        vec![CardType::Creature],
+        &mut third_creature_queue,
+    );
+    assert_eq!(
+        third_creature_queue.entries.len(),
+        0,
+        "neither Aligned Heart nor prowess should trigger from a third creature spell"
+    );
+
+    let mut prowess_queue = TriggerQueue::new();
+    queue_aligned_heart_spell_cast(&mut game, alice, vec![CardType::Instant], &mut prowess_queue);
+    assert_eq!(
+        prowess_queue.entries.len(),
+        1,
+        "the Monk token's prowess should trigger from a noncreature spell"
+    );
+    put_triggers_on_stack_with_dm(&mut game, &mut prowess_queue, &mut dm)
+        .expect("Prowess trigger should go on the stack");
+    resolve_stack_entry_with(&mut game, &mut dm).expect("Prowess trigger should resolve");
+    assert_eq!(
+        game.calculated_power(monk),
+        Some(2),
+        "prowess should give the Monk +1/+1 until end of turn"
+    );
+    assert_eq!(game.calculated_toughness(monk), Some(2));
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn aligned_heart_creates_one_monk_for_each_rally_counter_on_it() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+
+    let aligned_heart = aligned_heart_definition();
+    let source = game.create_object_from_definition(&aligned_heart, alice, Zone::Battlefield);
+    game.add_counters(source, crate::object::CounterType::Named("rally"), 1)
+        .expect("preexisting rally counter should be addable");
+
+    let mut first_queue = TriggerQueue::new();
+    queue_aligned_heart_spell_cast(&mut game, alice, vec![CardType::Instant], &mut first_queue);
+    assert_eq!(first_queue.entries.len(), 0);
+
+    let mut second_queue = TriggerQueue::new();
+    queue_aligned_heart_spell_cast(&mut game, alice, vec![CardType::Instant], &mut second_queue);
+    assert_eq!(second_queue.entries.len(), 1);
+    let mut dm = SelectFirstDecisionMaker;
+    put_triggers_on_stack_with_dm(&mut game, &mut second_queue, &mut dm)
+        .expect("Aligned Heart trigger should go on the stack");
+    resolve_stack_entry_with(&mut game, &mut dm).expect("Aligned Heart trigger should resolve");
+
+    assert_eq!(
+        game.counter_count(source, crate::object::CounterType::Named("rally")),
+        2,
+        "the trigger should add a rally counter before counting counters for tokens"
+    );
+    assert_eq!(
+        aligned_heart_monk_tokens(&game, alice).len(),
+        2,
+        "two rally counters on Aligned Heart should create two Monk tokens"
+    );
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Aligned Heart
Initial parse error:
```
unsupported target phrase (clause: 'rally counter on it'); oracle-only fallback also failed: unsupported target phrase (clause: 'rally counter on it')
```

Current worker: i-04a2d763e0a418219
Branch: codex/aws-card-fix-aligned-heart
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260604T121212Z-controller-dev-loop-wave0014
