### PR TITLE
Fix Ironsmith parse failure: All of History, All at Once

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
@@ -5364,10 +5364,27 @@ fn compile_subject_verb_effect(
             );
             Ok((vec![effect], choices))
         }
-        SubjectVerbActionAst::ForEachCounterKindPutOrRemove { target, all_kinds } => {
-            let (spec, choices) =
+        SubjectVerbActionAst::ForEachCounterKindPutOrRemove {
+            target,
+            all_kinds,
+            fixed_counter_type,
+            optional_action,
+        } => {
+            let (mut spec, choices) =
                 resolve_target_spec_with_choices(target, &current_reference_env(ctx))?;
-            let effect = if *all_kinds {
+            if fixed_counter_type.is_some()
+                && let TargetAst::Object(filter, explicit_target_span, _) = target
+                && explicit_target_span.is_none()
+            {
+                spec = ChooseSpec::All(resolve_it_tag(filter, &current_reference_env(ctx))?);
+            }
+            let effect = if let Some(counter_type) = fixed_counter_type {
+                crate::effects::ForEachCounterKindPutOrRemoveEffect::fixed_counter_type(
+                    spec,
+                    *counter_type,
+                    *optional_action,
+                )
+            } else if *all_kinds {
                 crate::effects::ForEachCounterKindPutOrRemoveEffect::new(spec)
             } else {
                 crate::effects::ForEachCounterKindPutOrRemoveEffect::one_kind(spec)

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -1636,6 +1636,8 @@ pub(crate) enum SubjectVerbActionAst {
     ForEachCounterKindPutOrRemove {
         target: TargetAst,
         all_kinds: bool,
+        fixed_counter_type: Option<CounterType>,
+        optional_action: bool,
     },
     PutCounterOfChosenKind {
         target: TargetAst,
@@ -3207,10 +3209,17 @@ impl std::fmt::Debug for SubjectVerbActionAst {
                 .field("from", from)
                 .field("to", to)
                 .finish(),
-            Self::ForEachCounterKindPutOrRemove { target, all_kinds } => f
+            Self::ForEachCounterKindPutOrRemove {
+                target,
+                all_kinds,
+                fixed_counter_type,
+                optional_action,
+            } => f
                 .debug_struct("ForEachCounterKindPutOrRemove")
                 .field("target", target)
                 .field("all_kinds", all_kinds)
+                .field("fixed_counter_type", fixed_counter_type)
+                .field("optional_action", optional_action)
                 .finish(),
             Self::PutCounterOfChosenKind { target } => f
                 .debug_struct("PutCounterOfChosenKind")
@@ -6551,11 +6560,33 @@ impl EffectAst {
         Self::subject_verb_counter_kind_put_or_remove(target, false)
     }
 
+    pub(crate) fn subject_verb_fixed_counter_kind_put_or_remove(
+        target: TargetAst,
+        counter_type: CounterType,
+        optional_action: bool,
+    ) -> Self {
+        Self::subject_verb(
+            SubjectVerbRoleAst::Actor,
+            PlayerAst::Implicit,
+            SubjectVerbActionAst::ForEachCounterKindPutOrRemove {
+                target,
+                all_kinds: false,
+                fixed_counter_type: Some(counter_type),
+                optional_action,
+            },
+        )
+    }
+
     fn subject_verb_counter_kind_put_or_remove(target: TargetAst, all_kinds: bool) -> Self {
         Self::subject_verb(
             SubjectVerbRoleAst::Actor,
             PlayerAst::Implicit,
-            SubjectVerbActionAst::ForEachCounterKindPutOrRemove { target, all_kinds },
+            SubjectVerbActionAst::ForEachCounterKindPutOrRemove {
+                target,
+                all_kinds,
+                fixed_counter_type: None,
+                optional_action: false,
+            },
         )
     }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry.rs
@@ -146,6 +146,7 @@ const TO_THAT_PLAYER_PATTERN: ClauseShape<'static> =
     clause_shape!(contains_phrases & [&["to", "that", "player"]]);
 const WITH_WORD_PATTERN: ClauseShape<'static> = clause_shape!(exact & ["with"]);
 const LEARN_WORD_PATTERN: ClauseShape<'static> = clause_shape!(exact & ["learn"]);
+const TIME_TRAVEL_WORD_PATTERN: ClauseShape<'static> = clause_shape!(exact & ["time", "travel"]);
 const OUTSIDE_GAME_ART_RATING_PATTERN: ClauseShape<'static> = clause_shape!(
     contains_any_phrases
         & [&[
@@ -1217,6 +1218,15 @@ fn parse_effect_sentences_from_sentence_inputs(
             continue;
         }
 
+        if TIME_TRAVEL_WORD_PATTERN
+            .matches_words(&crate::runtime_backend::token_word_refs(&sentence_tokens))
+        {
+            effects.push(time_travel_effect_ast());
+            carried_context = None;
+            sentence_idx += 1;
+            continue;
+        }
+
         if let Some(restriction) = parse_mana_usage_restriction_sentence_lexed(&sentence_tokens) {
             apply_mana_usage_restriction_to_previous_effect(
                 &mut effects,
@@ -2191,6 +2201,30 @@ pub(crate) fn primary_target_from_effect(effect: &EffectAst) -> Option<TargetAst
             found
         }
     }
+}
+
+fn time_travel_effect_ast() -> EffectAst {
+    let permanent_with_time_counter = ObjectFilter::permanent()
+        .you_control()
+        .with_counter_type(crate::object::CounterType::Time);
+    let suspended_card_with_time_counter = ObjectFilter::default()
+        .in_zone(Zone::Exile)
+        .owned_by(PlayerFilter::You)
+        .with_alternative_cast(crate::filter::AlternativeCastKind::Suspend)
+        .with_counter_type(crate::object::CounterType::Time);
+    let target = TargetAst::Object(
+        ObjectFilter {
+            any_of: vec![permanent_with_time_counter, suspended_card_with_time_counter],
+            ..ObjectFilter::default()
+        },
+        None,
+        None,
+    );
+    EffectAst::subject_verb_fixed_counter_kind_put_or_remove(
+        target,
+        crate::object::CounterType::Time,
+        true,
+    )
 }
 
 pub(crate) fn replace_it_damage_target_in_effects(effects: &mut [EffectAst], target: &TargetAst) {

--- a/crates/ironsmith-core/src/effect.rs
+++ b/crates/ironsmith-core/src/effect.rs
@@ -3531,6 +3531,8 @@ impl DealDistributedDamageEffect {
 pub struct ForEachCounterKindPutOrRemoveEffect {
     pub target: ChooseSpec,
     pub all_kinds: bool,
+    pub fixed_counter_type: Option<crate::counter::CounterType>,
+    pub optional_action: bool,
 }
 
 impl ForEachCounterKindPutOrRemoveEffect {
@@ -3538,6 +3540,8 @@ impl ForEachCounterKindPutOrRemoveEffect {
         Self {
             target,
             all_kinds: true,
+            fixed_counter_type: None,
+            optional_action: false,
         }
     }
 
@@ -3545,6 +3549,21 @@ impl ForEachCounterKindPutOrRemoveEffect {
         Self {
             target,
             all_kinds: false,
+            fixed_counter_type: None,
+            optional_action: false,
+        }
+    }
+
+    pub fn fixed_counter_type(
+        target: ChooseSpec,
+        counter_type: crate::counter::CounterType,
+        optional_action: bool,
+    ) -> Self {
+        Self {
+            target,
+            all_kinds: false,
+            fixed_counter_type: Some(counter_type),
+            optional_action,
         }
     }
 }

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -1052,6 +1052,33 @@ fn clockspinning_strict_parser_and_compiled_text_regression() {
     );
 }
 
+#[test]
+fn all_of_history_all_at_once_strict_parser_and_compiled_text_regression() {
+    assert_oracle_card_parses_strict("All of History, All at Once");
+
+    let def = parse_oracle_card_definition("All of History, All at Once");
+    let spell_debug = format!("{:#?}", def.spell_effect);
+    let rendered = unprocessed_compiled_lines(&def).join("\n");
+
+    assert_eq!(def.name(), "All of History, All at Once");
+    assert!(
+        rendered.contains("Time travel"),
+        "All of History, All at Once should render its time travel keyword action, got {rendered}"
+    );
+    assert!(
+        rendered.contains("Storm"),
+        "All of History, All at Once should retain storm after time travel parses, got {rendered}"
+    );
+    assert!(
+        spell_debug.contains("ForEachCounterKindPutOrRemoveEffect")
+            && spell_debug.contains("fixed_counter_type: Some")
+            && spell_debug.contains("Time")
+            && spell_debug.contains("all_kinds: false")
+            && spell_debug.contains("optional_action: true"),
+        "All of History, All at Once should lower time travel to fixed time-counter put/remove support, got {spell_debug}"
+    );
+}
+
 fn ichormoon_gauntlet_chosen_counter_effect(def: &CardDefinition) -> &Effect {
     def.abilities
         .iter()

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -88,6 +88,24 @@ fn is_target_permanent_or_suspended_card(spec: &ChooseSpec) -> bool {
         && filter.any_of.iter().any(|arm| arm == &suspended)
 }
 
+fn is_time_travel_object_set(spec: &ChooseSpec) -> bool {
+    let ChooseSpec::All(filter) = spec else {
+        return false;
+    };
+    let permanent = crate::target::ObjectFilter::permanent()
+        .you_control()
+        .with_counter_type(crate::object::CounterType::Time);
+    let suspended = crate::target::ObjectFilter::default()
+        .in_zone(crate::zone::Zone::Exile)
+        .owned_by(crate::target::PlayerFilter::You)
+        .with_alternative_cast(crate::filter::AlternativeCastKind::Suspend)
+        .with_counter_type(crate::object::CounterType::Time);
+    filter.any_of.len() == 2
+        && filter.zone.is_none()
+        && filter.any_of.iter().any(|arm| arm == &permanent)
+        && filter.any_of.iter().any(|arm| arm == &suspended)
+}
+
 fn describe_discard_hand_add_mana_draw_sequence(effects: &[&Effect]) -> Option<String> {
     let [discard_effect, mana_effect, draw_effect] = effects else {
         return None;
@@ -37963,6 +37981,12 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
     if let Some(for_each_counter_kind) =
         effect.downcast_ref::<crate::effects::ForEachCounterKindPutOrRemoveEffect>()
     {
+        if for_each_counter_kind.fixed_counter_type == Some(crate::object::CounterType::Time)
+            && for_each_counter_kind.optional_action
+            && is_time_travel_object_set(&for_each_counter_kind.target)
+        {
+            return "Time travel".to_string();
+        }
         let target = describe_choose_spec(&for_each_counter_kind.target);
         if for_each_counter_kind.all_kinds {
             return format!(

--- a/crates/ironsmith-runtime/src/effect_model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/effect_model_interpreter.rs
@@ -1166,7 +1166,13 @@ where
     if let Some(payload) =
         M::downcast_ref::<ironsmith_core::ForEachCounterKindPutOrRemoveEffect>(&effect)
     {
-        let effect = if payload.all_kinds {
+        let effect = if let Some(counter_type) = payload.fixed_counter_type {
+            crate::effects::ForEachCounterKindPutOrRemoveEffect::fixed_counter_type(
+                payload.target.clone(),
+                counter_type,
+                payload.optional_action,
+            )
+        } else if payload.all_kinds {
             crate::effects::ForEachCounterKindPutOrRemoveEffect::new(payload.target.clone())
         } else {
             crate::effects::ForEachCounterKindPutOrRemoveEffect::one_kind(payload.target.clone())

--- a/crates/ironsmith-runtime/src/effects/counters/for_each_counter_kind_put_or_remove.rs
+++ b/crates/ironsmith-runtime/src/effects/counters/for_each_counter_kind_put_or_remove.rs
@@ -15,6 +15,8 @@ use crate::target::ChooseSpec;
 pub struct ForEachCounterKindPutOrRemoveEffect {
     pub target: ChooseSpec,
     pub all_kinds: bool,
+    pub fixed_counter_type: Option<CounterType>,
+    pub optional_action: bool,
 }
 
 impl ForEachCounterKindPutOrRemoveEffect {
@@ -22,6 +24,8 @@ impl ForEachCounterKindPutOrRemoveEffect {
         Self {
             target,
             all_kinds: true,
+            fixed_counter_type: None,
+            optional_action: false,
         }
     }
 
@@ -29,6 +33,21 @@ impl ForEachCounterKindPutOrRemoveEffect {
         Self {
             target,
             all_kinds: false,
+            fixed_counter_type: None,
+            optional_action: false,
+        }
+    }
+
+    pub fn fixed_counter_type(
+        target: ChooseSpec,
+        counter_type: CounterType,
+        optional_action: bool,
+    ) -> Self {
+        Self {
+            target,
+            all_kinds: false,
+            fixed_counter_type: Some(counter_type),
+            optional_action,
         }
     }
 
@@ -100,7 +119,9 @@ impl EffectExecutor for ForEachCounterKindPutOrRemoveEffect {
             }
             counter_kinds.sort_by_key(|counter_type| format!("{counter_type:?}"));
 
-            let selected_kinds = if self.all_kinds {
+            let selected_kinds = if let Some(counter_type) = self.fixed_counter_type {
+                vec![counter_type]
+            } else if self.all_kinds {
                 counter_kinds
             } else {
                 let Some(counter_type) = self.choose_counter_kind(game, ctx, &counter_kinds) else {
@@ -111,10 +132,16 @@ impl EffectExecutor for ForEachCounterKindPutOrRemoveEffect {
 
             for counter_type in selected_kinds {
                 let label = Self::counter_label(counter_type);
-                let options = vec![
+                let mut options = vec![
                     SelectableOption::new(0, format!("Put one {label} counter on it")),
                     SelectableOption::new(1, format!("Remove one {label} counter from it")),
                 ];
+                if self.optional_action {
+                    options.push(SelectableOption::new(
+                        2,
+                        format!("Don't add or remove a {label} counter"),
+                    ));
+                }
                 let choice_ctx = SelectOptionsContext::new(
                     ctx.controller,
                     Some(ctx.source),
@@ -131,9 +158,14 @@ impl EffectExecutor for ForEachCounterKindPutOrRemoveEffect {
                 if ctx.decision_maker.awaiting_choice() {
                     return Ok(EffectOutcome::count(0));
                 }
-                let Some(choice) = choice.filter(|idx| *idx <= 1) else {
+                let max_choice = if self.optional_action { 2 } else { 1 };
+                let Some(choice) = choice.filter(|idx| *idx <= max_choice) else {
                     return Ok(EffectOutcome::count(0));
                 };
+
+                if choice == 2 {
+                    continue;
+                }
 
                 let spec = ChooseSpec::SpecificObject(target_id);
                 let outcome = if choice == 1 {

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -9474,6 +9474,237 @@ fn clockspinning_remove_branch_removes_one_chosen_counter() {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn all_of_history_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(80_610), "All of History, All at Once")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(2)],
+            vec![ManaSymbol::Blue],
+            vec![ManaSymbol::Blue],
+        ]))
+        .card_types(vec![CardType::Sorcery])
+        .parse_text(
+            "Time travel. (For each suspended card you own and each permanent you control with a time counter on it, you may add or remove a time counter.)\n\
+             Storm (When you cast this spell, copy it for each spell cast before it this turn.)",
+        )
+        .expect("All of History, All at Once should parse for runtime tests")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn all_of_history_time_travel_effect(def: &crate::cards::CardDefinition) -> &crate::effect::Effect {
+    def.spell_effect
+        .as_ref()
+        .expect("All of History, All at Once should have spell effects")
+        .flattened_default_effects()
+        .into_iter()
+        .find(|effect| {
+            effect
+                .downcast_ref::<crate::effects::ForEachCounterKindPutOrRemoveEffect>()
+                .is_some_and(|effect| {
+                    effect.fixed_counter_type == Some(crate::object::CounterType::Time)
+                })
+        })
+        .expect("All of History, All at Once should have a fixed time-counter put/remove effect")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn time_travel_permanent(game: &mut GameState, controller: PlayerId) -> ObjectId {
+    let permanent = CardBuilder::new(CardId::from_raw(80_611), "Time Travel Permanent")
+        .card_types(vec![CardType::Artifact])
+        .build();
+    game.create_object_from_card(&permanent, controller, Zone::Battlefield)
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+struct TimeTravelDecisionMaker {
+    mode_index: usize,
+    prompts: usize,
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+impl DecisionMaker for TimeTravelDecisionMaker {
+    fn decide_options(
+        &mut self,
+        _game: &GameState,
+        ctx: &crate::decisions::context::SelectOptionsContext,
+    ) -> Vec<usize> {
+        if ctx.description.starts_with("Choose for time counter") {
+            self.prompts += 1;
+            vec![self.mode_index.min(ctx.options.len().saturating_sub(1))]
+        } else {
+            vec![0]
+        }
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn all_of_history_all_at_once_adds_time_counters_to_each_eligible_object() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let def = all_of_history_definition();
+    let spell_id = game.create_object_from_definition(&def, alice, Zone::Stack);
+
+    let alice_permanent = time_travel_permanent(&mut game, alice);
+    game.add_counters(alice_permanent, crate::object::CounterType::Time, 1)
+        .expect("eligible controlled permanent should accept a time counter");
+    let bob_permanent = time_travel_permanent(&mut game, bob);
+    game.add_counters(bob_permanent, crate::object::CounterType::Time, 1)
+        .expect("opponent permanent should accept a time counter");
+
+    let suspended = suspended_card_definition();
+    let alice_suspended = game.create_object_from_definition(&suspended, alice, Zone::Exile);
+    game.add_counters(alice_suspended, crate::object::CounterType::Time, 2)
+        .expect("eligible owned suspended card should accept time counters");
+    let bob_suspended = game.create_object_from_definition(&suspended, bob, Zone::Exile);
+    game.add_counters(bob_suspended, crate::object::CounterType::Time, 2)
+        .expect("opponent suspended card should accept time counters");
+    let alice_unsuspended = game.create_object_from_definition(&suspended, alice, Zone::Exile);
+    game.add_counters(alice_unsuspended, crate::object::CounterType::Charge, 1)
+        .expect("ineligible exiled card should accept non-time counters");
+
+    let mut dm = TimeTravelDecisionMaker {
+        mode_index: 0,
+        prompts: 0,
+    };
+    let mut ctx = crate::effects::ExecutionContext::new_default(spell_id, alice)
+        .with_decision_maker(&mut dm);
+    crate::effects::execute_effect(&mut game, all_of_history_time_travel_effect(&def), &mut ctx)
+        .expect("All of History, All at Once time travel add branch should execute");
+
+    assert_eq!(
+        game.counter_count(alice_permanent, crate::object::CounterType::Time),
+        2,
+        "time travel should add a time counter to each controlled permanent with one"
+    );
+    assert_eq!(
+        game.counter_count(alice_suspended, crate::object::CounterType::Time),
+        3,
+        "time travel should add a time counter to each owned suspended card"
+    );
+    assert_eq!(
+        game.counter_count(bob_permanent, crate::object::CounterType::Time),
+        1,
+        "time travel should not affect permanents controlled by opponents"
+    );
+    assert_eq!(
+        game.counter_count(bob_suspended, crate::object::CounterType::Time),
+        2,
+        "time travel should not affect suspended cards owned by opponents"
+    );
+    assert_eq!(
+        game.counter_count(alice_unsuspended, crate::object::CounterType::Charge),
+        1,
+        "time travel should not affect exiled cards without time counters"
+    );
+    assert_eq!(dm.prompts, 2, "time travel should offer one choice per eligible object");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn all_of_history_all_at_once_removes_time_counters_from_each_eligible_object() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let def = all_of_history_definition();
+    let spell_id = game.create_object_from_definition(&def, alice, Zone::Stack);
+
+    let alice_permanent = time_travel_permanent(&mut game, alice);
+    game.add_counters(alice_permanent, crate::object::CounterType::Time, 2)
+        .expect("eligible controlled permanent should accept time counters");
+    let suspended = suspended_card_definition();
+    let alice_suspended = game.create_object_from_definition(&suspended, alice, Zone::Exile);
+    game.add_counters(alice_suspended, crate::object::CounterType::Time, 2)
+        .expect("eligible owned suspended card should accept time counters");
+
+    let mut dm = TimeTravelDecisionMaker {
+        mode_index: 1,
+        prompts: 0,
+    };
+    let mut ctx = crate::effects::ExecutionContext::new_default(spell_id, alice)
+        .with_decision_maker(&mut dm);
+    crate::effects::execute_effect(&mut game, all_of_history_time_travel_effect(&def), &mut ctx)
+        .expect("All of History, All at Once time travel remove branch should execute");
+
+    assert_eq!(
+        game.counter_count(alice_permanent, crate::object::CounterType::Time),
+        1,
+        "time travel should remove one time counter from each eligible permanent when chosen"
+    );
+    assert_eq!(
+        game.counter_count(alice_suspended, crate::object::CounterType::Time),
+        1,
+        "time travel should remove one time counter from each eligible suspended card when chosen"
+    );
+    assert_eq!(dm.prompts, 2, "time travel should offer one remove choice per eligible object");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn all_of_history_all_at_once_can_leave_eligible_objects_unchanged() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let def = all_of_history_definition();
+    let spell_id = game.create_object_from_definition(&def, alice, Zone::Stack);
+
+    let alice_permanent = time_travel_permanent(&mut game, alice);
+    game.add_counters(alice_permanent, crate::object::CounterType::Time, 2)
+        .expect("eligible controlled permanent should accept time counters");
+    let suspended = suspended_card_definition();
+    let alice_suspended = game.create_object_from_definition(&suspended, alice, Zone::Exile);
+    game.add_counters(alice_suspended, crate::object::CounterType::Time, 2)
+        .expect("eligible owned suspended card should accept time counters");
+
+    let mut dm = TimeTravelDecisionMaker {
+        mode_index: 2,
+        prompts: 0,
+    };
+    let mut ctx = crate::effects::ExecutionContext::new_default(spell_id, alice)
+        .with_decision_maker(&mut dm);
+    crate::effects::execute_effect(&mut game, all_of_history_time_travel_effect(&def), &mut ctx)
+        .expect("All of History, All at Once time travel skip branch should execute");
+
+    assert_eq!(
+        game.counter_count(alice_permanent, crate::object::CounterType::Time),
+        2,
+        "time travel should let you leave an eligible permanent unchanged"
+    );
+    assert_eq!(
+        game.counter_count(alice_suspended, crate::object::CounterType::Time),
+        2,
+        "time travel should let you leave an eligible suspended card unchanged"
+    );
+    assert_eq!(dm.prompts, 2, "time travel should offer one skip choice per eligible object");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn all_of_history_all_at_once_does_nothing_when_no_objects_are_eligible() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let def = all_of_history_definition();
+    let spell_id = game.create_object_from_definition(&def, alice, Zone::Stack);
+    let permanent = time_travel_permanent(&mut game, alice);
+    game.add_counters(permanent, crate::object::CounterType::Charge, 1)
+        .expect("ineligible permanent should accept non-time counters");
+
+    let mut dm = TimeTravelDecisionMaker {
+        mode_index: 0,
+        prompts: 0,
+    };
+    let mut ctx = crate::effects::ExecutionContext::new_default(spell_id, alice)
+        .with_decision_maker(&mut dm);
+    crate::effects::execute_effect(&mut game, all_of_history_time_travel_effect(&def), &mut ctx)
+        .expect("All of History, All at Once should resolve with no eligible objects");
+
+    assert_eq!(
+        game.counter_count(permanent, crate::object::CounterType::Charge),
+        1,
+        "time travel should not alter non-time counters on otherwise ineligible permanents"
+    );
+    assert_eq!(dm.prompts, 0, "time travel should not ask for choices with no eligible objects");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn feudkillers_verdict_creates_token_when_you_have_more_life_than_an_opponent() {
     let mut game = setup_game();


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: All of History, All at Once
Initial parse error:
```
parser does not yet support line family: 'Time travel. (For each suspended card you own and each permanent you control with a time counter on it, you may add or remove a time counter.)'; oracle-only fallback also failed: parser does not yet support line family: 'Time travel.'
```

Current worker: i-0f74131ab5c17da8e
Branch: codex/aws-card-fix-all-of-history-all-at-once
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260604T121212Z-controller-dev-loop-wave0014
