### PR TITLE
Fix Ironsmith parse failure: Dust Animus

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/etb_static_lines.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/etb_static_lines.rs
@@ -710,12 +710,15 @@ pub(crate) fn parse_enters_tapped_with_counters_line(
         return Ok(None);
     };
 
-    Ok(Some(vec![StaticAbility::enters_tapped_ability(), counters]))
+    let mut abilities = vec![StaticAbility::enters_tapped_ability()];
+    abilities.extend(counters);
+
+    Ok(Some(abilities))
 }
 
 pub(crate) fn parse_enters_with_counters_line(
     tokens: &[OwnedLexToken],
-) -> Result<Option<StaticAbility>, CardTextError> {
+) -> Result<Option<Vec<StaticAbility>>, CardTextError> {
     let full_words = crate::runtime_backend::lexer::token_word_refs(tokens);
     if etb_starts_with_trigger_intro_after_label(tokens) {
         return Ok(None);
@@ -758,6 +761,7 @@ pub(crate) fn parse_enters_with_counters_line(
     }
 
     let mut added_abilities: Vec<Ability> = Vec::new();
+    let mut additional_counters: Vec<(CounterType, Value)> = Vec::new();
     let mut after_with = captured.counter_clause_tokens;
     if let Some((and_with_idx, and_with_end)) =
         crate::runtime_backend::lexer::find_token_word_sequence_span(after_with, &["and", "with"])
@@ -837,6 +841,10 @@ pub(crate) fn parse_enters_with_counters_line(
         };
         if let Some(abilities) = parse_enters_with_added_abilities_tail(&tail) {
             added_abilities = abilities;
+        } else if let Some(sibling_counters) =
+            parse_enters_with_counter_conjunction_tail_tokens(&tail)
+        {
+            additional_counters = sibling_counters;
         } else if let Some(condition_tail) = parse_enters_with_counter_condition_tail_tokens(&tail)
         {
             let parsed =
@@ -923,15 +931,39 @@ pub(crate) fn parse_enters_with_counters_line(
     }
 
     if let Some((condition, display)) = condition {
-        return Ok(Some(
-            StaticAbility::enters_with_counters_and_abilities_if_condition(
+        let mut abilities = vec![StaticAbility::enters_with_counters_and_abilities_if_condition(
+            counter_type,
+            count,
+            condition.clone(),
+            display.clone(),
+            added_abilities,
+        )];
+        for (counter_type, count) in additional_counters {
+            abilities.push(
+                StaticAbility::enters_with_counters_and_abilities_if_condition(
+                    counter_type,
+                    count,
+                    condition.clone(),
+                    display.clone(),
+                    Vec::new(),
+                ),
+            );
+        }
+        return Ok(Some(abilities));
+    }
+
+    if !additional_counters.is_empty() {
+        let mut abilities = vec![StaticAbility::enters_with_counters_value(
+            counter_type,
+            count,
+        )];
+        for (counter_type, count) in additional_counters {
+            abilities.push(StaticAbility::enters_with_counters_value(
                 counter_type,
                 count,
-                condition,
-                display,
-                added_abilities,
-            ),
-        ));
+            ));
+        }
+        return Ok(Some(abilities));
     }
 
     if !added_abilities.is_empty() {
@@ -941,10 +973,46 @@ pub(crate) fn parse_enters_with_counters_line(
         )));
     }
 
-    Ok(Some(StaticAbility::enters_with_counters_value(
+    Ok(Some(vec![StaticAbility::enters_with_counters_value(
         counter_type,
         count,
-    )))
+    )]))
+}
+
+fn parse_enters_with_counter_conjunction_tail_tokens(
+    tokens: &[OwnedLexToken],
+) -> Option<Vec<(CounterType, Value)>> {
+    let mut rest = trim_commas(tokens);
+    let mut counters = Vec::new();
+
+    while rest.first().is_some_and(|token| ETB_AND_WORD_PATTERN.matches_token(token)) {
+        rest = trim_commas(&rest[1..]);
+        let (count, used) = if rest
+            .first()
+            .is_some_and(|token| ETB_ARTICLE_WORD_PATTERN.matches_token(token))
+        {
+            (Value::Fixed(1), 1)
+        } else {
+            parse_value(&rest)?
+        };
+        let counter_idx = crate::runtime_backend::grammar::primitives::find_token_index(
+            &rest[used..],
+            |token| ETB_COUNTER_OR_COUNTERS_WORD_PATTERN.matches_token(token),
+        )? + used;
+        let counter_type = parse_counter_type_from_tokens(&rest[used..=counter_idx])?;
+        counters.push((counter_type, count));
+
+        rest = trim_commas(&rest[counter_idx + 1..]);
+        if token_slice_first_is(&rest, "on") {
+            rest = trim_commas(&rest[1..]);
+        }
+        if token_slice_first_is(&rest, "it") {
+            rest = trim_commas(&rest[1..]);
+        }
+    }
+
+    (!counters.is_empty() && !rest.iter().any(|token| token.as_word().is_some()))
+        .then_some(counters)
 }
 
 fn parse_enters_with_added_abilities_tail(tokens: &[OwnedLexToken]) -> Option<Vec<Ability>> {
@@ -3415,11 +3483,11 @@ mod etb_enters_tapped_with_counters_tests {
             ["this", "creature"]
         );
 
-        let ability = parse_enters_with_counters_line(&tokens)
+        let abilities = parse_enters_with_counters_line(&tokens)
             .expect("parser should not error")
             .expect("enters with counters should parse");
         assert_eq!(
-            ability.id(),
+            abilities[0].id(),
             crate::static_abilities::StaticAbilityId::EnterWithCounters
         );
     }

--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -2972,7 +2972,7 @@ fn static_ability_ast_line_rules() -> &'static [StaticAbilityLineRuleDef] {
         single_static_ability_ast_rule!(parse_prevent_all_damage_dealt_to_creatures_line),
         single_static_ability_ast_passthrough_rule!(parse_creatures_cant_block_line),
         multi_static_ability_ast_rule!(parse_enters_tapped_with_counters_line),
-        single_static_ability_ast_rule!(parse_enters_with_counters_line),
+        multi_static_ability_ast_rule!(parse_enters_with_counters_line),
         single_static_ability_ast_rule!(parse_enters_with_additional_counter_for_filter_line),
         single_static_ability_ast_rule!(parse_reveal_from_hand_or_enters_tapped_line),
         single_static_ability_ast_rule!(parse_conditional_enters_tapped_unless_line),

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -16464,6 +16464,131 @@ fn parse_oracle_tainted_sigil_strictly_parses_and_renders_total_life_lost() {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+struct DustAnimusNoopDecisionMaker;
+
+#[cfg(ironsmith_runtime_parser_tests)]
+impl crate::decision::DecisionMaker for DustAnimusNoopDecisionMaker {}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn parse_oracle_dust_animus_strictly_parses_and_renders_conditional_counters() {
+    assert_oracle_card_parses_strict("Dust Animus");
+
+    let def = parse_oracle_card_definition("Dust Animus");
+    let rendered = canonical_compiled_lines(&def).join("\n");
+    assert!(
+        rendered.contains("Flying"),
+        "expected Dust Animus to render flying, got {rendered}"
+    );
+    assert!(
+        rendered.contains(
+            "If you control five or more untapped lands, this creature enters with two +1/+1 counters and a lifelink counter on it"
+        ),
+        "expected Dust Animus to render the combined conditional counter clause, got {rendered}"
+    );
+    assert!(
+        rendered.contains("Plot {1}{W}"),
+        "expected Dust Animus to keep plot text, got {rendered}"
+    );
+
+    let debug = format!("{:?}", def.abilities);
+    assert!(
+        debug.matches("EnterWithCountersIfCondition").count() >= 2
+            && debug.contains("PlusOnePlusOne")
+            && debug.contains("Lifelink")
+            && debug.contains("untapped: true"),
+        "expected Dust Animus to structurally model both conditional counters against untapped lands, got {debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn dust_animus_enters_with_both_counters_when_untapped_land_condition_is_met() {
+    let def = parse_oracle_card_definition("Dust Animus");
+    let mut game = crate::tests::test_helpers::setup_two_player_game();
+    let alice = PlayerId::from_index(0);
+    let mut dm = DustAnimusNoopDecisionMaker;
+
+    for idx in 0..5 {
+        let land = CardDefinitionBuilder::new(CardId::new(), format!("Untapped Land {idx}"))
+            .card_types(vec![CardType::Land])
+            .build();
+        game.create_object_from_definition(&land, alice, Zone::Battlefield);
+    }
+
+    let old_id = game.create_object_from_definition(&def, alice, Zone::Hand);
+    let animus_id = game
+        .move_object_with_etb_processing_with_dm(old_id, Zone::Battlefield, &mut dm)
+        .expect("Dust Animus should enter")
+        .new_id;
+
+    let animus = game.object(animus_id).expect("Dust Animus should exist");
+    assert_eq!(
+        animus
+            .counters
+            .get(&CounterType::PlusOnePlusOne)
+            .copied()
+            .unwrap_or_default(),
+        2,
+        "Dust Animus should enter with two +1/+1 counters when the land condition is met"
+    );
+    assert_eq!(
+        animus
+            .counters
+            .get(&CounterType::Lifelink)
+            .copied()
+            .unwrap_or_default(),
+        1,
+        "Dust Animus should enter with a lifelink counter when the land condition is met"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn dust_animus_enters_without_counters_when_fewer_than_five_lands_are_untapped() {
+    let def = parse_oracle_card_definition("Dust Animus");
+    let mut game = crate::tests::test_helpers::setup_two_player_game();
+    let alice = PlayerId::from_index(0);
+    let mut dm = DustAnimusNoopDecisionMaker;
+
+    for idx in 0..5 {
+        let land = CardDefinitionBuilder::new(CardId::new(), format!("Untapped Land {idx}"))
+            .card_types(vec![CardType::Land])
+            .build();
+        let land_id = game.create_object_from_definition(&land, alice, Zone::Battlefield);
+        if idx == 4 {
+            game.tap(land_id);
+        }
+    }
+
+    let old_id = game.create_object_from_definition(&def, alice, Zone::Hand);
+    let animus_id = game
+        .move_object_with_etb_processing_with_dm(old_id, Zone::Battlefield, &mut dm)
+        .expect("Dust Animus should enter")
+        .new_id;
+
+    let animus = game.object(animus_id).expect("Dust Animus should exist");
+    assert_eq!(
+        animus
+            .counters
+            .get(&CounterType::PlusOnePlusOne)
+            .copied()
+            .unwrap_or_default(),
+        0,
+        "Dust Animus should not get +1/+1 counters with only four untapped lands"
+    );
+    assert_eq!(
+        animus
+            .counters
+            .get(&CounterType::Lifelink)
+            .copied()
+            .unwrap_or_default(),
+        0,
+        "Dust Animus should not get a lifelink counter with only four untapped lands"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn parse_oracle_final_punishment_strictly_parses_and_renders_damage_dealt_this_turn() {
     assert_oracle_card_parses_strict("Final Punishment");

--- a/crates/ironsmith-runtime/src/compiled_text/mod.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/mod.rs
@@ -1036,11 +1036,32 @@ fn merge_specific_adjacent_surface_lines(lines: Vec<String>) -> Vec<String> {
                 idx += 2;
                 continue;
             }
+            if let Some((left_counter, left_condition)) =
+                split_self_enters_with_counter_if_condition(left)
+                && let Some((right_counter, right_condition)) =
+                    split_self_enters_with_counter_if_condition(right)
+                && left_condition.eq_ignore_ascii_case(right_condition)
+            {
+                merged.push(format!(
+                    "If {left_condition}, this creature enters with {left_counter} and {right_counter} on it."
+                ));
+                idx += 2;
+                continue;
+            }
         }
         merged.push(lines[idx].clone());
         idx += 1;
     }
     merged
+}
+
+fn split_self_enters_with_counter_if_condition(line: &str) -> Option<(&str, &str)> {
+    let rest = line.strip_prefix("This creature enters with ")?;
+    let (counter_phrase, condition) = rest.split_once(" on it if ")?;
+    if counter_phrase.is_empty() || condition.is_empty() {
+        return None;
+    }
+    Some((counter_phrase, condition.trim_end_matches('.')))
 }
 
 fn merge_cast_and_activate_restriction_lines(left: &str, right: &str) -> Option<String> {


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Dust Animus
Initial parse error:
```
unsupported trailing self ETB counter clause (clause: 'if you control five or more untapped lands this creature enters with two +1/+1 counters and a lifelink counter on it'); oracle-only fallback also failed: unsupported trailing self ETB counter clause (clause: 'if you control five or more untapped lands this creature enters with two +1/+1 counters and a lifelink counter on it')
```

Current worker: i-0fcb1bd36c6dafd56
Branch: codex/aws-card-fix-dust-animus
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260604T121212Z-controller-dev-loop-wave0016
