### PR TITLE
Fix Ironsmith parse failure: Niambi, Esteemed Speaker

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/leaf.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/leaf.rs
@@ -10,7 +10,7 @@ use crate::filter::ObjectFilter;
 use crate::mana::{ManaCost, ManaSymbol};
 use crate::object::CounterType;
 use crate::target::PlayerFilter;
-use crate::types::{CardType, Subtype};
+use crate::types::{CardType, Subtype, Supertype};
 use crate::zone::Zone;
 
 use super::effect_sentences::clause_pattern_helpers::{ClauseShape, clause_shape};
@@ -29,6 +29,7 @@ use super::object_filters::parse_object_filter_lexed;
 use super::token_primitives::{find_index as find_token_index, str_starts_with, str_strip_suffix};
 use super::util::{
     is_source_reference_words, parse_card_type, parse_counter_type_from_tokens, parse_number,
+    parse_supertype_word,
 };
 
 const NAMED_ARTIFACTS_YOU_CONTROL_MARKERS: &[&[&str]] = &[
@@ -90,6 +91,7 @@ pub(crate) enum ActivationCostSegmentCst {
     DiscardFiltered {
         count: u32,
         card_types: Vec<CardType>,
+        supertypes: Vec<Supertype>,
         filter: Option<ObjectFilter>,
         random: bool,
         name: Option<String>,
@@ -725,6 +727,7 @@ fn parse_discard_segment_tokens(
         return Ok(ActivationCostSegmentCst::DiscardFiltered {
             count,
             card_types: Vec::new(),
+            supertypes: Vec::new(),
             filter: None,
             random: false,
             name: Some(name),
@@ -736,6 +739,7 @@ fn parse_discard_segment_tokens(
         return Ok(ActivationCostSegmentCst::DiscardFiltered {
             count,
             card_types: Vec::new(),
+            supertypes: Vec::new(),
             filter: Some(filter),
             random: false,
             name: None,
@@ -744,6 +748,7 @@ fn parse_discard_segment_tokens(
     }
 
     let mut card_types = Vec::new();
+    let mut supertypes = Vec::new();
     while let Some(word) = tail.get(idx).copied() {
         if LEAF_CARD_OR_CARDS_WORD_PATTERN.matches_word(word) {
             break;
@@ -751,6 +756,11 @@ fn parse_discard_segment_tokens(
         if LEAF_AND_OR_WORD_PATTERN.matches_word(word)
             || LEAF_A_OR_AN_WORD_PATTERN.matches_word(word)
         {
+            idx += 1;
+            continue;
+        }
+        if let Some(supertype) = parse_supertype_word(word) {
+            crate::slice_primitives::push_unique(&mut supertypes, supertype);
             idx += 1;
             continue;
         }
@@ -783,13 +793,14 @@ fn parse_discard_segment_tokens(
         }
     };
 
-    if card_types.is_empty() && !random {
+    if card_types.is_empty() && supertypes.is_empty() && !random {
         return Ok(ActivationCostSegmentCst::DiscardCard(count));
     }
 
     Ok(ActivationCostSegmentCst::DiscardFiltered {
         count,
         card_types,
+        supertypes,
         filter: None,
         random,
         name: None,
@@ -2095,21 +2106,32 @@ pub(crate) fn lower_activation_cost_cst(
             ActivationCostSegmentCst::DiscardFiltered {
                 count,
                 card_types,
+                supertypes,
                 filter,
                 random,
                 name,
                 other,
             } => {
                 flush_pending_mana(&mut costs, &mut pending_mana_pips);
-                if *random || name.is_some() || *other || filter.is_some() {
+                if *random
+                    || name.is_some()
+                    || *other
+                    || filter.is_some()
+                    || !supertypes.is_empty()
+                {
                     let card_filter = if let Some(filter) = filter {
                         Some(filter.clone())
-                    } else if card_types.is_empty() && name.is_none() && !*other {
+                    } else if card_types.is_empty()
+                        && supertypes.is_empty()
+                        && name.is_none()
+                        && !*other
+                    {
                         None
                     } else {
                         let mut filter = ObjectFilter {
                             zone: Some(crate::zone::Zone::Hand),
                             card_types: card_types.clone(),
+                            supertypes: supertypes.clone(),
                             ..Default::default()
                         };
                         if let Some(name) = name {

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -36081,6 +36081,286 @@ fn render_activation_typed_discard_cost_keeps_card_type() {
     );
 }
 
+fn niambi_draw_activated_ability(def: &CardDefinition) -> &crate::ability::ActivatedAbility {
+    def.abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Activated(activated)
+                if activated.effects.flattened_default_effects().iter().any(|effect| {
+                    effect.downcast_ref::<DrawCardsEffect>().is_some()
+                }) =>
+            {
+                Some(activated)
+            }
+            _ => None,
+        })
+        .expect("Niambi, Esteemed Speaker should have a draw activated ability")
+}
+
+fn niambi_enter_triggered_ability(def: &CardDefinition) -> &crate::ability::TriggeredAbility {
+    def.abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Triggered(triggered)
+                if triggered.effects.flattened_default_effects().iter().any(|effect| {
+                    effect.downcast_ref::<IfEffect>().is_some_and(|if_effect| {
+                        if_effect.then.iter().any(|effect| {
+                            effect.downcast_ref::<GainLifeEffect>().is_some()
+                        })
+                    })
+                }) =>
+            {
+                Some(triggered)
+            }
+            _ => None,
+        })
+        .expect("Niambi, Esteemed Speaker should have an enters triggered ability")
+}
+
+#[test]
+fn niambi_esteemed_speaker_strict_parser_and_compiled_text_regression() {
+    assert_oracle_card_parses_strict("Niambi, Esteemed Speaker");
+
+    let def = parse_oracle_card_definition("Niambi, Esteemed Speaker");
+    let activated = niambi_draw_activated_ability(&def);
+    let rendered = unprocessed_compiled_lines(&def).join("\n");
+    let activated_debug = format!("{activated:#?}");
+
+    assert!(
+        rendered.contains("Discard a legendary card: Draw two cards"),
+        "Niambi compiled text should preserve the legendary discard activation cost, got {rendered}"
+    );
+    assert!(
+        rendered.contains(
+            "When Niambi enters, you may return another target creature you control to its owner's hand. If you do, you gain life equal to that creature's mana value"
+        ),
+        "Niambi compiled text should preserve the named ETB and returned-creature mana-value reference, got {rendered}"
+    );
+    assert!(
+        activated_debug.contains("DiscardEffect")
+            && activated_debug.contains("supertypes: [")
+            && activated_debug.contains("Legendary")
+            && activated_debug.contains("DrawCardsEffect"),
+        "Niambi activation should structurally require discarding a legendary card and draw two cards, got {activated_debug}"
+    );
+}
+
+#[test]
+fn niambi_esteemed_speaker_activation_cost_requires_and_discards_legendary_card() {
+    let def = parse_oracle_card_definition("Niambi, Esteemed Speaker");
+    let activated = niambi_draw_activated_ability(&def);
+    let alice = PlayerId::from_index(0);
+    let mut game = crate::game_state::GameState::new(vec!["Alice".to_string()], 20);
+    let source = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    game.remove_summoning_sickness(source);
+
+    let nonlegendary_card = CardBuilder::new(CardId::new(), "Nonlegendary Test Card")
+        .card_types(vec![CardType::Creature])
+        .build();
+    let nonlegendary_id = game.create_object_from_card(&nonlegendary_card, alice, Zone::Hand);
+    game.player_mut(alice)
+        .expect("Alice should exist")
+        .mana_pool
+        .add(ManaSymbol::White, 2);
+    game.player_mut(alice)
+        .expect("Alice should exist")
+        .mana_pool
+        .add(ManaSymbol::Blue, 1);
+
+    assert!(
+        crate::cost::can_pay_cost(&game, source, alice, &activated.mana_cost).is_err(),
+        "Niambi activation should not be payable with only a nonlegendary card in hand"
+    );
+
+    let legendary_card = CardBuilder::new(CardId::new(), "Legendary Test Card")
+        .supertypes(vec![Supertype::Legendary])
+        .card_types(vec![CardType::Creature])
+        .build();
+    let legendary_id = game.create_object_from_card(&legendary_card, alice, Zone::Hand);
+    let draw_one = CardBuilder::new(CardId::new(), "Niambi Draw One").build();
+    let draw_two = CardBuilder::new(CardId::new(), "Niambi Draw Two").build();
+    game.create_object_from_card(&draw_one, alice, Zone::Library);
+    game.create_object_from_card(&draw_two, alice, Zone::Library);
+
+    crate::cost::can_pay_cost(&game, source, alice, &activated.mana_cost)
+        .expect("Niambi activation should be payable with a legendary card in hand");
+    let mut dm = crate::decision::AutoPassDecisionMaker::default();
+    crate::special_actions::pay_total_cost_with_choice(
+        &mut game,
+        alice,
+        source,
+        &activated.mana_cost,
+        crate::costs::PaymentReason::ActivateAbility,
+        &mut dm,
+    )
+    .expect("Niambi activation cost should select and discard the legendary card");
+
+    let player = game.player(alice).expect("Alice should exist");
+    assert!(game.is_tapped(source), "Niambi should tap to pay the cost");
+    assert!(
+        player.hand.contains(&nonlegendary_id),
+        "nonlegendary hand card should not satisfy Niambi's legendary discard cost"
+    );
+    assert!(
+        !player.hand.contains(&legendary_id),
+        "legendary hand card should be discarded to pay Niambi's activation cost"
+    );
+    assert_eq!(player.graveyard.len(), 1, "one card should be discarded");
+
+    let mut ctx = crate::effects::ExecutionContext::new_default(source, alice);
+    for effect in activated.effects.flattened_default_effects() {
+        crate::effects::execute_effect(&mut game, effect, &mut ctx)
+            .expect("Niambi activated ability should draw two cards after costs are paid");
+    }
+    let player = game.player(alice).expect("Alice should exist");
+    assert_eq!(
+        player.hand.len(),
+        3,
+        "after discarding one legendary card, Niambi should draw two cards"
+    );
+    assert_eq!(player.library.len(), 0, "Niambi should draw both library cards");
+}
+
+#[test]
+fn niambi_esteemed_speaker_enter_trigger_returns_another_creature_and_gains_life() {
+    struct DeclineMay;
+    impl crate::decision::DecisionMaker for DeclineMay {}
+
+    let def = parse_oracle_card_definition("Niambi, Esteemed Speaker");
+    let triggered = niambi_enter_triggered_ability(&def);
+    let target_spec = triggered
+        .choices
+        .first()
+        .expect("Niambi enters trigger should target another creature")
+        .clone();
+    let ChooseSpec::Target(inner) = target_spec.unhinted() else {
+        panic!("Niambi enters trigger should use a target spec, got {target_spec:#?}");
+    };
+    let ChooseSpec::Object(filter) = inner.unhinted() else {
+        panic!("Niambi enters trigger should target an object, got {inner:#?}");
+    };
+    assert!(
+        filter.other,
+        "Niambi enters trigger must target another creature, not Niambi itself"
+    );
+    assert_eq!(
+        filter.controller,
+        Some(PlayerFilter::You),
+        "Niambi enters trigger should only target a creature you control"
+    );
+    assert_eq!(
+        filter.card_types,
+        vec![CardType::Creature],
+        "Niambi enters trigger should target a creature"
+    );
+
+    let alice = PlayerId::from_index(0);
+    let returned_def = CardDefinitionBuilder::new(CardId::new(), "Niambi Returned Creature")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(4)]]))
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+
+    let mut game = crate::game_state::GameState::new(vec!["Alice".to_string()], 20);
+    let source = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let returned = game.create_object_from_definition(&returned_def, alice, Zone::Battlefield);
+    let returned_stable_id = game
+        .object(returned)
+        .expect("returned creature should exist")
+        .stable_id;
+    let source_snapshot = crate::snapshot::ObjectSnapshot::from_object(
+        game.object(source).expect("Niambi should exist"),
+        &game,
+    );
+    let entry_event = crate::triggers::TriggerEvent::new_with_provenance(
+        crate::events::zones::ZoneChangeEvent::with_cause(
+            source,
+            Zone::Stack,
+            Zone::Battlefield,
+            crate::events::cause::EventCause::effect(),
+            Some(source_snapshot),
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+    let mut ctx = crate::effects::ExecutionContext::new_default(source, alice)
+        .with_targets(vec![crate::effects::ResolvedTarget::Object(returned)])
+        .with_target_assignments(vec![crate::game_state::TargetAssignment {
+            spec: target_spec.clone(),
+            range: 0..1,
+        }])
+        .with_triggering_event(entry_event);
+    ctx.snapshot_targets(&game);
+
+    for effect in triggered.effects.flattened_default_effects() {
+        crate::effects::execute_effect(&mut game, effect, &mut ctx)
+            .expect("Niambi enters trigger should return target and gain life");
+    }
+
+    let returned_hand_id = game
+        .find_object_by_stable_id(returned_stable_id)
+        .expect("returned creature should still exist after changing zones");
+    let player = game.player(alice).expect("Alice should exist");
+    assert!(
+        player.hand.contains(&returned_hand_id),
+        "accepted Niambi trigger should return the targeted creature to hand"
+    );
+    assert_eq!(
+        game.life_total(alice),
+        24,
+        "Niambi should gain life equal to the returned creature's mana value"
+    );
+
+    let mut declined_game = crate::game_state::GameState::new(vec!["Alice".to_string()], 20);
+    let declined_source =
+        declined_game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let declined_returned =
+        declined_game.create_object_from_definition(&returned_def, alice, Zone::Battlefield);
+    let declined_source_snapshot = crate::snapshot::ObjectSnapshot::from_object(
+        declined_game
+            .object(declined_source)
+            .expect("Niambi should exist"),
+        &declined_game,
+    );
+    let declined_entry_event = crate::triggers::TriggerEvent::new_with_provenance(
+        crate::events::zones::ZoneChangeEvent::with_cause(
+            declined_source,
+            Zone::Stack,
+            Zone::Battlefield,
+            crate::events::cause::EventCause::effect(),
+            Some(declined_source_snapshot),
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+    let mut dm = DeclineMay;
+    let mut declined_ctx = crate::effects::ExecutionContext::new_default(declined_source, alice)
+        .with_decision_maker(&mut dm)
+        .with_targets(vec![crate::effects::ResolvedTarget::Object(
+            declined_returned,
+        )])
+        .with_target_assignments(vec![crate::game_state::TargetAssignment {
+            spec: target_spec,
+            range: 0..1,
+        }])
+        .with_triggering_event(declined_entry_event);
+    declined_ctx.snapshot_targets(&declined_game);
+
+    for effect in triggered.effects.flattened_default_effects() {
+        crate::effects::execute_effect(&mut declined_game, effect, &mut declined_ctx)
+            .expect("declined Niambi enters trigger should resolve without doing anything");
+    }
+
+    let declined_player = declined_game.player(alice).expect("Alice should exist");
+    assert!(
+        !declined_player.hand.contains(&declined_returned),
+        "declining Niambi trigger should not return the targeted creature"
+    );
+    assert_eq!(
+        declined_game.life_total(alice),
+        20,
+        "declining Niambi trigger should skip the conditional life gain"
+    );
+}
+
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn render_activation_discard_hand_cost_keeps_full_hand_clause() {

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -18417,6 +18417,9 @@ fn normalize_redundant_short_name_etb_surface(
     if rest_lower.contains("behold ") {
         return line;
     }
+    if rest_lower.contains("another target") {
+        return line;
+    }
     if rest
         .to_ascii_lowercase()
         .contains(surface.to_ascii_lowercase().as_str())
@@ -21092,25 +21095,8 @@ fn describe_simple_discard_cost(discard: &crate::effects::DiscardEffect) -> Opti
         return None;
     };
     let count = count.max(0) as u32;
-    let (card_type, name_filter, other_filter) = match &discard.card_filter {
-        None => (None, None, false),
-        Some(filter) if filter.card_types.len() == 1 => {
-            let expected = ObjectFilter {
-                zone: Some(Zone::Hand),
-                card_types: filter.card_types.clone(),
-                name: filter.name.clone(),
-                other: filter.other,
-                ..Default::default()
-            };
-            if filter != &expected {
-                return None;
-            }
-            (
-                filter.card_types.first().copied(),
-                filter.name.as_deref(),
-                filter.other,
-            )
-        }
+    let (card_type, supertypes, name_filter, other_filter) = match &discard.card_filter {
+        None => (None, Vec::new(), None, false),
         Some(filter) if !filter.any_of.is_empty() => {
             if let Some(filter_text) = describe_discard_any_of_filter(filter) {
                 return Some(if count == 1 {
@@ -21121,9 +21107,11 @@ fn describe_simple_discard_cost(discard: &crate::effects::DiscardEffect) -> Opti
             }
             return None;
         }
-        Some(filter) if filter.card_types.is_empty() => {
+        Some(filter) if filter.card_types.len() <= 1 => {
             let expected = ObjectFilter {
                 zone: Some(Zone::Hand),
+                card_types: filter.card_types.clone(),
+                supertypes: filter.supertypes.clone(),
                 name: filter.name.clone(),
                 other: filter.other,
                 ..Default::default()
@@ -21131,13 +21119,18 @@ fn describe_simple_discard_cost(discard: &crate::effects::DiscardEffect) -> Opti
             if filter != &expected {
                 return None;
             }
-            (None, filter.name.as_deref(), filter.other)
+            (
+                filter.card_types.first().copied(),
+                filter.supertypes.clone(),
+                filter.name.as_deref(),
+                filter.other,
+            )
         }
         Some(_) => return None,
     };
 
     if let Some(name) = name_filter {
-        if count != 1 {
+        if count != 1 || !supertypes.is_empty() {
             return None;
         }
         let name = normalize_card_name_for_surface(name);
@@ -21148,17 +21141,22 @@ fn describe_simple_discard_cost(discard: &crate::effects::DiscardEffect) -> Opti
         });
     }
 
-    let Some(card_type) = card_type else {
+    if supertypes.is_empty() && card_type.is_none() {
         return Some(if count == 1 {
             "Discard a card".to_string()
         } else {
             format!("Discard {count} cards")
         });
-    };
-    let type_text = with_indefinite_article(&format!(
-        "{} card",
-        describe_card_type_word_local(card_type)
-    ));
+    }
+
+    let mut descriptors: Vec<&str> = supertypes
+        .iter()
+        .map(|supertype| supertype.name())
+        .collect();
+    if let Some(card_type) = card_type {
+        descriptors.push(describe_card_type_word_local(card_type));
+    }
+    let type_text = with_indefinite_article(&format!("{} card", descriptors.join(" ")));
     Some(if count == 1 {
         format!("Discard {type_text}")
     } else {
@@ -33628,6 +33626,14 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
                 player_verb(&player, "gain", "gains")
             );
         }
+        if let Value::ManaValueOf(spec) = &gain.amount {
+            return format!(
+                "{} {} life equal to {}",
+                player,
+                player_verb(&player, "gain", "gains"),
+                describe_dynamic_counter_basis(spec, "mana value")
+            );
+        }
         if matches!(
             gain.amount,
             Value::Add(_, _)
@@ -33642,7 +33648,6 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
                 | Value::SourceToughness
                 | Value::PowerOf(_)
                 | Value::ToughnessOf(_)
-                | Value::ManaValueOf(_)
                 | Value::Speed(_)
                 | Value::LifeTotal(_)
                 | Value::LifeTotalAsTurnBegan(_)


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Niambi, Esteemed Speaker
Initial parse error:
```
unsupported activation cost segment (clause: 'discard a legendary card'): rewrite discard parser does not yet support selector 'discard a legendary card'; oracle-only fallback also failed: unsupported activation cost segment (clause: 'discard a legendary card'): rewrite discard parser does not yet support selector 'discard a legendary card'
```

Current worker: i-0e18be6d69457bf56
Branch: codex/aws-card-fix-niambi-esteemed-speaker
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260604T121212Z-controller-dev-loop-wave0016
