### PR TITLE
Fix Ironsmith parse failure: Tormented Thoughts

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
@@ -5639,7 +5639,7 @@ fn compile_subject_verb_effect(
                     (subject.into_player_filter(), subject.into_choices())
                 };
             let subject = LoweredSubject::from_resolved(resolved_player.clone(), choices);
-            let mut resolved_count = count.clone();
+            let mut resolved_count = resolve_value_it_tag(count, &current_reference_env(ctx))?;
             subject.apply_player_refs_to_value(&mut resolved_count, ctx);
             let resolved_filter = resolved_filter
                 .map(|resolved| subject.bind_discard_filter(&resolved, ctx))

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sacrifice_discard.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sacrifice_discard.rs
@@ -139,6 +139,22 @@ fn parse_discard_count_prefix(tokens: &[OwnedLexToken]) -> Option<(Value, bool, 
     Some((value, any_number, used))
 }
 
+fn parse_discard_number_of_cards_equal_count(
+    tokens: &[OwnedLexToken],
+) -> Option<(Value, usize)> {
+    let words = crate::runtime_backend::token_word_refs(tokens);
+    let prefix_len = [
+        &["a", "number", "of", "cards", "equal", "to"][..],
+        &["the", "number", "of", "cards", "equal", "to"],
+        &["number", "of", "cards", "equal", "to"],
+    ]
+    .iter()
+    .find_map(|prefix| words.starts_with(prefix).then_some(prefix.len()))?;
+    let value_token_idx = token_index_for_word_index(tokens, prefix_len)?;
+    let (value, used_value_tokens) = parse_value(&tokens[value_token_idx..])?;
+    Some((value, value_token_idx + used_value_tokens))
+}
+
 fn wrap_unless_escaped(effect: EffectAst, unless_escaped: bool) -> EffectAst {
     if unless_escaped {
         EffectAst::Conditional {
@@ -509,6 +525,21 @@ pub(crate) fn parse_discard(
             false,
             Some(tagged_filter),
             None,
+        ));
+    }
+
+    if let Some((count, used)) = parse_discard_number_of_cards_equal_count(tokens) {
+        let trailing_tokens = trim_commas(&tokens[used..]);
+        let trailing_words = crate::runtime_backend::token_word_refs(&trailing_tokens);
+        let random = DISCARD_AT_RANDOM_PATTERN.matches_words(&trailing_words);
+        if !trailing_words.is_empty() && !random {
+            return Err(CardTextError::ParseError(format!(
+                "unsupported trailing discard clause (clause: '{}')",
+                clause_words.join(" ")
+            )));
+        }
+        return Ok(EffectAst::subject_verb_discard(
+            player, count, random, false, None, None,
         ));
     }
 

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -36839,6 +36839,42 @@ fn parse_additional_cost_sacrificed_power_reference_clause() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn tormented_thoughts_strict_parser_and_compiled_text_regression() {
+    let def = parse_oracle_card_definition("Tormented Thoughts");
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+    let lower = rendered.to_ascii_lowercase();
+    assert!(
+        lower.contains("as an additional cost to cast this spell, sacrifice a creature"),
+        "expected Tormented Thoughts sacrifice additional cost, got {rendered}"
+    );
+    assert!(
+        rendered.contains(
+            "Target player discards a number of cards equal to the sacrificed creature's power"
+        ),
+        "expected Tormented Thoughts to render dynamic sacrificed-power discard count, got {rendered}"
+    );
+
+    let discard = def
+        .spell_effect
+        .as_ref()
+        .expect("Tormented Thoughts should have spell effects")
+        .flattened_default_effects()
+        .into_iter()
+        .find_map(|effect| effect.downcast_ref::<crate::effects::DiscardEffect>().cloned())
+        .expect("Tormented Thoughts should lower to a discard effect");
+    assert!(
+        matches!(
+            &discard.count,
+            crate::effect::Value::PowerOf(spec)
+                if matches!(spec.as_ref(), ChooseSpec::Tagged(tag) if tag.as_str() == "sacrificed_0")
+        ),
+        "expected Tormented Thoughts discard count to reference the sacrificed creature cost tag, got {:?}",
+        discard.count
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn soulblast_strict_parser_and_compiled_text_regression() {
     let def = parse_oracle_card_definition("Soulblast");
     let rendered = unprocessed_compiled_lines(&def).join(" ");

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -6246,6 +6246,13 @@ pub(super) fn describe_discard_count(value: &Value, filter: Option<&ObjectFilter
             Value::ColorsAmong(filter) => {
                 format!("a card for each {}", describe_colors_among(filter))
             }
+            Value::SourcePower
+            | Value::SourceToughness
+            | Value::PowerOf(_)
+            | Value::ToughnessOf(_)
+            | Value::ManaValueOf(_) => {
+                format!("a number of cards equal to {}", describe_value(value))
+            }
             _ => describe_card_count(value),
         };
     };

--- a/crates/ironsmith-runtime/src/game_loop/priority_mana.rs
+++ b/crates/ironsmith-runtime/src/game_loop/priority_mana.rs
@@ -47,9 +47,10 @@ fn pay_selected_cost(
     >,
     decision_maker: &mut impl DecisionMaker,
 ) -> Result<(), GameLoopError> {
+    let processing_mode = cost.processing_mode();
     let effective_choice_tag = choice_tag
         .cloned()
-        .or_else(|| match cost.processing_mode() {
+        .or_else(|| match &processing_mode {
             crate::costs::CostProcessingMode::ExileFromHand { .. }
             | crate::costs::CostProcessingMode::ExileFromGraveyard { .. }
             | crate::costs::CostProcessingMode::ExileObjects { .. } => {
@@ -57,15 +58,23 @@ fn pay_selected_cost(
             }
             _ => None,
         });
+    let preserve_chosen_snapshot = matches!(
+        processing_mode,
+        crate::costs::CostProcessingMode::SacrificeTarget { .. }
+    );
 
     let mut cost_ctx = crate::costs::CostContext::new(source, payer, decision_maker)
         .with_reason(reason)
         .with_pre_chosen_cards(vec![chosen_id])
         .with_provenance(provenance);
     cost_ctx.tagged_objects = tagged_objects.clone();
-    let chosen_snapshot = game
-        .object(chosen_id)
-        .map(|obj| crate::snapshot::ObjectSnapshot::from_object(obj, game));
+    let chosen_snapshot = game.object(chosen_id).map(|obj| {
+        if preserve_chosen_snapshot {
+            crate::snapshot::ObjectSnapshot::from_object_with_calculated_characteristics(obj, game)
+        } else {
+            crate::snapshot::ObjectSnapshot::from_object(obj, game)
+        }
+    });
     if let Some(tag) = effective_choice_tag.as_ref()
         && let Some(snapshot) = chosen_snapshot.clone()
     {
@@ -78,7 +87,8 @@ fn pay_selected_cost(
 
     match cost.pay(game, &mut cost_ctx) {
         Ok(crate::costs::CostPaymentResult::Paid) => {
-            if let Some(tag) = effective_choice_tag.as_ref()
+            if !preserve_chosen_snapshot
+                && let Some(tag) = effective_choice_tag.as_ref()
                 && let Some(snapshot) = chosen_snapshot.as_ref()
                 && let Some(current_id) = game.find_object_by_stable_id(snapshot.stable_id)
                 && let Some(current) = game.object(current_id)

--- a/crates/ironsmith-runtime/src/game_loop/priority_state.rs
+++ b/crates/ironsmith-runtime/src/game_loop/priority_state.rs
@@ -377,6 +377,33 @@ pub(crate) fn choose_tagged_cost_step(
         }
     }
 
+    let sacrifice_player = next_effect
+        .downcast_ref::<ironsmith_core::SacrificePlayerEffect>()
+        .or_else(|| {
+            next_effect
+                .downcast_ref::<crate::effects::WithIdEffect>()
+                .and_then(|with_id| {
+                    with_id
+                        .effect
+                        .downcast_ref::<ironsmith_core::SacrificePlayerEffect>()
+                })
+        });
+    if let Some(sacrifice) = sacrifice_player {
+        if sacrifice.player == crate::target::PlayerFilter::You
+            && tagged_filter_matches(&sacrifice.filter, &choose.tag)
+        {
+            return Some(ActivationCostStep::Sacrifice {
+                cost: crate::costs::Cost::sacrifice(choose.filter.clone()),
+                filter: choose.filter.clone(),
+                description: crate::costs::CostProcessingMode::SacrificeTarget {
+                    filter: choose.filter.clone(),
+                }
+                .display(),
+                choice_tag: Some(choose.tag.clone()),
+            });
+        }
+    }
+
     if let Some(exile) = next_effect.downcast_ref::<crate::effects::ExileEffect>() {
         let zone = choose.filter.zone.or(choose.zone)?;
         let description = match zone {

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -28516,6 +28516,280 @@ fn test_corpse_cobble_sums_the_power_of_sacrificed_creatures() {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn tormented_thoughts_definition_for_runtime_tests() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(398_623), "Tormented Thoughts")
+        .mana_cost(ManaCost::new())
+        .card_types(vec![CardType::Sorcery])
+        .parse_text(
+            "As an additional cost to cast this spell, sacrifice a creature.\nTarget player discards a number of cards equal to the sacrificed creature's power.",
+        )
+        .expect("Tormented Thoughts should parse for runtime tests")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn tormented_thoughts_test_card(name: &str, card_types: Vec<CardType>) -> crate::card::Card {
+    CardBuilder::new(CardId::new(), name)
+        .card_types(card_types)
+        .build()
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+struct TormentedThoughtsDiscardDecisionMaker {
+    discard_order: Vec<ObjectId>,
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+struct TormentedThoughtsCostDecisionMaker {
+    sacrifice_id: ObjectId,
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+impl DecisionMaker for TormentedThoughtsCostDecisionMaker {
+    fn decide_objects(
+        &mut self,
+        _game: &GameState,
+        ctx: &crate::decisions::context::SelectObjectsContext,
+    ) -> Vec<ObjectId> {
+        if ctx
+            .candidates
+            .iter()
+            .any(|candidate| candidate.id == self.sacrifice_id && candidate.legal)
+        {
+            vec![self.sacrifice_id]
+        } else {
+            ctx.candidates
+                .iter()
+                .filter(|candidate| candidate.legal)
+                .map(|candidate| candidate.id)
+                .take(ctx.min)
+                .collect()
+        }
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+impl DecisionMaker for TormentedThoughtsDiscardDecisionMaker {
+    fn decide_objects(
+        &mut self,
+        _game: &GameState,
+        ctx: &crate::decisions::context::SelectObjectsContext,
+    ) -> Vec<ObjectId> {
+        let legal_ids = ctx
+            .candidates
+            .iter()
+            .filter(|candidate| candidate.legal)
+            .map(|candidate| candidate.id)
+            .collect::<Vec<_>>();
+        self.discard_order
+            .iter()
+            .copied()
+            .filter(|id| legal_ids.contains(id))
+            .take(ctx.min)
+            .collect()
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn cast_tormented_thoughts_targeting_player(
+    game: &mut GameState,
+    trigger_queue: &mut TriggerQueue,
+    spell_id: ObjectId,
+    target_player: PlayerId,
+    sacrifice_id: ObjectId,
+) {
+    use crate::decision::{GameProgress, LegalAction};
+
+    let mut state = PriorityLoopState::new(game.players_in_game());
+    let mut dm = TormentedThoughtsCostDecisionMaker { sacrifice_id };
+    let mut progress = apply_priority_response_with_dm(
+        game,
+        trigger_queue,
+        &mut state,
+        &PriorityResponse::PriorityAction(LegalAction::CastSpell {
+            spell_id,
+            from_zone: Zone::Hand,
+            casting_method: CastingMethod::Normal,
+        }),
+        &mut dm,
+    )
+    .expect("Tormented Thoughts cast should start");
+
+    for _ in 0..5 {
+        progress = match progress {
+            GameProgress::NeedsDecisionCtx(
+                crate::decisions::context::DecisionContext::Targets(_),
+            ) => {
+                apply_priority_response_with_dm(
+                    game,
+                    trigger_queue,
+                    &mut state,
+                    &PriorityResponse::Targets(vec![Target::Player(target_player)]),
+                    &mut dm,
+                )
+                .expect("Tormented Thoughts should accept target player")
+            }
+            GameProgress::NeedsDecisionCtx(
+                crate::decisions::context::DecisionContext::SelectOptions(ctx),
+            ) => {
+                let sacrifice_cost_index = ctx
+                    .options
+                    .iter()
+                    .find(|option| option.description.to_ascii_lowercase().contains("sacrifice"))
+                    .map(|option| option.index)
+                    .unwrap_or_else(|| {
+                        panic!(
+                            "Tormented Thoughts should offer a sacrifice cost option, got {:?}",
+                            ctx.options
+                        )
+                    });
+                apply_priority_response_with_dm(
+                    game,
+                    trigger_queue,
+                    &mut state,
+                    &PriorityResponse::NextCostChoice(sacrifice_cost_index),
+                    &mut dm,
+                )
+                .expect("Tormented Thoughts should accept choosing the sacrifice cost")
+            }
+            GameProgress::NeedsDecisionCtx(
+                crate::decisions::context::DecisionContext::SelectObjects(ctx),
+            ) => {
+                assert!(
+                    ctx.candidates
+                        .iter()
+                        .any(|candidate| candidate.id == sacrifice_id && candidate.legal),
+                    "Tormented Thoughts should allow sacrificing the chosen creature as its additional cost"
+                );
+                apply_priority_response_with_dm(
+                    game,
+                    trigger_queue,
+                    &mut state,
+                    &PriorityResponse::CardCostChoice(sacrifice_id),
+                    &mut dm,
+                )
+                .expect("Tormented Thoughts should accept the sacrificed creature")
+            }
+            GameProgress::NeedsDecisionCtx(
+                crate::decisions::context::DecisionContext::Priority(_),
+            ) => {
+                break;
+            }
+            other => panic!("unexpected Tormented Thoughts cast flow state: {other:?}"),
+        };
+    }
+
+    assert_eq!(game.stack.len(), 1, "Tormented Thoughts should be on the stack");
+    let stack_entry = game.stack.last().expect("Tormented Thoughts should be stacked");
+    assert_eq!(stack_entry.targets, vec![Target::Player(target_player)]);
+    let sacrificed = stack_entry
+        .tagged_objects
+        .get(&crate::tag::TagKey::from("sacrificed_0"))
+        .expect("Tormented Thoughts stack entry should remember the sacrificed creature");
+    assert_eq!(sacrificed.len(), 1);
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn run_tormented_thoughts_discards_by_sacrificed_power(
+    sacrificed_power: i32,
+    target_hand_size: usize,
+) {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let mut trigger_queue = TriggerQueue::new();
+
+    game.turn.active_player = alice;
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.priority_player = Some(alice);
+
+    let tormented_thoughts = tormented_thoughts_definition_for_runtime_tests();
+    let spell_id = game.create_object_from_definition(&tormented_thoughts, alice, Zone::Hand);
+    let fodder = CardBuilder::new(CardId::new(), "Tormented Thoughts Fodder")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(sacrificed_power, 1))
+        .build();
+    let fodder_id = game.create_object_from_card(&fodder, alice, Zone::Battlefield);
+    let alice_hand_card = game.create_object_from_card(
+        &tormented_thoughts_test_card("Alice Untouched Hand Card", vec![CardType::Instant]),
+        alice,
+        Zone::Hand,
+    );
+    let bob_hand = (0..target_hand_size)
+        .map(|idx| {
+            game.create_object_from_card(
+                &tormented_thoughts_test_card(
+                    &format!("Bob Tormented Card {}", idx + 1),
+                    vec![CardType::Artifact],
+                ),
+                bob,
+                Zone::Hand,
+            )
+        })
+        .collect::<Vec<_>>();
+
+    cast_tormented_thoughts_targeting_player(
+        &mut game,
+        &mut trigger_queue,
+        spell_id,
+        bob,
+        fodder_id,
+    );
+
+    assert!(
+        !game.battlefield.contains(&fodder_id)
+            && player_zone_contains_named(
+                &game,
+                alice,
+                Zone::Graveyard,
+                "Tormented Thoughts Fodder"
+            ),
+        "Tormented Thoughts should sacrifice the creature as an additional cost"
+    );
+    assert!(
+        game.player(alice)
+            .expect("Alice exists")
+            .hand
+            .contains(&alice_hand_card),
+        "Tormented Thoughts should not discard cards from the caster when Bob is targeted"
+    );
+
+    let mut dm = TormentedThoughtsDiscardDecisionMaker {
+        discard_order: bob_hand.clone(),
+    };
+    resolve_stack_entry_with(&mut game, &mut dm).expect("Tormented Thoughts should resolve");
+
+    let expected_discards = target_hand_size.min(sacrificed_power.max(0) as usize);
+    for (idx, card_id) in bob_hand.iter().enumerate() {
+        let name = format!("Bob Tormented Card {}", idx + 1);
+        if idx < expected_discards {
+            assert!(
+                !game.player(bob).expect("Bob exists").hand.contains(card_id)
+                    && player_zone_contains_named(&game, bob, Zone::Graveyard, &name),
+                "Tormented Thoughts should discard Bob's card {name}"
+            );
+        } else {
+            assert!(
+                game.player(bob).expect("Bob exists").hand.contains(card_id),
+                "Tormented Thoughts should leave Bob's extra card {name} in hand"
+            );
+        }
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn tormented_thoughts_discards_cards_equal_to_sacrificed_creature_power() {
+    run_tormented_thoughts_discards_by_sacrificed_power(3, 4);
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn tormented_thoughts_discards_only_available_cards_when_power_exceeds_hand_size() {
+    run_tormented_thoughts_discards_by_sacrificed_power(4, 2);
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 fn soulblast_definition_for_runtime_tests() -> crate::cards::CardDefinition {
     CardDefinitionBuilder::new(CardId::from_raw(130_369), "Soulblast")
         .mana_cost(ManaCost::new())

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -28691,6 +28691,7 @@ fn cast_tormented_thoughts_targeting_player(
 #[cfg(ironsmith_runtime_parser_tests)]
 fn run_tormented_thoughts_discards_by_sacrificed_power(
     sacrificed_power: i32,
+    plus_one_plus_one_counters: u32,
     target_hand_size: usize,
 ) {
     let mut game = setup_game();
@@ -28710,6 +28711,13 @@ fn run_tormented_thoughts_discards_by_sacrificed_power(
         .power_toughness(PowerToughness::fixed(sacrificed_power, 1))
         .build();
     let fodder_id = game.create_object_from_card(&fodder, alice, Zone::Battlefield);
+    if plus_one_plus_one_counters > 0 {
+        game.add_counters(
+            fodder_id,
+            crate::object::CounterType::PlusOnePlusOne,
+            plus_one_plus_one_counters,
+        );
+    }
     let alice_hand_card = game.create_object_from_card(
         &tormented_thoughts_test_card("Alice Untouched Hand Card", vec![CardType::Instant]),
         alice,
@@ -28759,7 +28767,8 @@ fn run_tormented_thoughts_discards_by_sacrificed_power(
     };
     resolve_stack_entry_with(&mut game, &mut dm).expect("Tormented Thoughts should resolve");
 
-    let expected_discards = target_hand_size.min(sacrificed_power.max(0) as usize);
+    let battlefield_power = sacrificed_power + plus_one_plus_one_counters as i32;
+    let expected_discards = target_hand_size.min(battlefield_power.max(0) as usize);
     for (idx, card_id) in bob_hand.iter().enumerate() {
         let name = format!("Bob Tormented Card {}", idx + 1);
         if idx < expected_discards {
@@ -28780,13 +28789,19 @@ fn run_tormented_thoughts_discards_by_sacrificed_power(
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn tormented_thoughts_discards_cards_equal_to_sacrificed_creature_power() {
-    run_tormented_thoughts_discards_by_sacrificed_power(3, 4);
+    run_tormented_thoughts_discards_by_sacrificed_power(3, 0, 4);
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn tormented_thoughts_discards_only_available_cards_when_power_exceeds_hand_size() {
-    run_tormented_thoughts_discards_by_sacrificed_power(4, 2);
+    run_tormented_thoughts_discards_by_sacrificed_power(4, 0, 2);
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn tormented_thoughts_uses_sacrificed_creature_lki_power_after_counters() {
+    run_tormented_thoughts_discards_by_sacrificed_power(1, 3, 4);
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Tormented Thoughts
Initial parse error:
```
unsupported discard card qualifier (clause: 'a number of cards equal to the sacrificed creature's power'); oracle-only fallback also failed: unsupported discard card qualifier (clause: 'a number of cards equal to the sacrificed creature's power')
```

Current worker: i-0fb9088ac9c94d6e4
Branch: codex/aws-card-fix-tormented-thoughts
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260604T121212Z-controller-dev-loop-wave0016
