### PR TITLE
Fix Ironsmith parse failure: Aetheric Amplifier

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/model/modal_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/modal_support.rs
@@ -6,7 +6,9 @@ use crate::effect::Value;
 use crate::target::PlayerFilter;
 use ironsmith_core::ValueSurfaceHint;
 
-use super::activation_and_restrictions::activated_line_core::infer_activated_functional_zones_lexed;
+use super::activation_and_restrictions::activated_line_core::{
+    infer_activated_functional_zones_lexed, parse_activate_only_timing_lexed,
+};
 use super::clause_support::{parse_effect_sentences_lexed, parse_trigger_clause_lexed};
 use super::effect_ast_traversal::try_for_each_nested_effects_mut;
 use super::grammar::primitives as grammar;
@@ -112,6 +114,14 @@ pub(crate) fn parse_modal_header(info: &LineInfo) -> Result<Option<ModalHeader>,
                 activation_restrictions: Vec::new(),
             });
             effect_start_idx = colon_idx + 1;
+        }
+    }
+
+    if let Some(activated) = activated.as_mut() {
+        for sentence in split_lexed_sentences(&tokens[choose_idx + 1..]) {
+            if let Some(timing) = parse_activate_only_timing_lexed(sentence) {
+                activated.timing = timing;
+            }
         }
     }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_pattern_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_pattern_helpers.rs
@@ -858,6 +858,17 @@ pub(crate) fn parse_double_counters_clause(
         )
     };
 
+    let counter_holder_words = crate::runtime_backend::token_word_refs(&tokens[counters_idx + 1..]);
+    if matches!(counter_holder_words.as_slice(), ["you", "have"]) {
+        return Ok(Some(EffectAst::subject_verb_double_counters_on_target(
+            counter_type,
+            TargetAst::Player(
+                PlayerFilter::You,
+                span_from_tokens(&tokens[counters_idx + 1..]),
+            ),
+        )));
+    }
+
     let on_idx = find_token_index(&tokens[counters_idx + 1..], |token| {
         CLAUSE_ON_WORD_PATTERN.matches_token(token)
     })

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -40384,6 +40384,143 @@ fn parse_deepglow_skate_strict_oracle_text() {
     assert_eq!(filter.zone, Some(Zone::Battlefield));
 }
 
+#[test]
+fn aetheric_amplifier_strict_parser_and_compiled_text_regression() {
+    assert_oracle_card_parses_strict("Aetheric Amplifier");
+    let def = parse_oracle_card_definition("Aetheric Amplifier");
+    let rendered = unprocessed_compiled_lines(&def).join("\n");
+
+    assert!(
+        rendered.contains(
+            "{4}, {T}: Choose one. Activate only as a sorcery.\n\
+• Double the number of each kind of counter on target permanent.\n\
+• Double the number of each kind of counter you have."
+        ),
+        "expected Aetheric Amplifier compiled text to preserve both counter-doubling modes, got {rendered}"
+    );
+
+    let modal = def
+        .abilities
+        .iter()
+        .filter_map(|ability| match &ability.kind {
+            AbilityKind::Activated(activated) => Some(activated),
+            _ => None,
+        })
+        .find_map(|activated| {
+            activated
+                .effects
+                .flattened_default_effects()
+                .iter()
+                .find_map(|effect| effect.downcast_ref::<ChooseModeEffect>())
+        })
+        .expect("Aetheric Amplifier should compile its choose-one activation as a modal effect");
+    let modal_activated = def
+        .abilities
+        .iter()
+        .filter_map(|ability| match &ability.kind {
+            AbilityKind::Activated(activated) => Some(activated),
+            _ => None,
+        })
+        .find(|activated| {
+            activated
+                .effects
+                .flattened_default_effects()
+                .iter()
+                .any(|effect| effect.downcast_ref::<ChooseModeEffect>().is_some())
+        })
+        .expect("Aetheric Amplifier should have a modal activated ability");
+    assert_eq!(
+        modal_activated.timing,
+        crate::ability::ActivationTiming::SorcerySpeed,
+        "Aetheric Amplifier modal activation must preserve activate-only-as-sorcery timing"
+    );
+    assert_eq!(modal.modes.len(), 2);
+
+    let doubles = modal
+        .modes
+        .iter()
+        .flat_map(|mode| mode.effects.iter())
+        .filter_map(|effect| effect.downcast_ref::<DoubleCountersEffect>())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        doubles.len(),
+        2,
+        "Aetheric Amplifier should compile both modes as double-counters effects"
+    );
+    assert!(
+        doubles.iter().any(|effect| {
+            effect.counter_type.is_none()
+                && effect.target.is_target()
+                && matches!(
+                    effect.target.base(),
+                    ChooseSpec::Object(filter) if filter.zone == Some(Zone::Battlefield)
+                )
+        }),
+        "expected one mode to target a permanent"
+    );
+    assert!(
+        doubles.iter().any(|effect| {
+            effect.counter_type.is_none()
+                && matches!(effect.target.base(), ChooseSpec::SourceController)
+        }),
+        "expected one mode to double counters the controller has"
+    );
+}
+
+#[test]
+fn aetheric_amplifier_modal_activation_is_sorcery_speed() {
+    let def = parse_oracle_card_definition("Aetheric Amplifier");
+    let mut game = crate::tests::test_helpers::setup_two_player_game();
+    let alice = PlayerId::from_index(0);
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+    game.turn.step = None;
+    let amplifier_id = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    game.player_mut(alice)
+        .expect("alice exists")
+        .mana_pool
+        .add(ManaSymbol::Colorless, 4);
+
+    let modal_ability_index = game
+        .object(amplifier_id)
+        .expect("Aetheric Amplifier should exist")
+        .abilities
+        .iter()
+        .position(|ability| match &ability.kind {
+            AbilityKind::Activated(activated) => activated
+                .effects
+                .flattened_default_effects()
+                .iter()
+                .any(|effect| effect.downcast_ref::<ChooseModeEffect>().is_some()),
+            _ => false,
+        })
+        .expect("Aetheric Amplifier should have a modal activated ability");
+
+    game.turn.phase = crate::game_state::Phase::FirstMain;
+    assert!(
+        crate::decision::compute_legal_actions(&game, alice)
+            .into_iter()
+            .any(|action| matches!(
+                action,
+                crate::decision::LegalAction::ActivateAbility { source, ability_index }
+                    if source == amplifier_id && ability_index == modal_ability_index
+            )),
+        "Aetheric Amplifier's modal activation should be legal in its controller's main phase"
+    );
+
+    game.turn.phase = crate::game_state::Phase::Combat;
+    assert!(
+        !crate::decision::compute_legal_actions(&game, alice)
+            .into_iter()
+            .any(|action| matches!(
+                action,
+                crate::decision::LegalAction::ActivateAbility { source, ability_index }
+                    if source == amplifier_id && ability_index == modal_ability_index
+            )),
+        "Aetheric Amplifier's modal activation should not be legal outside sorcery speed"
+    );
+}
+
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn parse_then_that_player_discards_clause() {

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -17497,26 +17497,20 @@ pub(super) fn describe_inline_ability_with_self_subject(
                 ));
             }
             if let Some(x_definition) = trailing_x_definition {
-                if !line.is_empty() {
-                    line.push_str(". ");
-                }
-                line.push_str(&x_definition);
+                append_sentence_clause(&mut line, &x_definition);
             }
             let restriction_clauses = collect_activation_restriction_clauses(
                 &activated.timing,
                 &activated.additional_restrictions,
             );
             if !restriction_clauses.is_empty() {
-                if !line.is_empty() {
-                    line.push_str(". ");
-                }
-                line.push_str(&join_activation_restriction_clauses(&restriction_clauses));
+                append_activation_clause(
+                    &mut line,
+                    &join_activation_restriction_clauses(&restriction_clauses),
+                );
             }
             for clause in describe_mana_usage_restriction_clauses_for_activated(activated) {
-                if !line.is_empty() {
-                    line.push_str(". ");
-                }
-                line.push_str(&clause);
+                append_activation_clause(&mut line, &clause);
             }
             let line = if line.is_empty() {
                 "an activated ability".to_string()
@@ -31791,6 +31785,18 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
             }
             return format!("Double the number of {counter_text} on each {filter_text}");
         }
+        if matches!(
+            double_counters.target.base(),
+            ChooseSpec::Player(_)
+                | ChooseSpec::SpecificPlayer(_)
+                | ChooseSpec::EachPlayer(_)
+                | ChooseSpec::SourceController
+                | ChooseSpec::SourceOwner
+        ) {
+            let player_text = describe_choose_spec(&double_counters.target);
+            let verb = if player_text == "you" { "have" } else { "has" };
+            return format!("Double the number of {counter_text} {player_text} {verb}");
+        }
         return format!(
             "Double the number of {counter_text} on {}",
             describe_choose_spec(&double_counters.target)
@@ -39285,6 +39291,32 @@ pub(super) fn join_activation_restriction_clauses(clauses: &[String]) -> String 
     line
 }
 
+fn append_sentence_clause(line: &mut String, clause: &str) {
+    if !line.is_empty() {
+        if line.ends_with('.') || line.ends_with('!') || line.ends_with('?') {
+            line.push(' ');
+        } else {
+            line.push_str(". ");
+        }
+    }
+    line.push_str(clause);
+}
+
+fn append_activation_clause(line: &mut String, clause: &str) {
+    let Some(newline_idx) = line.find('\n') else {
+        append_sentence_clause(line, clause);
+        return;
+    };
+
+    let mut header = line[..newline_idx].trim_end().to_string();
+    if let Some(stripped) = header.strip_suffix('—') {
+        header = stripped.trim_end().to_string();
+    }
+    append_sentence_clause(&mut header, clause);
+    header.push_str(&line[newline_idx..]);
+    *line = header;
+}
+
 pub(super) fn describe_keyword_ability(ability: &Ability) -> Option<String> {
     if let AbilityKind::Activated(activated) = &ability.kind
         && let Some(craft) = describe_structural_craft_keyword(ability, activated)
@@ -42537,22 +42569,20 @@ pub(super) fn describe_ability(
                 line.push_str(&effects);
             }
             if let Some(x_definition) = trailing_x_definition {
-                if !line.is_empty() {
-                    line.push_str(". ");
-                }
-                line.push_str(&x_definition);
+                append_sentence_clause(&mut line, &x_definition);
             }
             let restriction_clauses = collect_activation_restriction_clauses(
                 &activated.timing,
                 &activated.additional_restrictions,
             );
             if !restriction_clauses.is_empty() {
-                line.push_str(". ");
-                line.push_str(&join_activation_restriction_clauses(&restriction_clauses));
+                append_activation_clause(
+                    &mut line,
+                    &join_activation_restriction_clauses(&restriction_clauses),
+                );
             }
             for clause in describe_mana_usage_restriction_clauses_for_activated(activated) {
-                line.push_str(". ");
-                line.push_str(&clause);
+                append_activation_clause(&mut line, &clause);
             }
             if is_grandeur_activation_cost(activated) {
                 line = format!("Grandeur — {line}");

--- a/crates/ironsmith-runtime/src/effects/counters/double_counters.rs
+++ b/crates/ironsmith-runtime/src/effects/counters/double_counters.rs
@@ -1,12 +1,45 @@
 //! Double counters on selected objects.
 
 use crate::effect::EffectOutcome;
-use crate::effects::helpers::resolve_objects_for_effect;
+use crate::effects::helpers::{resolve_objects_for_effect, resolve_players_from_spec};
 use crate::effects::{EffectExecutor, ExecutionContext, ExecutionError};
 use crate::events::processing::process_put_counters_with_event;
 use crate::game_state::GameState;
+use crate::object::CounterType;
 use crate::target::ChooseSpec;
 pub use ironsmith_core::DoubleCountersEffect;
+
+fn double_counters_targets_players(target: &ChooseSpec) -> bool {
+    matches!(
+        target.base(),
+        ChooseSpec::Player(_)
+            | ChooseSpec::SpecificPlayer(_)
+            | ChooseSpec::EachPlayer(_)
+            | ChooseSpec::SourceController
+            | ChooseSpec::SourceOwner
+    )
+}
+
+fn player_counter_counts(
+    game: &GameState,
+    player_id: crate::ids::PlayerId,
+    counter_type: Option<CounterType>,
+) -> Result<Vec<(CounterType, u32)>, ExecutionError> {
+    let player = game
+        .player(player_id)
+        .ok_or(ExecutionError::PlayerNotFound(player_id))?;
+    let candidates = [
+        (CounterType::Poison, player.poison_counters),
+        (CounterType::Energy, player.energy_counters),
+        (CounterType::Experience, player.experience_counters),
+    ];
+    Ok(candidates
+        .into_iter()
+        .filter(|(candidate, count)| {
+            *count > 0 && counter_type.is_none_or(|wanted| wanted == *candidate)
+        })
+        .collect())
+}
 
 impl EffectExecutor for DoubleCountersEffect {
     fn execute(
@@ -14,6 +47,32 @@ impl EffectExecutor for DoubleCountersEffect {
         game: &mut GameState,
         ctx: &mut ExecutionContext,
     ) -> Result<EffectOutcome, ExecutionError> {
+        if double_counters_targets_players(&self.target) {
+            let player_ids = resolve_players_from_spec(game, &self.target, ctx)?;
+            let mut outcomes = Vec::new();
+            for player_id in player_ids {
+                for (counter_type, count) in
+                    player_counter_counts(game, player_id, self.counter_type)?
+                {
+                    if let Some(event) = game.add_player_counters_with_source(
+                        player_id,
+                        counter_type,
+                        count,
+                        Some(ctx.source),
+                        Some(ctx.controller),
+                    ) {
+                        outcomes.push(EffectOutcome::count(count as i32).with_event(event));
+                    }
+                }
+            }
+
+            return Ok(if outcomes.is_empty() {
+                EffectOutcome::resolved()
+            } else {
+                EffectOutcome::aggregate_summing_counts(outcomes)
+            });
+        }
+
         let target_ids = resolve_objects_for_effect(game, ctx, &self.target)?;
         if target_ids.is_empty() {
             return Ok(EffectOutcome::resolved());
@@ -164,5 +223,83 @@ mod tests {
             .expect("choosing zero Deepglow Skate targets should resolve");
 
         assert_eq!(game.counter_count(unchosen, CounterType::Charge), 2);
+    }
+
+    #[test]
+    fn aetheric_amplifier_target_mode_doubles_each_counter_kind_on_target_permanent() {
+        let mut game = crate::tests::test_helpers::setup_two_player_game();
+        let alice = PlayerId::from_index(0);
+        let source = game.new_object_id();
+        let target = create_permanent(&mut game, "Aetheric Amplifier target", alice);
+        let other = create_permanent(&mut game, "Aetheric Amplifier bystander", alice);
+
+        game.add_counters(target, CounterType::PlusOnePlusOne, 2);
+        game.add_counters(target, CounterType::Charge, 1);
+        game.add_counters(other, CounterType::Charge, 3);
+
+        let mut ctx = ExecutionContext::new_default(source, alice);
+        ctx.targets = vec![ResolvedTarget::Object(target)];
+
+        let effect = DoubleCountersEffect::new(
+            None,
+            ChooseSpec::target(ChooseSpec::Object(ObjectFilter::permanent())),
+        );
+        effect
+            .execute(&mut game, &mut ctx)
+            .expect("Aetheric Amplifier target mode should resolve");
+
+        assert_eq!(game.counter_count(target, CounterType::PlusOnePlusOne), 4);
+        assert_eq!(game.counter_count(target, CounterType::Charge), 2);
+        assert_eq!(game.counter_count(other, CounterType::Charge), 3);
+    }
+
+    #[test]
+    fn aetheric_amplifier_player_mode_doubles_each_player_counter_kind_you_have() {
+        let mut game = crate::tests::test_helpers::setup_two_player_game();
+        let alice = PlayerId::from_index(0);
+        let bob = PlayerId::from_index(1);
+        let source = game.new_object_id();
+        {
+            let alice_player = game.player_mut(alice).expect("alice exists");
+            alice_player.poison_counters = 1;
+            alice_player.energy_counters = 2;
+            alice_player.experience_counters = 3;
+        }
+        game.player_mut(bob).expect("bob exists").energy_counters = 5;
+
+        let mut ctx = ExecutionContext::new_default(source, alice);
+        let effect = DoubleCountersEffect::new(None, ChooseSpec::SourceController);
+        let outcome = effect
+            .execute(&mut game, &mut ctx)
+            .expect("Aetheric Amplifier player mode should resolve");
+
+        let alice_player = game.player(alice).expect("alice exists");
+        assert_eq!(alice_player.poison_counters, 2);
+        assert_eq!(alice_player.energy_counters, 4);
+        assert_eq!(alice_player.experience_counters, 6);
+        assert_eq!(game.player(bob).expect("bob exists").energy_counters, 5);
+        assert_eq!(outcome.events.len(), 3);
+    }
+
+    #[test]
+    fn aetheric_amplifier_player_mode_does_not_create_absent_counter_kinds() {
+        let mut game = crate::tests::test_helpers::setup_two_player_game();
+        let alice = PlayerId::from_index(0);
+        let source = game.new_object_id();
+        game.player_mut(alice)
+            .expect("alice exists")
+            .energy_counters = 2;
+
+        let mut ctx = ExecutionContext::new_default(source, alice);
+        let effect = DoubleCountersEffect::new(None, ChooseSpec::SourceController);
+        let outcome = effect
+            .execute(&mut game, &mut ctx)
+            .expect("Aetheric Amplifier player mode should resolve");
+
+        let alice_player = game.player(alice).expect("alice exists");
+        assert_eq!(alice_player.poison_counters, 0);
+        assert_eq!(alice_player.energy_counters, 4);
+        assert_eq!(alice_player.experience_counters, 0);
+        assert_eq!(outcome.events.len(), 1);
     }
 }


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Aetheric Amplifier
Initial parse error:
```
missing 'on' in double-counters clause (clause: 'double the number of each kind of counter you have'); oracle-only fallback also failed: missing 'on' in double-counters clause (clause: 'double the number of each kind of counter you have')
```

Current worker: i-06255311e06447ae1
Branch: codex/aws-card-fix-aetheric-amplifier
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260604T121212Z-controller-dev-loop-wave0016
