### PR TITLE
Fix Ironsmith parse failure: Chaos Lord

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -3984,7 +3984,13 @@ pub(crate) fn parse_static_text_marker_line(tokens: &[OwnedLexToken]) -> Option<
     }
 
     if is_attack_as_haste_unless_entered_this_turn_marker_line_lexed(tokens) {
-        return Some(keyword_static_marker(tokens));
+        let condition = Condition::Not(Box::new(Condition::ObjectEnteredBattlefieldThisTurn(
+            ObjectFilter::source(),
+        )));
+        return Some(StaticAbility::new(
+            GrantAbility::source(StaticAbility::can_attack_as_though_haste())
+                .with_condition(condition),
+        ));
     }
 
     if is_sab_sunen_cant_attack_or_block_unless_line_lexed(tokens) {

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
@@ -3130,6 +3130,40 @@ fn parse_player_life_relation_predicate(words: &[&str]) -> Option<PredicateAst> 
     }
 }
 
+fn parse_count_parity_predicate(words: &[&str]) -> Option<PredicateAst> {
+    let words = match words {
+        ["number", "of", rest @ ..] => rest,
+        ["count", "of", rest @ ..] => rest,
+        _ => return None,
+    };
+    let (scope, parity) = words.split_at(words.len().checked_sub(2)?);
+    if parity.first().copied() != Some("is") {
+        return None;
+    }
+    let even = match parity.get(1).copied()? {
+        "even" => true,
+        "odd" => false,
+        _ => return None,
+    };
+    let count = match scope {
+        ["permanent"] | ["permanents"] => {
+            crate::static_abilities::AnthemCountExpression::MatchingFilter(
+                crate::target::ObjectFilter::permanent(),
+            )
+        }
+        _ => return None,
+    };
+    Some(PredicateAst::CountParity {
+        count,
+        even,
+        display: Some(format!(
+            "the number of {} is {}",
+            scope.join(" "),
+            if even { "even" } else { "odd" }
+        )),
+    })
+}
+
 fn parse_player_cards_in_hand_relation_predicate(words: &[&str]) -> Option<PredicateAst> {
     let tokens = crate::runtime_backend::lexer::synthetic_word_tokens(words);
     let relation =
@@ -5838,6 +5872,10 @@ pub(crate) fn parse_predicate(tokens: &[OwnedLexToken]) -> Result<PredicateAst, 
     }
 
     if let Some(predicate) = parse_player_life_relation_predicate(&filtered) {
+        return Ok(predicate);
+    }
+
+    if let Some(predicate) = parse_count_parity_predicate(&filtered) {
         return Ok(predicate);
     }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
@@ -407,6 +407,15 @@ pub(crate) fn compile_condition_from_predicate_ast(
             let player = resolve_non_target_player_filter(*player, &refs)?;
             Condition::PlayerHasMoreLifeThanEachOtherPlayer { player }
         }
+        PredicateAst::CountParity {
+            count,
+            even,
+            display,
+        } => Condition::CountParity {
+            count: count.clone(),
+            even: *even,
+            display: display.clone(),
+        },
         PredicateAst::PlayerIsMonarch { player } => {
             let player = resolve_non_target_player_filter(*player, &refs)?;
             Condition::PlayerIsMonarch { player }

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -472,6 +472,11 @@ pub(crate) enum PredicateAst {
     PlayerHasMoreLifeThanEachOtherPlayer {
         player: PlayerAst,
     },
+    CountParity {
+        count: crate::static_abilities::AnthemCountExpression,
+        even: bool,
+        display: Option<String>,
+    },
     PlayerIsMonarch {
         player: PlayerAst,
     },

--- a/crates/ironsmith-core/src/static_ability_id.rs
+++ b/crates/ironsmith-core/src/static_ability_id.rs
@@ -75,6 +75,7 @@ pub enum StaticAbilityId {
     CantBeBlockedByMoreThan,
     CantBeBlockedExceptByNOrMore,
     CanAttackAsThoughNoDefender,
+    CanAttackAsThoughHaste,
     MustAttack,
     GoadedBySourceController,
     MustAttackAttachedController,
@@ -343,6 +344,7 @@ impl StaticAbilityId {
             | CantBeBlockedByMoreThan
             | CantBeBlockedExceptByNOrMore
             | CanAttackAsThoughNoDefender
+            | CanAttackAsThoughHaste
             | MustAttack
             | GoadedBySourceController
             | MustAttackAttachedController
@@ -655,6 +657,7 @@ impl StaticAbilityId {
                 | CantBeBlockedAsLongAsDefendingPlayerControlsCardType
                 | CantBeBlockedAsLongAsDefendingPlayerControlsCardTypes
                 | CanAttackAsThoughNoDefender
+                | CanAttackAsThoughHaste
                 | MustAttack
                 | MustBlock
                 | CantAttack

--- a/crates/ironsmith-core/src/static_ability_model.rs
+++ b/crates/ironsmith-core/src/static_ability_model.rs
@@ -2042,6 +2042,13 @@ impl<
         )
     }
 
+    pub fn can_attack_as_though_haste() -> Self {
+        Self::identified(
+            StaticAbilityId::CanAttackAsThoughHaste,
+            "can attack as though haste",
+        )
+    }
+
     pub fn set_colors(filter: ObjectFilter, colors: ColorSet) -> Self {
         Self {
             id: Some(StaticAbilityId::SetColors),

--- a/crates/ironsmith-core/src/value_model.rs
+++ b/crates/ironsmith-core/src/value_model.rs
@@ -893,6 +893,11 @@ pub enum Condition {
         comparison: Comparison,
         display: Option<String>,
     },
+    CountParity {
+        count: AnthemCountExpression,
+        even: bool,
+        display: Option<String>,
+    },
     OwnsCardExiledWithCounter(CounterType),
     SourceAttackedThisTurn,
     SourceCameUnderYourControlThisTurn,

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -65248,6 +65248,40 @@ fn parse_wild_dogs_keeps_unique_life_leader_upkeep_trigger() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn chaos_lord_parses_even_permanent_control_trigger_and_haste_as_though_text() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(2_614), "Chaos Lord")
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![crate::types::Subtype::Human])
+        .power_toughness(PowerToughness::fixed(7, 7))
+        .parse_text(
+            "First strike\nAt the beginning of your upkeep, target opponent gains control of this creature if the number of permanents is even.\nThis creature can attack as though it had haste unless it entered this turn.",
+        )
+        .expect("Chaos Lord should parse strictly");
+
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+    assert!(
+        rendered.contains("First strike")
+            && rendered.contains(
+                "At the beginning of your upkeep, if the number of permanents is even, target opponent gains control of this creature."
+            )
+            && rendered.contains(
+                "This creature can attack as though it had haste unless it entered this turn."
+            ),
+        "expected Chaos Lord to render its even-permanent control trigger and as-though attack clause, got {rendered}"
+    );
+
+    let debug = format!("{:?}", def.abilities);
+    assert!(
+        debug.contains("CountParity")
+            && debug.contains("ChangeControllerToPlayer")
+            && debug.contains("CanAttackAsThoughHaste")
+            && debug.contains("ObjectEnteredBattlefieldThisTurn"),
+        "expected Chaos Lord to lower parity and haste-unless-entered structurally, got {debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_lulu_loyal_hollyphant_keeps_revolt_gate_and_untap_followup() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Lulu, Loyal Hollyphant")
         .card_types(vec![CardType::Creature])

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -9721,6 +9721,23 @@ pub(super) fn describe_apply_continuous_effect(
     if let Some(text) = describe_apply_continuous_animation_effect(effect, &target, plural_target) {
         return Some(text);
     }
+    if matches!(effect.target, crate::continuous::EffectTarget::Source)
+        && effect.additional_modifications.is_empty()
+        && effect.runtime_modifications.is_empty()
+        && matches!(effect.until, Until::Forever)
+        && let Some(crate::continuous::Modification::AddAbility(ability)) = &effect.modification
+        && ability.id() == crate::static_abilities::StaticAbilityId::CanAttackAsThoughHaste
+        && let Some(Condition::Not(inner)) = &effect.condition
+        && matches!(
+            inner.as_ref(),
+            Condition::ObjectEnteredBattlefieldThisTurn(filter) if *filter == ObjectFilter::source()
+        )
+    {
+        return Some(
+            "This creature can attack as though it had haste unless it entered this turn"
+                .to_string(),
+        );
+    }
     if effect.modification.is_none()
         && effect.additional_modifications.is_empty()
         && matches!(
@@ -12550,6 +12567,10 @@ pub(super) fn describe_condition(condition: &Condition) -> String {
             .as_ref()
             .map(|s| s.to_string())
             .unwrap_or_else(|| "count comparison".to_string()),
+        Condition::CountParity { display, even, .. } => display
+            .as_ref()
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| format!("count is {}", if *even { "even" } else { "odd" })),
         Condition::ValueComparison {
             left,
             operator,

--- a/crates/ironsmith-runtime/src/condition_eval.rs
+++ b/crates/ironsmith-runtime/src/condition_eval.rs
@@ -1294,6 +1294,7 @@ fn assert_condition_variant_coverage(condition: &Condition) {
         Condition::EquippedCreatureAttacking => {}
         Condition::SourceChosenOption(..) => {}
         Condition::CountComparison { .. } => {}
+        Condition::CountParity { .. } => {}
         Condition::OwnsCardExiledWithCounter(..) => {}
         Condition::SourceAttackedThisTurn => {}
         Condition::SourceCameUnderYourControlThisTurn => {}
@@ -2014,6 +2015,15 @@ pub fn evaluate_condition_external(
             ctx.source,
             ctx.controller,
         )),
+        Condition::CountParity { count, even, .. } => {
+            let value = crate::static_abilities::resolve_anthem_count_expression(
+                count,
+                game,
+                ctx.source,
+                ctx.controller,
+            );
+            value % 2 == if *even { 0 } else { 1 }
+        }
         Condition::OwnsCardExiledWithCounter(counter) => game.exile.iter().any(|&id| {
             game.object(id).is_some_and(|obj| {
                 obj.owner == ctx.controller && obj.counters.get(counter).copied().unwrap_or(0) > 0
@@ -2807,6 +2817,7 @@ fn evaluate_condition_simple(
         | Condition::EquippedCreatureAttacking
         | Condition::SourceChosenOption(_)
         | Condition::CountComparison { .. }
+        | Condition::CountParity { .. }
         | Condition::OwnsCardExiledWithCounter(_)
         | Condition::SourceAttackedThisTurn
         | Condition::SourceDealtCombatDamageToPlayerThisTurn
@@ -3951,6 +3962,15 @@ fn evaluate_condition(
                 ctx.controller,
             )),
         ),
+        Condition::CountParity { count, even, .. } => {
+            let value = crate::static_abilities::resolve_anthem_count_expression(
+                count,
+                game,
+                ctx.source,
+                ctx.controller,
+            );
+            Ok(value % 2 == if *even { 0 } else { 1 })
+        }
         Condition::ValueComparison {
             left,
             operator,

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -11988,6 +11988,178 @@ fn wild_dogs_upkeep_trigger_hands_control_to_the_life_leader() {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn chaos_lord_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(2_614), "Chaos Lord")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(4)],
+            vec![ManaSymbol::Red],
+            vec![ManaSymbol::Red],
+            vec![ManaSymbol::Red],
+        ]))
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![crate::types::Subtype::Human])
+        .power_toughness(PowerToughness::fixed(7, 7))
+        .parse_text(
+            "First strike\nAt the beginning of your upkeep, target opponent gains control of this creature if the number of permanents is even.\nThis creature can attack as though it had haste unless it entered this turn.",
+        )
+        .expect("Chaos Lord should parse for runtime tests")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn chaos_lord_filler_permanent_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(2_615), "Chaos Lord Count Filler")
+        .card_types(vec![CardType::Artifact])
+        .build()
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn chaos_lord_tap_ability_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(2_616), "Chaos Lord Tap Test")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .parse_text(
+            "This creature can attack as though it had haste unless it entered this turn.\n{T}: Add {R}.",
+        )
+        .expect("tap-test creature should parse")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn queue_chaos_lord_upkeep_trigger(game: &mut GameState) -> TriggerQueue {
+    let alice = PlayerId::from_index(0);
+    game.turn.phase = Phase::Beginning;
+    game.turn.step = Some(crate::game_state::Step::Upkeep);
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+
+    let mut trigger_queue = TriggerQueue::new();
+    generate_and_queue_step_triggers(game, &mut trigger_queue);
+    assert_eq!(
+        trigger_queue.entries.len(),
+        1,
+        "Chaos Lord should trigger at the beginning of its controller's upkeep"
+    );
+    trigger_queue
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn chaos_lord_upkeep_trigger_gives_target_opponent_control_when_permanent_count_is_even() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let chaos_lord = chaos_lord_definition();
+    let filler = chaos_lord_filler_permanent_definition();
+    let chaos_lord_id = game.create_object_from_definition(&chaos_lord, alice, Zone::Battlefield);
+    game.create_object_from_definition(&filler, alice, Zone::Battlefield);
+
+    let mut trigger_queue = queue_chaos_lord_upkeep_trigger(&mut game);
+    let mut dm = SelectFirstDecisionMaker;
+    put_triggers_on_stack_with_dm(&mut game, &mut trigger_queue, &mut dm)
+        .expect("Chaos Lord upkeep trigger should go on the stack with target opponent");
+    resolve_stack_entry(&mut game).expect("Chaos Lord upkeep trigger should resolve");
+
+    assert_eq!(
+        game.current_controller(chaos_lord_id),
+        Some(bob),
+        "target opponent should gain control when the number of permanents is even"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn chaos_lord_upkeep_trigger_does_not_queue_when_permanent_count_is_odd() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let chaos_lord = chaos_lord_definition();
+    game.create_object_from_definition(&chaos_lord, alice, Zone::Battlefield);
+
+    game.turn.phase = Phase::Beginning;
+    game.turn.step = Some(crate::game_state::Step::Upkeep);
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+
+    let mut trigger_queue = TriggerQueue::new();
+    generate_and_queue_step_triggers(&mut game, &mut trigger_queue);
+    assert!(
+        trigger_queue.entries.is_empty(),
+        "Chaos Lord's parity gate should prevent the upkeep trigger when the number of permanents is odd"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn chaos_lord_can_attack_as_though_hasty_only_if_it_did_not_enter_this_turn() {
+    let mut old_permanent_game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let chaos_lord = chaos_lord_definition();
+    let old_chaos_lord =
+        old_permanent_game.create_object_from_definition(&chaos_lord, alice, Zone::Battlefield);
+    old_permanent_game.set_summoning_sick(old_chaos_lord);
+    assert!(
+        crate::rules::combat::can_attack(
+            old_permanent_game
+                .object(old_chaos_lord)
+                .expect("old Chaos Lord exists"),
+            &old_permanent_game,
+        ),
+        "Chaos Lord should attack as though it had haste when it is summoning sick but did not enter this turn"
+    );
+
+    let mut entered_this_turn_game = setup_game();
+    let chaos_lord_in_hand =
+        entered_this_turn_game.create_object_from_definition(&chaos_lord, alice, Zone::Hand);
+    let entered_chaos_lord = entered_this_turn_game
+        .move_object_by_effect(chaos_lord_in_hand, Zone::Battlefield)
+        .expect("Chaos Lord should enter the battlefield");
+    assert!(
+        !crate::rules::combat::can_attack(
+            entered_this_turn_game
+                .object(entered_chaos_lord)
+                .expect("entered Chaos Lord exists"),
+            &entered_this_turn_game,
+        ),
+        "Chaos Lord should not get the as-though-haste attack permission if it entered this turn"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn chaos_lord_attack_as_haste_clause_does_not_grant_haste_for_tap_abilities() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let tap_creature = chaos_lord_tap_ability_definition();
+    let tap_creature_id =
+        game.create_object_from_definition(&tap_creature, alice, Zone::Battlefield);
+    game.set_summoning_sick(tap_creature_id);
+
+    assert!(
+        crate::rules::combat::can_attack(
+            game.object(tap_creature_id)
+                .expect("old tap-test creature exists"),
+            &game,
+        ),
+        "the as-though-haste clause should grant attack-only permission"
+    );
+    assert!(
+        !game.object_has_static_ability_id(
+            tap_creature_id,
+            crate::static_abilities::StaticAbilityId::Haste,
+        ),
+        "the as-though-haste attack permission must not become the Haste keyword"
+    );
+    assert!(
+        !crate::decision::compute_legal_actions(&game, alice)
+            .iter()
+            .any(|action| matches!(
+                action,
+                crate::decision::LegalAction::ActivateManaAbility { source, .. }
+                    if *source == tap_creature_id
+            )),
+        "summoning-sick tap ability should remain illegal without true haste"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 fn touch_of_the_eternal_definition() -> crate::cards::CardDefinition {
     CardDefinitionBuilder::new(CardId::from_raw(278_197), "Touch of the Eternal")
         .mana_cost(ManaCost::from_pips(vec![

--- a/crates/ironsmith-runtime/src/rules/combat.rs
+++ b/crates/ironsmith-runtime/src/rules/combat.rs
@@ -537,6 +537,8 @@ pub(crate) fn can_attack_with_view(
     // Summoning sickness prevents attacking (unless haste)
     if game.is_summoning_sick(creature.id)
         && !view.object_has_static_ability_id(creature.id, StaticAbilityId::Haste)
+        && !view
+            .object_has_static_ability_id(creature.id, StaticAbilityId::CanAttackAsThoughHaste)
     {
         return false;
     }

--- a/crates/ironsmith-runtime/src/static_abilities/combat.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/combat.rs
@@ -731,6 +731,13 @@ define_combat_ability!(
     "Can attack as though it didn't have defender"
 );
 
+// Can attack as though it had haste. This is attack-only, not the haste keyword.
+define_combat_ability!(
+    CanAttackAsThoughHaste,
+    CanAttackAsThoughHaste,
+    "Can attack as though it had haste"
+);
+
 /// Must attack each combat if able.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct MustAttack;

--- a/crates/ironsmith-runtime/src/static_abilities/compiler_model.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/compiler_model.rs
@@ -105,6 +105,7 @@ impl StaticAbility {
             Some(StaticAbilityId::CanAttackAsThoughNoDefender) => {
                 Self::can_attack_as_though_no_defender()
             }
+            Some(StaticAbilityId::CanAttackAsThoughHaste) => Self::can_attack_as_though_haste(),
             Some(StaticAbilityId::MayAssignDamageAsUnblocked) => {
                 Self::may_assign_damage_as_unblocked()
             }

--- a/crates/ironsmith-runtime/src/static_abilities/continuous.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/continuous.rs
@@ -2188,6 +2188,10 @@ impl GrantAbility {
         self.condition = Some(condition);
         self
     }
+
+    fn applies_to_source(&self) -> bool {
+        self.source_only || self.filter == ObjectFilter::source()
+    }
 }
 
 impl PartialEq for GrantAbility {
@@ -2205,11 +2209,25 @@ impl StaticAbilityKind for GrantAbility {
     }
 
     fn display(&self) -> String {
-        let subject = if self.source_only {
+        let applies_to_source = self.applies_to_source();
+        let subject = if applies_to_source {
             "this creature".to_string()
         } else {
             grant_subject_text(&self.filter)
         };
+        if applies_to_source
+            && self.ability.id() == StaticAbilityId::CanAttackAsThoughHaste
+            && let Some(crate::ConditionExpr::Not(inner)) = &self.condition
+            && matches!(
+                inner.as_ref(),
+                crate::ConditionExpr::ObjectEnteredBattlefieldThisTurn(filter)
+                    if *filter == ObjectFilter::source()
+            )
+        {
+            return format!(
+                "{subject} can attack as though it had haste unless it entered this turn"
+            );
+        }
         let raw_ability_text = self.ability.display();
         let mut ability_text = raw_ability_text.clone();
         if matches!(
@@ -2232,7 +2250,7 @@ impl StaticAbilityKind for GrantAbility {
             }
         };
         if let Some(condition) = &self.condition {
-            if self.source_only
+            if applies_to_source
                 && self.ability.is_keyword()
                 && leading_source_keyword_condition(condition)
             {
@@ -2263,6 +2281,8 @@ impl StaticAbilityKind for GrantAbility {
     ) -> Vec<ContinuousEffect> {
         let target = if self.source_only {
             EffectTarget::Source
+        } else if self.filter == ObjectFilter::source() {
+            EffectTarget::Source
         } else {
             effect_target_for_filter(source, &self.filter)
         };
@@ -2279,7 +2299,7 @@ impl StaticAbilityKind for GrantAbility {
     }
 
     fn apply_restrictions(&self, game: &mut GameState, _source: ObjectId, controller: PlayerId) {
-        if self.source_only {
+        if self.applies_to_source() {
             self.ability.apply_restrictions(game, _source, controller);
             return;
         }

--- a/crates/ironsmith-runtime/src/static_abilities/mod.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/mod.rs
@@ -2058,6 +2058,10 @@ impl StaticAbility {
         Self::new(CanAttackAsThoughNoDefender)
     }
 
+    pub fn can_attack_as_though_haste() -> Self {
+        Self::new(CanAttackAsThoughHaste)
+    }
+
     pub fn doesnt_untap() -> Self {
         Self::new(DoesntUntap)
     }


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Chaos Lord
Initial parse error:
```
unsupported conditional gain-control clause (clause: 'control of this creature if the number of permanents is even'); oracle-only fallback also failed: unsupported conditional gain-control clause (clause: 'control of this creature if the number of permanents is even')
```

Current worker: i-0acb8027347e765e3
Branch: codex/aws-card-fix-chaos-lord
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260604T121212Z-controller-dev-loop-wave0019
