### PR TITLE
Fix Ironsmith parse failure: Jasmine Dragon Tea Shop

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/abilities.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/abilities.rs
@@ -774,10 +774,78 @@ pub(crate) fn is_spend_mana_restriction_sentence_lexed(tokens: &[OwnedLexToken])
 pub(crate) fn parse_mana_usage_restriction_sentence_lexed(
     tokens: &[OwnedLexToken],
 ) -> Option<ManaUsageRestriction> {
-    parse_legacy_mana_usage_restriction_sentence_lexed(tokens)
+    parse_cast_or_activate_source_mana_usage_restriction_sentence_lexed(tokens)
+        .or_else(|| parse_legacy_mana_usage_restriction_sentence_lexed(tokens))
         .or_else(|| parse_activate_ability_mana_usage_restriction_sentence_lexed(tokens))
         .or_else(|| parse_cant_be_spent_to_cast_sentence_lexed(tokens))
         .or_else(|| parse_filter_mana_usage_restriction_sentence_lexed(tokens))
+}
+
+fn parse_cast_or_activate_source_mana_usage_restriction_sentence_lexed(
+    tokens: &[OwnedLexToken],
+) -> Option<ManaUsageRestriction> {
+    const OR_ACTIVATE_ABILITY_OF_PHRASES: &[&[&str]] = &[
+        &["or", "activate", "an", "ability", "of"],
+        &["or", "activate", "abilities", "of"],
+    ];
+    const CAST_OR_ACTIVATE_SOURCE_PATTERN: LexPattern<'static> = LexPattern::new(&[
+        LexPattern::any_phrase(SPEND_MANA_CAST_PREFIXES),
+        LexPattern::object(
+            "spell_spec",
+            LexCaptureKind::UntilAnyPhrase(OR_ACTIVATE_ABILITY_OF_PHRASES),
+        ),
+        LexPattern::any_phrase(OR_ACTIVATE_ABILITY_OF_PHRASES),
+        LexPattern::object("source_spec", LexCaptureKind::OneOrMoreWords),
+    ]);
+
+    let clause = LexedClause::new(tokens);
+    let matched = CAST_OR_ACTIVATE_SOURCE_PATTERN.match_clause(clause)?;
+    let spell_clause = matched.capture_clause("spell_spec", clause)?;
+    let source_clause = matched.capture_clause("source_spec", clause)?;
+    let spell_tokens = trim_lexed_commas(spell_clause.tokens());
+    let source_tokens = trim_lexed_commas(source_clause.tokens());
+    let spell_filter = parse_mana_usage_spell_filter_tokens(spell_tokens)?;
+    let ability_source_filter = parse_mana_usage_ability_source_filter_tokens(source_tokens)?;
+
+    Some(ManaUsageRestriction::CastSpellOrActivateAbilitySourceMatching {
+        spell_filter,
+        ability_source_filter,
+    })
+}
+
+fn parse_mana_usage_spell_filter_tokens(tokens: &[OwnedLexToken]) -> Option<ObjectFilter> {
+    parse_special_mana_usage_spell_filter_tokens(tokens)
+        .or_else(|| parse_simple_subtype_spell_filter_tokens(tokens))
+        .or_else(|| {
+            let filter = parse_spell_filter_with_grammar_entrypoint(tokens);
+            (filter != ObjectFilter::default()).then_some(filter)
+        })
+}
+
+fn parse_simple_subtype_spell_filter_tokens(tokens: &[OwnedLexToken]) -> Option<ObjectFilter> {
+    let tokens = strip_mana_usage_spell_filter_article_tokens(trim_lexed_commas(tokens));
+    let words = LexedClause::new(tokens).word_refs();
+    let [subtype_word, spell_word] = words.as_slice() else {
+        return None;
+    };
+    if !matches!(*spell_word, "spell" | "spells") {
+        return None;
+    }
+    let subtype = parse_subtype_flexible(subtype_word)?;
+    Some(ObjectFilter::default().with_subtype(subtype))
+}
+
+fn parse_mana_usage_ability_source_filter_tokens(tokens: &[OwnedLexToken]) -> Option<ObjectFilter> {
+    let tokens = strip_mana_usage_spell_filter_article_tokens(trim_lexed_commas(tokens));
+    let words = LexedClause::new(tokens).word_refs();
+    let [subtype_word, source_word] = words.as_slice() else {
+        return None;
+    };
+    if !matches!(*source_word, "source" | "sources") {
+        return None;
+    }
+    let subtype = parse_subtype_flexible(subtype_word)?;
+    Some(ObjectFilter::default().with_subtype(subtype))
 }
 
 fn parse_cant_be_spent_to_cast_sentence_lexed(

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -2610,6 +2610,26 @@ fn rewrite_activate_ability_mana_restriction_parses() {
 }
 
 #[test]
+fn rewrite_cast_or_activate_source_mana_restriction_parses() {
+    let tokens = lex_line(
+        "Spend this mana only to cast an Ally spell or activate an ability of an Ally source.",
+        0,
+    )
+    .expect("rewrite lexer should classify cast-or-activate mana restriction");
+
+    match parse_mana_usage_restriction_sentence_lexed(&tokens) {
+        Some(crate::ability::ManaUsageRestriction::CastSpellOrActivateAbilitySourceMatching {
+            spell_filter,
+            ability_source_filter,
+        }) => {
+            assert_eq!(spell_filter.subtypes, vec![Subtype::Ally]);
+            assert_eq!(ability_source_filter.subtypes, vec![Subtype::Ally]);
+        }
+        other => panic!("expected cast-or-activate Ally restriction, got {other:?}"),
+    }
+}
+
+#[test]
 fn rewrite_cant_be_spent_mana_restriction_parses_as_positive_filter() {
     let tokens = lex_line("This mana can't be spent to cast nonartifact spells.", 0)
         .expect("rewrite lexer should classify negative mana restriction");

--- a/crates/ironsmith-core/src/ability_model.rs
+++ b/crates/ironsmith-core/src/ability_model.rs
@@ -38,6 +38,10 @@ pub enum ManaUsageRestriction {
         enters_with_counters: Vec<(crate::CounterType, u32)>,
         granted_abilities: Vec<StaticAbilityId>,
     },
+    CastSpellOrActivateAbilitySourceMatching {
+        spell_filter: ObjectFilter,
+        ability_source_filter: ObjectFilter,
+    },
     ActivateAbility,
 }
 

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -56570,6 +56570,136 @@ fn james_wandering_dad_follow_him_models_activate_only_mana_usage_restriction() 
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn jasmine_dragon_tea_shop_strict_parser_compiled_text_and_model_regression() {
+    assert_oracle_card_parses_strict("Jasmine Dragon Tea Shop");
+    let def = parse_oracle_card_definition("Jasmine Dragon Tea Shop");
+    let rendered = canonical_compiled_lines(&def).join(" ");
+    let rendered_lower = rendered.to_ascii_lowercase();
+
+    assert!(
+        rendered_lower.contains(
+            "spend this mana only to cast an ally spell or activate an ability of an ally source",
+        ),
+        "expected Jasmine Dragon Tea Shop compiled text to preserve cast-or-activate spend restriction, got {rendered}"
+    );
+
+    let mana_activated = def
+        .abilities
+        .iter()
+        .find_map(|ability| {
+            let AbilityKind::Activated(activated) = &ability.kind else {
+                return None;
+            };
+            activated
+                .mana_usage_restrictions
+                .iter()
+                .any(|restriction| {
+                    matches!(
+                        restriction,
+                        crate::ability::ManaUsageRestriction::CastSpellOrActivateAbilitySourceMatching {
+                            ..
+                        }
+                    )
+                })
+                .then_some(activated)
+        })
+        .expect("Jasmine Dragon Tea Shop should have restricted Ally mana ability");
+
+    let has_ally_cast_or_ability_restriction = mana_activated
+        .mana_usage_restrictions
+        .iter()
+        .any(|restriction| {
+            matches!(
+                restriction,
+                crate::ability::ManaUsageRestriction::CastSpellOrActivateAbilitySourceMatching {
+                    spell_filter,
+                    ability_source_filter,
+                } if spell_filter.subtypes == vec![Subtype::Ally]
+                    && ability_source_filter.subtypes == vec![Subtype::Ally]
+            )
+        });
+    assert!(
+        has_ally_cast_or_ability_restriction,
+        "Jasmine Dragon Tea Shop mana should be restricted to Ally spells or Ally-source abilities"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn jasmine_dragon_tea_shop_token_activation_creates_white_ally() {
+    let def = parse_oracle_card_definition("Jasmine Dragon Tea Shop");
+    let token_activated = def
+        .abilities
+        .iter()
+        .find_map(|ability| {
+            let AbilityKind::Activated(activated) = &ability.kind else {
+                return None;
+            };
+            activated
+                .effects
+                .iter()
+                .any(|effect| effect.downcast_ref::<CreateTokenEffect>().is_some())
+                .then_some(activated)
+        })
+        .expect("Jasmine Dragon Tea Shop should have a token-creating activated ability");
+
+    let alice = PlayerId::from_index(0);
+    let mut game = crate::game_state::GameState::new(vec!["Alice".to_string()], 20);
+    let tea_shop_id = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    game.player_mut(alice)
+        .expect("alice exists")
+        .mana_pool
+        .add(ManaSymbol::Colorless, 5);
+
+    let mut dm = crate::decision::SelectFirstDecisionMaker;
+    crate::special_actions::pay_total_cost_with_choice(
+        &mut game,
+        alice,
+        tea_shop_id,
+        &token_activated.mana_cost,
+        crate::costs::PaymentReason::ActivateAbility,
+        &mut dm,
+    )
+    .expect("Jasmine Dragon Tea Shop token activation cost should be payable");
+    assert!(
+        game.is_tapped(tea_shop_id),
+        "Jasmine Dragon Tea Shop should tap to pay its token activation cost"
+    );
+
+    let mut ctx = crate::effects::ExecutionContext::new(tea_shop_id, alice, &mut dm);
+    crate::game_loop::execute_resolution_program(
+        &mut game,
+        &mut ctx,
+        alice,
+        tea_shop_id,
+        &token_activated.effects,
+        None,
+        &[],
+    )
+    .expect("Jasmine Dragon Tea Shop token activation should resolve");
+
+    let ally_tokens: Vec<_> = game
+        .battlefield
+        .iter()
+        .filter_map(|&id| game.object(id).map(|object| (id, object)))
+        .filter(|(_, object)| {
+            matches!(object.kind, crate::object::ObjectKind::Token)
+                && object.subtypes.contains(&Subtype::Ally)
+                && game.controller_of(*object) == alice
+        })
+        .collect();
+    assert_eq!(ally_tokens.len(), 1, "expected one Ally token");
+    let (token_id, token) = ally_tokens[0];
+    assert!(
+        token.colors().contains(Color::White),
+        "Jasmine Dragon Tea Shop should create a white Ally token"
+    );
+    assert_eq!(game.current_power(token_id), Some(1));
+    assert_eq!(game.current_toughness(token_id), Some(1));
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn throne_of_eldraine_strict_parser_and_compiled_text_regression() {
     assert_oracle_card_parses_strict("Throne of Eldraine");
     let def = parse_oracle_card_definition("Throne of Eldraine");

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -38950,6 +38950,17 @@ fn describe_mana_usage_restriction(
             line.push_str(&bonuses.join(" and "));
             Some(line)
         }
+        crate::ability::ManaUsageRestriction::CastSpellOrActivateAbilitySourceMatching {
+            spell_filter,
+            ability_source_filter,
+        } => {
+            let spell_text =
+                describe_mana_usage_spell_filter_target_with_options(spell_filter, false)?;
+            let source_text = describe_mana_usage_ability_source_filter(ability_source_filter)?;
+            Some(format!(
+                "Spend this mana only to cast {spell_text} or activate an ability of {source_text}"
+            ))
+        }
         crate::ability::ManaUsageRestriction::ActivateAbility => {
             Some("Spend this mana only to activate abilities".to_string())
         }
@@ -39034,6 +39045,46 @@ fn describe_mana_usage_spell_filter_target_with_options(
         "a"
     };
     Some(format!("{article} {described}"))
+}
+
+fn describe_mana_usage_ability_source_filter(filter: &ObjectFilter) -> Option<String> {
+    let mut remainder = filter.clone();
+    remainder.card_types.clear();
+    remainder.subtypes.clear();
+    remainder.supertypes.clear();
+    if remainder != ObjectFilter::default() {
+        return None;
+    }
+
+    let mut descriptors = Vec::new();
+    descriptors.extend(
+        filter
+            .supertypes
+            .iter()
+            .map(|supertype| supertype.to_string()),
+    );
+    descriptors.extend(
+        filter
+            .card_types
+            .iter()
+            .map(|card_type| card_type.name().to_string()),
+    );
+    descriptors.extend(filter.subtypes.iter().map(|subtype| subtype.to_string()));
+
+    if descriptors.is_empty() {
+        return Some("a source".to_string());
+    }
+
+    let described = join_with_or(&descriptors);
+    let article = if matches!(
+        described.chars().next().map(|ch| ch.to_ascii_lowercase()),
+        Some('a' | 'e' | 'i' | 'o' | 'u')
+    ) {
+        "an"
+    } else {
+        "a"
+    };
+    Some(format!("{article} {described} source"))
 }
 
 fn describe_special_mana_usage_spell_filter_target(

--- a/crates/ironsmith-runtime/src/game_loop/priority_mana.rs
+++ b/crates/ironsmith-runtime/src/game_loop/priority_mana.rs
@@ -686,6 +686,29 @@ fn cast_spell_filter_matches_payment_source(
     filter.matches(source_obj, &filter_ctx, game)
 }
 
+fn activate_ability_source_filter_matches_payment_source(
+    game: &GameState,
+    unit: &crate::ability::RestrictedManaUnit,
+    filter: &crate::target::ObjectFilter,
+    payment_source: Option<ObjectId>,
+) -> bool {
+    let Some(source_id) = payment_source else {
+        return false;
+    };
+    let Some(source_obj) = game.object(source_id) else {
+        return false;
+    };
+    if source_obj.zone == Zone::Stack {
+        return false;
+    }
+
+    let Some(mana_source) = game.object(unit.source) else {
+        return false;
+    };
+    let filter_ctx = game.filter_context_for(game.controller_of(mana_source), Some(unit.source));
+    filter.matches(source_obj, &filter_ctx, game)
+}
+
 fn restriction_requires_matching_spell(restriction: &crate::ability::ManaUsageRestriction) -> bool {
     match restriction {
         crate::ability::ManaUsageRestriction::CastSpell {
@@ -696,6 +719,9 @@ fn restriction_requires_matching_spell(restriction: &crate::ability::ManaUsageRe
             restrict_to_matching_spell,
             ..
         } => *restrict_to_matching_spell,
+        crate::ability::ManaUsageRestriction::CastSpellOrActivateAbilitySourceMatching {
+            ..
+        } => true,
         crate::ability::ManaUsageRestriction::ActivateAbility => true,
     }
 }
@@ -744,6 +770,9 @@ fn restriction_bonus_applies_to_payment_source(
             }
             cast_spell_filter_matches_payment_source(game, unit, filter, payment_source)
         }
+        crate::ability::ManaUsageRestriction::CastSpellOrActivateAbilitySourceMatching {
+            ..
+        } => false,
         crate::ability::ManaUsageRestriction::ActivateAbility => false,
     }
 }
@@ -808,6 +837,18 @@ pub(super) fn payment_source_matches_restriction(
                 return true;
             }
             cast_spell_filter_matches_payment_source(game, unit, filter, Some(source_obj.id))
+        }
+        crate::ability::ManaUsageRestriction::CastSpellOrActivateAbilitySourceMatching {
+            spell_filter,
+            ability_source_filter,
+        } => {
+            cast_spell_filter_matches_payment_source(game, unit, spell_filter, Some(source_obj.id))
+                || activate_ability_source_filter_matches_payment_source(
+                    game,
+                    unit,
+                    ability_source_filter,
+                    Some(source_obj.id),
+                )
         }
         crate::ability::ManaUsageRestriction::ActivateAbility => source_obj.zone != Zone::Stack,
     }
@@ -948,6 +989,9 @@ pub(super) fn apply_spent_mana_bonuses(
                 enters_with_counters,
                 granted_abilities,
             ),
+            crate::ability::ManaUsageRestriction::CastSpellOrActivateAbilitySourceMatching {
+                ..
+            } => continue,
             crate::ability::ManaUsageRestriction::ActivateAbility => continue,
         };
 
@@ -4449,6 +4493,45 @@ mod priority_mana_tests {
             .expect("Arena-style mana ability should parse")
     }
 
+    fn jasmine_dragon_tea_shop_definition() -> crate::cards::CardDefinition {
+        CardDefinitionBuilder::new(CardId::new(), "Jasmine Dragon Tea Shop")
+            .card_types(vec![CardType::Land])
+            .parse_text(
+                "{T}: Add {C}.\n\
+                 {T}: Add one mana of any color. Spend this mana only to cast an Ally spell or activate an ability of an Ally source.\n\
+                 {5}, {T}: Create a 1/1 white Ally creature token.",
+            )
+            .expect("Jasmine Dragon Tea Shop should parse")
+    }
+
+    fn jasmine_dragon_tea_shop_restricted_mana_game() -> (GameState, PlayerId, ObjectId) {
+        let mut game = setup_game();
+        let alice = PlayerId::from_index(0);
+        let tea_shop = jasmine_dragon_tea_shop_definition();
+        let tea_shop_id = game.create_object_from_definition(&tea_shop, alice, Zone::Battlefield);
+        let restriction = game
+            .object(tea_shop_id)
+            .expect("Jasmine Dragon Tea Shop should exist")
+            .abilities
+            .iter()
+            .find_map(|ability| {
+                let AbilityKind::Activated(activated) = &ability.kind else {
+                    return None;
+                };
+                activated.mana_usage_restrictions.first().cloned()
+            })
+            .expect("Jasmine Dragon Tea Shop should have restricted mana");
+        game.player_mut(alice)
+            .expect("alice should exist")
+            .add_restricted_mana(RestrictedManaUnit {
+                symbol: ManaSymbol::Green,
+                source: tea_shop_id,
+                source_chosen_creature_type: None,
+                restrictions: vec![restriction],
+            });
+        (game, alice, tea_shop_id)
+    }
+
     fn restricted_mana_ability_index(game: &GameState, source: ObjectId) -> usize {
         game.object(source)
             .expect("source should exist")
@@ -4807,6 +4890,60 @@ mod priority_mana_tests {
         assert!(
             spend_pool_symbol(&mut game, alice, ManaSymbol::Colorless, Some(spell_id)).is_none(),
             "James restricted mana should not be spendable to cast spells"
+        );
+    }
+
+    #[test]
+    fn jasmine_dragon_tea_shop_restricted_mana_pays_only_ally_spells_or_ally_source_abilities() {
+        let (mut game, alice, _) = jasmine_dragon_tea_shop_restricted_mana_game();
+        let ally_spell = CardDefinitionBuilder::new(CardId::new(), "Ally Spell")
+            .card_types(vec![CardType::Creature])
+            .subtypes(vec![Subtype::Ally])
+            .build();
+        let ally_spell_id = game.create_object_from_definition(&ally_spell, alice, Zone::Stack);
+        assert!(
+            spend_pool_symbol(&mut game, alice, ManaSymbol::Green, Some(ally_spell_id)).is_some(),
+            "Jasmine Dragon Tea Shop restricted mana should pay for Ally spells"
+        );
+
+        let (mut game, alice, _) = jasmine_dragon_tea_shop_restricted_mana_game();
+        let non_ally_spell = CardDefinitionBuilder::new(CardId::new(), "Non-Ally Spell")
+            .card_types(vec![CardType::Creature])
+            .subtypes(vec![Subtype::Elf])
+            .build();
+        let non_ally_spell_id =
+            game.create_object_from_definition(&non_ally_spell, alice, Zone::Stack);
+        assert!(
+            spend_pool_symbol(&mut game, alice, ManaSymbol::Green, Some(non_ally_spell_id))
+                .is_none(),
+            "Jasmine Dragon Tea Shop restricted mana should reject non-Ally spells"
+        );
+
+        let (mut game, alice, _) = jasmine_dragon_tea_shop_restricted_mana_game();
+        let ally_source = CardDefinitionBuilder::new(CardId::new(), "Ally Ability Source")
+            .card_types(vec![CardType::Creature])
+            .subtypes(vec![Subtype::Ally])
+            .parse_text("{1}: You gain 1 life.")
+            .expect("Ally ability source should parse");
+        let ally_source_id =
+            game.create_object_from_definition(&ally_source, alice, Zone::Battlefield);
+        assert!(
+            spend_pool_symbol(&mut game, alice, ManaSymbol::Green, Some(ally_source_id)).is_some(),
+            "Jasmine Dragon Tea Shop restricted mana should pay for abilities of Ally sources"
+        );
+
+        let (mut game, alice, _) = jasmine_dragon_tea_shop_restricted_mana_game();
+        let non_ally_source = CardDefinitionBuilder::new(CardId::new(), "Non-Ally Ability Source")
+            .card_types(vec![CardType::Creature])
+            .subtypes(vec![Subtype::Elf])
+            .parse_text("{1}: You gain 1 life.")
+            .expect("non-Ally ability source should parse");
+        let non_ally_source_id =
+            game.create_object_from_definition(&non_ally_source, alice, Zone::Battlefield);
+        assert!(
+            spend_pool_symbol(&mut game, alice, ManaSymbol::Green, Some(non_ally_source_id))
+                .is_none(),
+            "Jasmine Dragon Tea Shop restricted mana should reject abilities of non-Ally sources"
         );
     }
 


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Jasmine Dragon Tea Shop
Initial parse error:
```
compiled text dropped required semantic marker: spend-this-mana-only
```

Current worker: i-0d9310435d67b899d
Branch: codex/aws-card-fix-jasmine-dragon-tea-shop
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260604T121212Z-controller-dev-loop-wave0019
