### PR TITLE
Fix Ironsmith parse failure: Rayne, Academy Chancellor

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/trigger_clause_core.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/trigger_clause_core.rs
@@ -1470,6 +1470,24 @@ pub(crate) fn parse_trigger_clause_lexed(
         filter
     }
 
+    fn parse_you_or_controlled_object_subject(
+        subject_words: &[&str],
+    ) -> Option<(PlayerFilter, ObjectFilter)> {
+        let tail = subject_words.strip_prefix(&["you", "or"])?;
+        let tail = non_article_word_refs(tail);
+        let object_kind = tail.strip_suffix(&["you", "control"])?;
+        let filter = match object_kind {
+            ["permanent"] | ["permanents"] => ObjectFilter::permanent(),
+            ["creature"] | ["creatures"] => ObjectFilter::creature(),
+            ["artifact"] | ["artifacts"] => ObjectFilter::artifact(),
+            ["enchantment"] | ["enchantments"] => ObjectFilter::enchantment(),
+            ["land"] | ["lands"] => ObjectFilter::land(),
+            ["planeswalker"] | ["planeswalkers"] => ObjectFilter::planeswalker(),
+            _ => return None,
+        };
+        Some((PlayerFilter::You, filter.you_control()))
+    }
+
     fn parse_damage_by_dies_trigger_lexed(
         subject_tokens: &[OwnedLexToken],
         other: bool,
@@ -3319,6 +3337,16 @@ pub(crate) fn parse_trigger_clause_lexed(
         } else {
             let tail_word_start = becomes_idx + 4;
             let tail_words = &words[tail_word_start..];
+            if let Some(source_controller) = parse_spell_or_ability_controller_tail(tail_words)
+                && let Some((player, object)) =
+                    parse_you_or_controlled_object_subject(subject_words)
+            {
+                return Ok(TriggerSpec::PlayerOrObjectBecomesTargetedBySourceController {
+                    player,
+                    object,
+                    source_controller,
+                });
+            }
             if let Some(source_controller) = parse_spell_or_ability_controller_tail(tail_words)
                 && let Some(filter) = subject_filter.clone()
             {

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/mod.rs
@@ -1196,21 +1196,33 @@ fn normalize_named_source_trigger_for_builder(
         {
             return None;
         }
-        let rewritten_head =
-            normalize_named_source_trigger_head_for_builder(builder, trigger_head.as_str())?;
+        let mut changed = false;
+        let rewritten_head = if let Some(rewritten_head) =
+            normalize_named_source_trigger_head_for_builder(builder, trigger_head.as_str())
+        {
+            changed = true;
+            rewritten_head
+        } else {
+            trigger_head
+        };
         let names = source_name_aliases_for_builder(builder);
         let mut rewritten_body = effect_body;
         if !names.is_empty() && !mentions_named_reference(rewritten_body.as_str()) {
             let subject = named_source_subject_for_builder(builder);
             for name_lower in &names {
-                if text_contains_control_of_alias(rewritten_body.as_str(), name_lower.as_str()) {
-                    rewritten_body = replace_named_source_aliases_for_trigger_normalization(
-                        &rewritten_body,
-                        name_lower,
-                        subject,
-                    );
+                let next_body = replace_named_source_aliases_for_trigger_normalization(
+                    &rewritten_body,
+                    name_lower,
+                    subject,
+                );
+                if next_body != rewritten_body {
+                    changed = true;
                 }
+                rewritten_body = next_body;
             }
+        }
+        if !changed {
+            return None;
         }
         return Some(format!("{rewritten_head}, {rewritten_body}"));
     }
@@ -1377,24 +1389,6 @@ fn split_first_comma_lexed(text: &str) -> Option<(String, String)> {
         .trim_start()
         .to_string();
     (!head.is_empty() && !body.is_empty()).then_some((head, body))
-}
-
-fn text_contains_control_of_alias(text: &str, alias: &str) -> bool {
-    let Some(alias_words) = lexed_word_strings(alias) else {
-        return false;
-    };
-    if alias_words.is_empty() {
-        return false;
-    }
-    let Ok(tokens) = lex_line(text, 0) else {
-        return false;
-    };
-    let mut phrase = Vec::with_capacity(alias_words.len() + 2);
-    phrase.extend(["control", "of"]);
-    phrase.extend(alias_words.iter().map(String::as_str));
-    TokenWordView::new(&tokens)
-        .find_phrase_start(phrase.as_slice())
-        .is_some()
 }
 
 fn mentions_named_reference(text: &str) -> bool {
@@ -2629,6 +2623,23 @@ mod tests {
                 && rewritten.contains("if they do, you draw that many cards")
                 && rewritten.contains("lose that much life"),
             "expected source-name rewrite to normalize the whole triggered line, got {rewritten}"
+        );
+    }
+
+    #[test]
+    fn named_source_rewrite_covers_trigger_body_when_head_needs_no_rewrite() {
+        let builder = CardDefinitionBuilder::new(CardId::from_raw(1), "Rayne, Academy Chancellor")
+            .card_types(vec![CardType::Creature]);
+
+        let rewritten = normalize_named_source_trigger_for_builder(
+            &builder,
+            "Whenever a permanent you control becomes the target of a spell or ability an opponent controls, you may draw a card. You may draw an additional card if Rayne is enchanted.",
+        )
+        .expect("expected body-only named source rewrite to apply");
+
+        assert!(
+            rewritten.contains("you may draw an additional card if this creature is enchanted"),
+            "expected source name in trigger body condition to normalize, got {rewritten}"
         );
     }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
@@ -826,10 +826,18 @@ fn parse_source_crewed_by_exactly_predicate(
 
 fn parse_source_bare_state_shape(tokens: &[OwnedLexToken]) -> Option<PredicateAst> {
     let clause = LexedClause::new(tokens);
-    let state_phrases: &[&[&str]] = &[&["tapped"], &["untapped"]];
+    let state_phrases: &[&[&str]] = &[
+        &["enchanted"],
+        &["equipped"],
+        &["tapped"],
+        &["untapped"],
+    ];
     let atoms = [
         LexPattern::subject("subject", LexCaptureKind::UntilAnyPhrase(state_phrases)),
-        LexPattern::object("state", LexCaptureKind::OneOf(&["tapped", "untapped"])),
+        LexPattern::object(
+            "state",
+            LexCaptureKind::OneOf(&["enchanted", "equipped", "tapped", "untapped"]),
+        ),
     ];
     let matched = LexPattern::new(&atoms).match_clause(clause)?;
     let subject_clause = matched.capture_clause_by_role(LexCaptureRole::Subject, clause)?;
@@ -847,11 +855,17 @@ fn parse_source_copula_state_shape(tokens: &[OwnedLexToken]) -> Option<Predicate
         LexPattern::subject("subject", LexCaptureKind::UntilAnyPhrase(copula_phrases)),
         LexPattern::action(
             "copula",
-            LexCaptureKind::UntilAnyPhrase(&[&["tapped"], &["untapped"], &["saddled"]]),
+            LexCaptureKind::UntilAnyPhrase(&[
+                &["enchanted"],
+                &["equipped"],
+                &["tapped"],
+                &["untapped"],
+                &["saddled"],
+            ]),
         ),
         LexPattern::object(
             "state",
-            LexCaptureKind::OneOf(&["tapped", "untapped", "saddled"]),
+            LexCaptureKind::OneOf(&["enchanted", "equipped", "tapped", "untapped", "saddled"]),
         ),
     ];
     let matched = LexPattern::new(&atoms).match_clause(clause)?;
@@ -895,6 +909,20 @@ fn source_state_predicate_from_clause(
             Some(PredicateAst::SourceIsTapped)
         } else {
             Some(PredicateAst::Not(Box::new(PredicateAst::SourceIsTapped)))
+        };
+    }
+    if clause_matches_phrase(clause, &["equipped"]) {
+        return if negative {
+            Some(PredicateAst::Not(Box::new(PredicateAst::SourceIsEquipped)))
+        } else {
+            Some(PredicateAst::SourceIsEquipped)
+        };
+    }
+    if clause_matches_phrase(clause, &["enchanted"]) {
+        return if negative {
+            Some(PredicateAst::Not(Box::new(PredicateAst::SourceIsEnchanted)))
+        } else {
+            Some(PredicateAst::SourceIsEnchanted)
         };
     }
     if clause_matches_phrase(clause, &["saddled"]) {
@@ -6960,6 +6988,14 @@ mod tests {
             (
                 "If this creature is untapped",
                 PredicateAst::Not(Box::new(PredicateAst::SourceIsTapped)),
+            ),
+            (
+                "If this creature is enchanted",
+                PredicateAst::SourceIsEnchanted,
+            ),
+            (
+                "If this creature isn't equipped",
+                PredicateAst::Not(Box::new(PredicateAst::SourceIsEquipped)),
             ),
             (
                 "If this permanent is saddled",

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
@@ -563,6 +563,8 @@ pub(crate) fn compile_condition_from_predicate_ast(
             Condition::ObjectPutIntoGraveyardFromBattlefieldThisTurn(filter.clone())
         }
         PredicateAst::SourceIsTapped => Condition::SourceIsTapped,
+        PredicateAst::SourceIsEquipped => Condition::SourceIsEquipped,
+        PredicateAst::SourceIsEnchanted => Condition::SourceIsEnchanted,
         PredicateAst::SourceIsSaddled => Condition::SourceIsSaddled,
         PredicateAst::SourceCrewedByExactly { count, filter } => Condition::SourceCrewedByExactly {
             count: *count,

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/trigger_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/trigger_support.rs
@@ -103,6 +103,15 @@ pub(crate) fn compile_trigger_spec(trigger: TriggerSpec) -> Trigger {
             target,
             source_controller,
         } => Trigger::becomes_targeted_by_source_controller(target, source_controller),
+        TriggerSpec::PlayerOrObjectBecomesTargetedBySourceController {
+            player,
+            object,
+            source_controller,
+        } => Trigger::player_or_object_becomes_targeted_by_source_controller(
+            player,
+            object,
+            source_controller,
+        ),
         TriggerSpec::ThisDealsDamage => Trigger::this_deals_damage(),
         TriggerSpec::ThisDealsDamageToPlayer { player, amount } => {
             Trigger::this_deals_damage_to_player(player, amount)

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -165,6 +165,11 @@ pub(crate) enum TriggerSpec {
         target: ObjectFilter,
         source_controller: PlayerFilter,
     },
+    PlayerOrObjectBecomesTargetedBySourceController {
+        player: PlayerFilter,
+        object: ObjectFilter,
+        source_controller: PlayerFilter,
+    },
     ThisDealsDamage,
     ThisDealsDamageToPlayer {
         player: PlayerFilter,
@@ -554,6 +559,8 @@ pub(crate) enum PredicateAst {
         player: PlayerAst,
     },
     SourceIsTapped,
+    SourceIsEquipped,
+    SourceIsEnchanted,
     SourceIsSaddled,
     SourceCrewedByExactly {
         count: u32,
@@ -641,6 +648,8 @@ impl PredicateAst {
         match self {
             PredicateAst::SourceChosenOption(_)
             | PredicateAst::SourceIsTapped
+            | PredicateAst::SourceIsEquipped
+            | PredicateAst::SourceIsEnchanted
             | PredicateAst::SourceIsSaddled
             | PredicateAst::SourceCrewedByExactly { .. }
             | PredicateAst::SourceMatches(_)

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/chain_carry.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/chain_carry.rs
@@ -540,6 +540,43 @@ pub(crate) fn parse_effect_chain_lexed(
     let starts_with_each_player =
         grammar::words_match_any_prefix(tokens, EACH_PLAYER_PREFIXES).is_some();
 
+    if let Some(trailing_if) = split_trailing_if_clause_lexed(tokens) {
+        if let Some(player) = parse_leading_player_may_lexed(trailing_if.leading_tokens) {
+            let mut stripped = remove_through_first_word(trailing_if.leading_tokens, "may");
+            if stripped
+                .first()
+                .is_some_and(|token| CHAIN_HAVE_OR_HAS_WORD_PATTERN.matches_token(token))
+            {
+                stripped.remove(0);
+            }
+            if CHAIN_CHOOSE_TO_PREFIX_PATTERN.matches_words(&token_word_refs(&stripped)) {
+                stripped = remove_through_first_word_tokens(&stripped, "to");
+            }
+            let mut effects = parse_effect_chain_lexed(&stripped)?;
+            for effect in &mut effects {
+                bind_implicit_player_context(effect, player);
+            }
+            return Ok(vec![EffectAst::Conditional {
+                predicate: trailing_if.predicate,
+                if_true: vec![EffectAst::MayByPlayer { player, effects }],
+                if_false: Vec::new(),
+            }]);
+        }
+
+        if token_slice_first_is(trailing_if.leading_tokens, "may")
+            && !starts_with_each_opponent
+            && !starts_with_each_player
+        {
+            let stripped = remove_first_word(trailing_if.leading_tokens, "may");
+            let effects = parse_effect_chain_lexed(&stripped)?;
+            return Ok(vec![EffectAst::Conditional {
+                predicate: trailing_if.predicate,
+                if_true: vec![EffectAst::May { effects }],
+                if_false: Vec::new(),
+            }]);
+        }
+    }
+
     if let Some(player) = parse_leading_player_may_lexed(tokens) {
         let mut stripped = remove_through_first_word(tokens, "may");
         if stripped

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -10887,6 +10887,31 @@ fn rewrite_lexed_conditional_parser_routes_commaless_clause_through_structure_sp
 }
 
 #[test]
+fn rewrite_lexed_leading_may_trailing_if_keeps_condition_outside_permission() {
+    let text = "You may draw an additional card if this is enchanted.";
+    let lexed = lex_line(text, 0).expect("rewrite lexer should classify may-if draw sentence");
+
+    let parsed = super::clause_support::parse_effect_sentences_lexed(&lexed)
+        .expect("may-if draw sentence should parse");
+
+    match parsed.as_slice() {
+        [crate::cards::builders::EffectAst::Conditional {
+            predicate,
+            if_true,
+            if_false,
+        }] => {
+            assert!(matches!(predicate, crate::cards::builders::PredicateAst::SourceIsEnchanted));
+            assert!(if_false.is_empty());
+            assert!(matches!(
+                if_true.as_slice(),
+                [crate::cards::builders::EffectAst::MayByPlayer { .. }]
+            ));
+        }
+        other => panic!("expected conditional may draw, got {other:?}"),
+    }
+}
+
+#[test]
 fn rewrite_lexed_conditional_parser_keeps_if_you_dont_result_predicate() {
     let text = "If you don't, create a Treasure token.";
     let lexed = lex_line(text, 0).expect("rewrite lexer should classify if-you-don't conditional");

--- a/crates/ironsmith-core/src/trigger_model.rs
+++ b/crates/ironsmith-core/src/trigger_model.rs
@@ -110,6 +110,11 @@ pub enum TriggerKind {
         target: ObjectFilter,
         controller: PlayerFilter,
     },
+    PlayerOrObjectBecomesTargetedBySourceController {
+        player: PlayerFilter,
+        object: ObjectFilter,
+        controller: PlayerFilter,
+    },
     ThisDealsDamage,
     ThisDealsDamageToPlayer {
         player: PlayerFilter,
@@ -594,6 +599,31 @@ impl Trigger {
         Self::typed(
             "becomes_targeted_by_source_controller",
             TriggerKind::BecomesTargetedBySourceController { target, controller },
+        )
+    }
+    pub fn player_or_object_becomes_targeted_by_source_controller(
+        player: PlayerFilter,
+        object: ObjectFilter,
+        controller: PlayerFilter,
+    ) -> Self {
+        let controller_text = match controller {
+            PlayerFilter::You => "you",
+            PlayerFilter::Opponent => "an opponent",
+            PlayerFilter::Any => "a player",
+            _ => "a player",
+        };
+        Self::typed(
+            format!(
+                "Whenever {} or {} becomes the target of a spell or ability {} controls",
+                crate::filter_model::describe_player_filter(&player),
+                object.description(),
+                controller_text
+            ),
+            TriggerKind::PlayerOrObjectBecomesTargetedBySourceController {
+                player,
+                object,
+                controller,
+            },
         )
     }
     pub fn this_deals_damage() -> Self {

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -164,6 +164,144 @@ fn kodama_of_the_center_tree_strict_parser_compiled_text_and_model_regression() 
 }
 
 #[test]
+fn rayne_academy_chancellor_strict_parser_and_compiled_text_regression() {
+    assert_oracle_card_parses_strict("Rayne, Academy Chancellor");
+
+    let def = parse_oracle_card_definition("Rayne, Academy Chancellor");
+    let rendered = compiled_text_lines(&def).join(" ");
+    let abilities_debug = format!("{:#?}", def.abilities);
+
+    assert!(
+        rendered.contains(
+            "Whenever you or a permanent you control becomes the target of a spell or ability an opponent controls, you may draw a card"
+        ),
+        "expected Rayne's player-or-permanent opponent-controlled targeting trigger to render, got {rendered}"
+    );
+    assert!(
+        rendered.contains("You may draw an additional card if this creature is enchanted"),
+        "expected Rayne's enchanted additional-draw clause to render, got {rendered}"
+    );
+    assert!(
+        abilities_debug.contains("SourceIsEnchanted") && abilities_debug.contains("MayEffect"),
+        "expected Rayne's additional draw to be a conditional optional effect, got {abilities_debug}"
+    );
+}
+
+#[test]
+fn rayne_academy_chancellor_targeting_trigger_draws_conditionally_at_runtime() {
+    struct AcceptMayDecisionMaker;
+    impl crate::decision::DecisionMaker for AcceptMayDecisionMaker {
+        fn decide_boolean(
+            &mut self,
+            _game: &crate::game_state::GameState,
+            _ctx: &crate::decisions::context::BooleanContext,
+        ) -> bool {
+            true
+        }
+    }
+
+    fn alice_hand_count(game: &crate::game_state::GameState, alice: PlayerId) -> usize {
+        game.objects_in_zone(Zone::Hand)
+            .into_iter()
+            .filter_map(|id| game.object(id))
+            .filter(|object| game.controller_of(object) == alice)
+            .count()
+    }
+
+    fn resolve_rayne_targeting_trigger(
+        enchanted: bool,
+        target_player: bool,
+        source_controller: PlayerId,
+    ) -> (usize, usize) {
+        let def = parse_oracle_card_definition("Rayne, Academy Chancellor");
+        let mut game = crate::tests::test_helpers::setup_two_player_game();
+        let alice = PlayerId::from_index(0);
+        let rayne = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+
+        for idx in 0..2 {
+            let draw_card = CardDefinitionBuilder::new(CardId::new(), format!("Rayne Draw {idx}"))
+                .card_types(vec![CardType::Creature])
+                .build();
+            game.create_object_from_definition(&draw_card, alice, Zone::Library);
+        }
+
+        if enchanted {
+            let aura = CardDefinitionBuilder::new(CardId::new(), "Rayne Test Aura")
+                .card_types(vec![CardType::Enchantment])
+                .subtypes(vec![Subtype::Aura])
+                .build();
+            let aura_id = game.create_object_from_definition(&aura, alice, Zone::Battlefield);
+            game.object_mut(aura_id)
+                .expect("Rayne test Aura should exist")
+                .attached_to = Some(crate::object::AttachmentTarget::Object(rayne));
+            game.object_mut(rayne)
+                .expect("Rayne should exist")
+                .attachments
+                .push(aura_id);
+        }
+
+        let spell = CardDefinitionBuilder::new(CardId::new(), "Rayne Targeting Spell")
+            .card_types(vec![CardType::Instant])
+            .build();
+        let spell_id = game.create_object_from_definition(&spell, source_controller, Zone::Stack);
+        let target = if target_player {
+            crate::game_state::Target::Player(alice)
+        } else {
+            crate::game_state::Target::Object(rayne)
+        };
+        let event = crate::triggers::TriggerEvent::new_with_provenance(
+            crate::events::spells::BecomesTargetedEvent::new_target(
+                target,
+                spell_id,
+                source_controller,
+                false,
+            ),
+            crate::provenance::ProvNodeId::default(),
+        );
+
+        let triggers = crate::triggers::check_triggers(&game, &event);
+        let matching_count = triggers.iter().filter(|entry| entry.source == rayne).count();
+        let mut trigger_queue = crate::triggers::TriggerQueue::new();
+        for trigger in triggers.into_iter().filter(|entry| entry.source == rayne) {
+            trigger_queue.add(trigger);
+        }
+        if matching_count > 0 {
+            let mut dm = AcceptMayDecisionMaker;
+            crate::game_loop::put_triggers_on_stack_with_dm(&mut game, &mut trigger_queue, &mut dm)
+                .expect("Rayne trigger should go on the stack");
+            crate::game_loop::resolve_stack_entry_with(&mut game, &mut dm)
+                .expect("Rayne trigger should resolve");
+        }
+
+        (matching_count, alice_hand_count(&game, alice))
+    }
+
+    let bob = PlayerId::from_index(1);
+    let alice = PlayerId::from_index(0);
+
+    assert_eq!(
+        resolve_rayne_targeting_trigger(false, false, bob),
+        (1, 1),
+        "Rayne should draw one card when unenchanted and targeted by an opponent's source"
+    );
+    assert_eq!(
+        resolve_rayne_targeting_trigger(true, false, bob),
+        (1, 2),
+        "Rayne should draw the additional optional card while enchanted"
+    );
+    assert_eq!(
+        resolve_rayne_targeting_trigger(false, true, bob),
+        (1, 1),
+        "Rayne should draw when its controller becomes targeted by an opponent's source"
+    );
+    assert_eq!(
+        resolve_rayne_targeting_trigger(true, false, alice),
+        (0, 0),
+        "Rayne should not trigger from a source its controller controls"
+    );
+}
+
+#[test]
 fn rampaging_aetherhood_strict_parser_and_compiled_text_regression() {
     let def = parse_oracle_card_definition("Rampaging Aetherhood");
     let ability_debug = format!("{:#?}", def.abilities);

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -659,6 +659,36 @@ fn describe_copy_tagged_then_may_cast_copy(effects: &[Effect]) -> Option<String>
     Some(text)
 }
 
+fn may_draws_one_for_you(effect: &Effect) -> Option<()> {
+    let may = effect.downcast_ref::<crate::effects::MayEffect>()?;
+    if !matches!(may.decider, Some(PlayerFilter::You)) || may.effects.len() != 1 {
+        return None;
+    }
+    let draw = may.effects[0].downcast_ref::<crate::effects::DrawCardsEffect>()?;
+    (draw.player == PlayerFilter::You && draw.count == Value::Fixed(1)).then_some(())
+}
+
+fn describe_may_draw_then_source_enchanted_additional_draw(effects: &[Effect]) -> Option<String> {
+    let [first, second] = effects else {
+        return None;
+    };
+    may_draws_one_for_you(first)?;
+
+    let conditional = second.downcast_ref::<crate::effects::ConditionalEffect>()?;
+    if conditional.condition != crate::effect::Condition::SourceIsEnchanted
+        || !conditional.if_false.is_empty()
+        || conditional.if_true.len() != 1
+    {
+        return None;
+    }
+    may_draws_one_for_you(&conditional.if_true[0])?;
+
+    Some(format!(
+        "You may draw a card. You may draw an additional card if {}",
+        lowercase_first(&describe_condition(&conditional.condition))
+    ))
+}
+
 fn describe_spell_mastery_reanimation_effects(effects: &[&Effect]) -> Option<String> {
     let [move_effect, conditional_effect] = effects else {
         return None;
@@ -5577,6 +5607,9 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
         return compact;
     }
     if let Some(compact) = describe_copy_tagged_then_may_cast_copy(effects) {
+        return compact;
+    }
+    if let Some(compact) = describe_may_draw_then_source_enchanted_additional_draw(effects) {
         return compact;
     }
     if effects.len() > 2

--- a/crates/ironsmith-runtime/src/events/spells/becomes_targeted.rs
+++ b/crates/ironsmith-runtime/src/events/spells/becomes_targeted.rs
@@ -6,11 +6,11 @@ use crate::events::traits::{EventKind, GameEventType};
 use crate::game_state::{GameState, Target};
 use crate::ids::{ObjectId, PlayerId};
 
-/// A permanent became the target of a spell or ability.
+/// An object or player became the target of a spell or ability.
 #[derive(Debug, Clone)]
 pub struct BecomesTargetedEvent {
-    /// The object that became targeted.
-    pub target: ObjectId,
+    /// The object or player that became targeted.
+    pub target: Target,
     /// The spell or ability source that targeted it.
     pub source: ObjectId,
     /// The controller of the source.
@@ -20,9 +20,39 @@ pub struct BecomesTargetedEvent {
 }
 
 impl BecomesTargetedEvent {
-    /// Create a new becomes-targeted event.
+    /// Create a new object becomes-targeted event.
     pub fn new(
         target: ObjectId,
+        source: ObjectId,
+        source_controller: PlayerId,
+        by_ability: bool,
+    ) -> Self {
+        Self {
+            target: Target::Object(target),
+            source,
+            source_controller,
+            by_ability,
+        }
+    }
+
+    /// Create a new player becomes-targeted event.
+    pub fn new_player(
+        target: PlayerId,
+        source: ObjectId,
+        source_controller: PlayerId,
+        by_ability: bool,
+    ) -> Self {
+        Self {
+            target: Target::Player(target),
+            source,
+            source_controller,
+            by_ability,
+        }
+    }
+
+    /// Create a new becomes-targeted event for any target kind.
+    pub fn new_target(
+        target: Target,
         source: ObjectId,
         source_controller: PlayerId,
         by_ability: bool,
@@ -34,6 +64,20 @@ impl BecomesTargetedEvent {
             by_ability,
         }
     }
+
+    pub fn target_object(&self) -> Option<ObjectId> {
+        match self.target {
+            Target::Object(id) => Some(id),
+            Target::Player(_) => None,
+        }
+    }
+
+    pub fn target_player(&self) -> Option<PlayerId> {
+        match self.target {
+            Target::Object(_) => None,
+            Target::Player(player) => Some(player),
+        }
+    }
 }
 
 impl GameEventType for BecomesTargetedEvent {
@@ -42,20 +86,21 @@ impl GameEventType for BecomesTargetedEvent {
     }
 
     fn affected_player(&self, game: &GameState) -> PlayerId {
-        game.object(self.target)
-            .map(|o| game.controller_of(o))
-            .unwrap_or(self.source_controller)
+        match self.target {
+            Target::Object(object_id) => game
+                .object(object_id)
+                .map(|o| game.controller_of(o))
+                .unwrap_or(self.source_controller),
+            Target::Player(player) => player,
+        }
     }
 
     fn with_target_replaced(&self, old: &Target, new: &Target) -> Option<Box<dyn GameEventType>> {
-        if &Target::Object(self.target) != old {
+        if &self.target != old {
             return None;
         }
-        let Target::Object(new_target) = new else {
-            return None;
-        };
         Some(Box::new(Self {
-            target: *new_target,
+            target: *new,
             source: self.source,
             source_controller: self.source_controller,
             by_ability: self.by_ability,
@@ -75,7 +120,7 @@ impl GameEventType for BecomesTargetedEvent {
     }
 
     fn object_id(&self) -> Option<ObjectId> {
-        Some(self.target)
+        self.target_object()
     }
 
     fn player(&self) -> Option<PlayerId> {

--- a/crates/ironsmith-runtime/src/game_loop/targeting.rs
+++ b/crates/ironsmith-runtime/src/game_loop/targeting.rs
@@ -114,14 +114,11 @@ pub(super) fn target_events_from_targets(
 ) -> Vec<TriggerEvent> {
     targets
         .iter()
-        .filter_map(|target| {
-            let Target::Object(target_id) = target else {
-                return None;
-            };
-            Some(TriggerEvent::new_with_provenance(
-                BecomesTargetedEvent::new(*target_id, source, source_controller, by_ability),
+        .map(|target| {
+            TriggerEvent::new_with_provenance(
+                BecomesTargetedEvent::new_target(*target, source, source_controller, by_ability),
                 provenance,
-            ))
+            )
         })
         .collect()
 }

--- a/crates/ironsmith-runtime/src/triggers/mod.rs
+++ b/crates/ironsmith-runtime/src/triggers/mod.rs
@@ -866,6 +866,21 @@ impl Trigger {
         ))
     }
 
+    /// Create a "when [player] or [target] becomes the target of a spell or ability [player] controls" trigger.
+    pub fn player_or_object_becomes_targeted_by_source_controller(
+        player_filter: PlayerFilter,
+        object_filter: ObjectFilter,
+        source_controller: PlayerFilter,
+    ) -> Self {
+        Self::new(
+            PlayerOrObjectBecomesTargetedBySourceControllerTrigger::new(
+                player_filter,
+                object_filter,
+                source_controller,
+            ),
+        )
+    }
+
     // === Card Triggers ===
 
     /// Create a "whenever you draw a card" trigger (fires once per card drawn).

--- a/crates/ironsmith-runtime/src/triggers/model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/triggers/model_interpreter.rs
@@ -187,6 +187,13 @@ pub(crate) fn interpret_trigger_model(
         TriggerKind::BecomesTargetedBySourceController { target, controller } => {
             crate::triggers::Trigger::becomes_targeted_by_source_controller(target, controller)
         }
+        TriggerKind::PlayerOrObjectBecomesTargetedBySourceController {
+            player,
+            object,
+            controller,
+        } => crate::triggers::Trigger::player_or_object_becomes_targeted_by_source_controller(
+            player, object, controller,
+        ),
         TriggerKind::ThisDealsDamage => crate::triggers::Trigger::this_deals_damage(),
         TriggerKind::ThisDealsDamageToPlayer { player, amount } => {
             crate::triggers::Trigger::this_deals_damage_to_player(player, amount)

--- a/crates/ironsmith-runtime/src/triggers/spell_ability/becomes_targeted.rs
+++ b/crates/ironsmith-runtime/src/triggers/spell_ability/becomes_targeted.rs
@@ -16,7 +16,7 @@ impl TriggerMatcher for BecomesTargetedTrigger {
         let Some(e) = event.downcast::<BecomesTargetedEvent>() else {
             return false;
         };
-        e.target == ctx.source_id
+        e.target_object() == Some(ctx.source_id)
     }
 
     fn display(&self) -> String {

--- a/crates/ironsmith-runtime/src/triggers/spell_ability/becomes_targeted_by_source_controller.rs
+++ b/crates/ironsmith-runtime/src/triggers/spell_ability/becomes_targeted_by_source_controller.rs
@@ -14,6 +14,27 @@ pub struct BecomesTargetedBySourceControllerTrigger {
     pub source_controller: PlayerFilter,
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub struct PlayerOrObjectBecomesTargetedBySourceControllerTrigger {
+    pub player_filter: PlayerFilter,
+    pub object_filter: ObjectFilter,
+    pub source_controller: PlayerFilter,
+}
+
+impl PlayerOrObjectBecomesTargetedBySourceControllerTrigger {
+    pub fn new(
+        player_filter: PlayerFilter,
+        object_filter: ObjectFilter,
+        source_controller: PlayerFilter,
+    ) -> Self {
+        Self {
+            player_filter,
+            object_filter,
+            source_controller,
+        }
+    }
+}
+
 impl BecomesTargetedBySourceControllerTrigger {
     pub fn new(target_filter: ObjectFilter, source_controller: PlayerFilter) -> Self {
         Self {
@@ -31,7 +52,10 @@ impl TriggerMatcher for BecomesTargetedBySourceControllerTrigger {
         let Some(e) = event.downcast::<BecomesTargetedEvent>() else {
             return false;
         };
-        let Some(target) = ctx.game.object(e.target) else {
+        let Some(target_id) = e.target_object() else {
+            return false;
+        };
+        let Some(target) = ctx.game.object(target_id) else {
             return false;
         };
         if !self
@@ -54,6 +78,51 @@ impl TriggerMatcher for BecomesTargetedBySourceControllerTrigger {
         format!(
             "Whenever {} becomes the target of a spell or ability {} controls",
             self.target_filter.description(),
+            controller
+        )
+    }
+}
+
+impl TriggerMatcher for PlayerOrObjectBecomesTargetedBySourceControllerTrigger {
+    fn matches(&self, event: &TriggerEvent, ctx: &TriggerContext) -> bool {
+        if event.kind() != EventKind::BecomesTargeted {
+            return false;
+        }
+        let Some(e) = event.downcast::<BecomesTargetedEvent>() else {
+            return false;
+        };
+        if !self
+            .source_controller
+            .matches_player(e.source_controller, &ctx.filter_ctx)
+        {
+            return false;
+        }
+        if let Some(player) = e.target_player()
+            && self.player_filter.matches_player(player, &ctx.filter_ctx)
+        {
+            return true;
+        }
+        let Some(target_id) = e.target_object() else {
+            return false;
+        };
+        let Some(target) = ctx.game.object(target_id) else {
+            return false;
+        };
+        self.object_filter
+            .matches(target, &ctx.filter_ctx, ctx.game)
+    }
+
+    fn display(&self) -> String {
+        let controller = match self.source_controller {
+            PlayerFilter::You => "you",
+            PlayerFilter::Opponent => "an opponent",
+            PlayerFilter::Any => "a player",
+            _ => "a player",
+        };
+        format!(
+            "Whenever {} or {} becomes the target of a spell or ability {} controls",
+            crate::triggers::describe_player_filter_subject(&self.player_filter),
+            self.object_filter.description(),
             controller
         )
     }

--- a/crates/ironsmith-runtime/src/triggers/spell_ability/becomes_targeted_by_spell.rs
+++ b/crates/ironsmith-runtime/src/triggers/spell_ability/becomes_targeted_by_spell.rs
@@ -26,7 +26,7 @@ impl TriggerMatcher for BecomesTargetedBySpellTrigger {
         let Some(e) = event.downcast::<BecomesTargetedEvent>() else {
             return false;
         };
-        if e.target != ctx.source_id || e.by_ability {
+        if e.target_object() != Some(ctx.source_id) || e.by_ability {
             return false;
         }
         let Some(source) = ctx.game.object(e.source) else {
@@ -62,7 +62,7 @@ impl TriggerMatcher for BecomesTargetedByStackObjectTrigger {
         let Some(e) = event.downcast::<BecomesTargetedEvent>() else {
             return false;
         };
-        if e.target != ctx.source_id {
+        if e.target_object() != Some(ctx.source_id) {
             return false;
         }
         let Some(source) = ctx.game.object(e.source) else {
@@ -102,7 +102,10 @@ impl TriggerMatcher for BecomesTargetedObjectByStackObjectTrigger {
         let Some(e) = event.downcast::<BecomesTargetedEvent>() else {
             return false;
         };
-        let Some(target) = ctx.game.object(e.target) else {
+        let Some(target_id) = e.target_object() else {
+            return false;
+        };
+        let Some(target) = ctx.game.object(target_id) else {
             return false;
         };
         if !self

--- a/crates/ironsmith-runtime/src/triggers/spell_ability/becomes_targeted_object.rs
+++ b/crates/ironsmith-runtime/src/triggers/spell_ability/becomes_targeted_object.rs
@@ -26,7 +26,10 @@ impl TriggerMatcher for BecomesTargetedObjectTrigger {
         let Some(e) = event.downcast::<BecomesTargetedEvent>() else {
             return false;
         };
-        let Some(target) = ctx.game.object(e.target) else {
+        let Some(target_id) = e.target_object() else {
+            return false;
+        };
+        let Some(target) = ctx.game.object(target_id) else {
             return false;
         };
         self.filter.matches(target, &ctx.filter_ctx, ctx.game)

--- a/crates/ironsmith-runtime/src/triggers/spell_ability/mod.rs
+++ b/crates/ironsmith-runtime/src/triggers/spell_ability/mod.rs
@@ -12,7 +12,9 @@ mod you_cast_this_spell;
 
 pub use ability_activated::AbilityActivatedTrigger;
 pub use becomes_targeted::BecomesTargetedTrigger;
-pub use becomes_targeted_by_source_controller::BecomesTargetedBySourceControllerTrigger;
+pub use becomes_targeted_by_source_controller::{
+    BecomesTargetedBySourceControllerTrigger, PlayerOrObjectBecomesTargetedBySourceControllerTrigger,
+};
 pub use becomes_targeted_by_spell::{
     BecomesTargetedBySpellTrigger, BecomesTargetedByStackObjectTrigger,
     BecomesTargetedObjectByStackObjectTrigger,


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Rayne, Academy Chancellor
Initial parse error:
```
missing condition after trailing if clause; oracle-only fallback also failed: missing condition after trailing if clause
```

Current worker: i-06205fd526db406da
Branch: codex/aws-card-fix-rayne-academy-chancellor
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260604T121212Z-controller-dev-loop-wave0019
