### PR TITLE
Fix Ironsmith parse failure: Gomazoa

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_inner/sentence_shape_predicates.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_inner/sentence_shape_predicates.rs
@@ -713,6 +713,9 @@ fn parse_effect_sentence_lexed_inner(
     }
 
     let sentence_words = crate::runtime_backend::token_word_refs(tokens);
+    if let Some(effect) = parse_source_and_blocked_creatures_top_library_shuffle_sentence(tokens) {
+        return Ok(vec![effect]);
+    }
     if sentence_words.starts_with(&["at", "the", "beginning", "of"])
         && sentence_words
             .windows(3)
@@ -795,6 +798,70 @@ fn parse_effect_sentence_lexed_inner(
     apply_trailing_counter_constraint_to_destroy_all(&mut effects, tokens);
     normalize_search_followup_shuffles(&mut effects);
     Ok(effects)
+}
+
+fn source_and_creatures_blocked_by_source_words(words: &[&str]) -> bool {
+    words
+        == [
+            "this", "creature", "and", "each", "creature", "it's", "blocking",
+        ]
+}
+
+fn parse_source_and_blocked_creatures_top_library_shuffle_sentence(
+    tokens: &[OwnedLexToken],
+) -> Option<EffectAst> {
+    if !token_slice_first_is(tokens, "put") {
+        return None;
+    }
+    let (target_slice, after_on_top_of) = grammar::split_lexed_once_on_separator(&tokens[1..], || {
+        use winnow::Parser as _;
+        grammar::phrase(&["on", "top", "of"]).void()
+    })?;
+    let target_tokens = trim_commas(target_slice);
+    let target_words = crate::runtime_backend::token_word_refs(&target_tokens);
+    if !source_and_creatures_blocked_by_source_words(&target_words) {
+        return None;
+    }
+
+    let destination_words = crate::runtime_backend::token_word_refs(after_on_top_of);
+    let has_owner_library = destination_words
+        .iter()
+        .any(|word| matches!(*word, "owner" | "owners" | "owner's" | "owners'"))
+        && destination_words
+            .iter()
+            .any(|word| matches!(*word, "library" | "libraries"));
+    if !has_owner_library
+        || !word_slice_contains_phrase(
+            &destination_words,
+            &["then", "those", "players", "shuffle"],
+        )
+    {
+        return None;
+    }
+
+    let mut blocked_creature = ObjectFilter::creature();
+    blocked_creature.blocked_by_source = true;
+    let mut moved_objects = ObjectFilter::default();
+    moved_objects.any_of = vec![ObjectFilter::source(), blocked_creature];
+
+    Some(EffectAst::ForEachObject {
+        filter: moved_objects,
+        effects: vec![
+            EffectAst::subject_verb_move_to_zone(
+                TargetAst::Tagged(TagKey::from(IT_TAG), None),
+                Zone::Library,
+                true,
+                crate::cards::builders::ReturnControllerAst::Preserve,
+                false,
+                None,
+            ),
+            EffectAst::subject_verb(
+                SubjectVerbRoleAst::LibraryOwner,
+                PlayerAst::ItsOwner,
+                SubjectVerbActionAst::ShuffleLibrary,
+            ),
+        ],
+    })
 }
 
 fn parse_effect_sentence_with_where_x_lexed(

--- a/crates/ironsmith-core/src/filter_model.rs
+++ b/crates/ironsmith-core/src/filter_model.rs
@@ -411,6 +411,7 @@ pub struct ObjectFilter {
     pub nonblocking: bool,
     pub blocked: bool,
     pub blocked_by: Option<ObjectRef>,
+    pub blocked_by_source: bool,
     pub unblocked: bool,
     pub in_combat_with_source: bool,
     pub entered_since_your_last_turn_ended: bool,
@@ -1577,6 +1578,9 @@ impl ObjectFilter {
                 ObjectRef::Tagged(_) => "one of those creatures",
             };
             post_noun_qualifiers.push(format!("blocked by {blocker_text} this turn"));
+        }
+        if self.blocked_by_source {
+            post_noun_qualifiers.push("blocked by this creature this turn".to_string());
         }
         if self.tapped && self.untapped {
             parts.push("tapped/untapped".to_string());

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -23736,6 +23736,142 @@ fn parse_draw_then_put_source_on_top_of_library() {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn gomazoa_activated_ability(def: &CardDefinition) -> &crate::ability::ActivatedAbility {
+    def.abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Activated(activated) => Some(activated),
+            _ => None,
+        })
+        .expect("Gomazoa should have an activated ability")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn execute_gomazoa_ability(
+    game: &mut crate::game_state::GameState,
+    source: ObjectId,
+    controller: PlayerId,
+    activated: &crate::ability::ActivatedAbility,
+) {
+    let mut ctx = crate::effects::ExecutionContext::new_default(source, controller);
+    for effect in activated.effects.flattened_default_effects() {
+        crate::effects::execute_effect(game, effect, &mut ctx)
+            .expect("Gomazoa activated ability effect should resolve");
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn library_contains_card_name(
+    game: &crate::game_state::GameState,
+    player: PlayerId,
+    name: &str,
+) -> bool {
+    game.player(player)
+        .expect("player exists")
+        .library
+        .iter()
+        .any(|id| game.object(*id).is_some_and(|object| object.name == name))
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn parse_oracle_gomazoa_strict_and_renders_blocked_creatures_shuffle_clause() {
+    let def = parse_oracle_card_definition("Gomazoa");
+    let activated = gomazoa_activated_ability(&def);
+    assert!(activated.has_tap_cost(), "Gomazoa should keep its tap cost");
+
+    let rendered = unprocessed_compiled_lines(&def)
+        .join(" ")
+        .to_ascii_lowercase();
+    assert!(
+        rendered.contains("defender")
+            && rendered.contains("flying")
+            && rendered.contains("put this creature and each creature it's blocking on top of their owners' libraries")
+            && rendered.contains("then those players shuffle"),
+        "expected Gomazoa compiled text to preserve the blocking top-library shuffle clause, got {rendered}"
+    );
+
+    let ability_debug = format!("{activated:#?}").to_ascii_lowercase();
+    assert!(
+        ability_debug.contains("foreachobject")
+            && ability_debug.contains("blocked_by_source: true")
+            && ability_debug.contains("movetozoneeffect")
+            && ability_debug.contains("shufflelibraryeffect"),
+        "expected Gomazoa ability to structurally move source plus blocked creatures and shuffle owners, got {ability_debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn gomazoa_runtime_moves_source_and_creature_it_is_blocking_to_owners_libraries() {
+    let def = parse_oracle_card_definition("Gomazoa");
+    let activated = gomazoa_activated_ability(&def);
+    let vanilla = CardDefinitionBuilder::new(CardId::new(), "Attacking Bear")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    let mut game = crate::tests::test_helpers::setup_two_player_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let gomazoa = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let attacker = game.create_object_from_definition(&vanilla, bob, Zone::Battlefield);
+    let mut combat = crate::combat_state::CombatState::default();
+    combat.attackers.push(crate::combat_state::AttackerInfo {
+        creature: attacker,
+        target: crate::combat_state::AttackTarget::Player(alice),
+    });
+    combat.blockers.insert(attacker, vec![gomazoa]);
+    game.combat = Some(combat);
+
+    execute_gomazoa_ability(&mut game, gomazoa, alice, activated);
+
+    assert!(
+        !game.battlefield.contains(&gomazoa) && !game.battlefield.contains(&attacker),
+        "Gomazoa and the creature it blocked should leave the battlefield"
+    );
+    assert!(
+        library_contains_card_name(&game, alice, "Gomazoa")
+            && library_contains_card_name(&game, bob, "Attacking Bear"),
+        "Gomazoa and its blocked attacker should be in their owners' libraries"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn gomazoa_runtime_does_not_move_creature_blocking_it_when_source_attacks() {
+    let def = parse_oracle_card_definition("Gomazoa");
+    let activated = gomazoa_activated_ability(&def);
+    let blocker_def = CardDefinitionBuilder::new(CardId::new(), "Blocking Bear")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    let mut game = crate::tests::test_helpers::setup_two_player_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let gomazoa = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let blocker = game.create_object_from_definition(&blocker_def, bob, Zone::Battlefield);
+    let mut combat = crate::combat_state::CombatState::default();
+    combat.attackers.push(crate::combat_state::AttackerInfo {
+        creature: gomazoa,
+        target: crate::combat_state::AttackTarget::Player(bob),
+    });
+    combat.blockers.insert(gomazoa, vec![blocker]);
+    game.combat = Some(combat);
+
+    execute_gomazoa_ability(&mut game, gomazoa, alice, activated);
+
+    assert!(
+        !game.battlefield.contains(&gomazoa),
+        "Gomazoa should move itself even if it is attacking"
+    );
+    assert!(
+        game.battlefield.contains(&blocker)
+            && !library_contains_card_name(&game, bob, "Blocking Bear"),
+        "a creature blocking Gomazoa is not a creature Gomazoa is blocking"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn parse_draw_then_put_source_third_from_top() {
     let err = CardDefinitionBuilder::new(CardId::new(), "Sensei Top Third Variant")

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -3586,6 +3586,40 @@ fn describe_for_each_tagged_shuffle_into_owner_library(
     Some("Its owner shuffles it into their library".to_string())
 }
 
+fn describe_source_and_blocked_creatures_top_library_shuffle(
+    for_each: &crate::effects::ForEachObject,
+) -> Option<String> {
+    let [move_effect, shuffle_effect] = for_each.effects.as_slice() else {
+        return None;
+    };
+    let [source_filter, blocked_filter] = for_each.filter.any_of.as_slice() else {
+        return None;
+    };
+    let mut expected_blocked_filter = ObjectFilter::creature();
+    expected_blocked_filter.blocked_by_source = true;
+    if source_filter != &ObjectFilter::source() || blocked_filter != &expected_blocked_filter {
+        return None;
+    }
+    let move_to_zone = move_effect.downcast_ref::<crate::effects::MoveToZoneEffect>()?;
+    if move_to_zone.zone != Zone::Library
+        || !move_to_zone.to_top
+        || !matches!(move_to_zone.target.base(), ChooseSpec::Iterated)
+    {
+        return None;
+    }
+    let shuffle = shuffle_effect.downcast_ref::<crate::effects::ShuffleLibraryEffect>()?;
+    if !matches!(
+        &shuffle.player,
+        PlayerFilter::OwnerOf(crate::filter::ObjectRef::Tagged(tag)) if tag.as_str() == "__it__"
+    ) {
+        return None;
+    }
+    Some(
+        "Put this creature and each creature it's blocking on top of their owners' libraries, then those players shuffle"
+            .to_string(),
+    )
+}
+
 fn describe_source_owner_shuffle_then_reveal_named_to_battlefield(
     effects: &[&Effect],
 ) -> Option<String> {
@@ -31818,6 +31852,9 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
             return compact;
         }
         if let Some(compact) = describe_for_each_prevent_combat_damage_unless_pays(for_each) {
+            return compact;
+        }
+        if let Some(compact) = describe_source_and_blocked_creatures_top_library_shuffle(for_each) {
             return compact;
         }
         if for_each.effects.len() == 1

--- a/crates/ironsmith-runtime/src/filter.rs
+++ b/crates/ironsmith-runtime/src/filter.rs
@@ -2311,6 +2311,19 @@ impl ObjectFilterExt for ObjectFilter {
         {
             return false;
         }
+        if self.blocked_by_source {
+            let Some(source_id) = ctx.source else {
+                return false;
+            };
+            let Some(combat) = &game.combat else {
+                return false;
+            };
+            if !crate::combat_state::get_blocked_attacker(combat, source_id)
+                .is_some_and(|attacker| attacker == object.id)
+            {
+                return false;
+            }
+        }
         if self.in_combat_with_source {
             let Some(source_id) = ctx.source else {
                 return false;
@@ -2913,6 +2926,19 @@ impl ObjectFilterExt for ObjectFilter {
             && !creature_was_blocked_by_ref(game, ctx, snapshot.object_id, blocker_ref)
         {
             return false;
+        }
+        if self.blocked_by_source {
+            let Some(source_id) = ctx.source else {
+                return false;
+            };
+            let Some(combat) = &game.combat else {
+                return false;
+            };
+            if !crate::combat_state::get_blocked_attacker(combat, source_id)
+                .is_some_and(|attacker| attacker == snapshot.object_id)
+            {
+                return false;
+            }
         }
 
         // Power check
@@ -3535,6 +3561,9 @@ impl ObjectFilterExt for ObjectFilter {
                 ObjectRef::Tagged(_) => "one of those creatures",
             };
             post_noun_qualifiers.push(format!("blocked by {blocker_text} this turn"));
+        }
+        if self.blocked_by_source {
+            post_noun_qualifiers.push("blocked by this creature this turn".to_string());
         }
         if self.tapped && self.untapped {
             parts.push("tapped/untapped".to_string());


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Gomazoa
Initial parse error:
```
unsupported put clause (clause: 'this creature'); oracle-only fallback also failed: unsupported put clause (clause: 'this creature')
```

Current worker: i-0a015b581a4c18907
Branch: codex/aws-card-fix-gomazoa
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260604T121212Z-controller-dev-loop-wave0019
