### PR TITLE
Fix Ironsmith parse failure: Katara, Seeking Revenge

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
@@ -1527,6 +1527,10 @@ fn is_this_spell_possessive_word(word: &str) -> bool {
     )
 }
 
+fn is_paid_cost_possessive_word(word: &str) -> bool {
+    matches!(word, "its" | "his" | "her" | "their")
+}
+
 fn ordinal_number_word(word: &str) -> Option<u32> {
     ironsmith_core::parse_ordinal_word(word).or_else(|| parse_named_number(word))
 }
@@ -3359,6 +3363,9 @@ fn parse_paid_cost_label_predicate(words: &[&str]) -> Option<PredicateAst> {
     let negated = paid_cost_tail_is_negated(paid_tail)?;
     let label = match label_words.as_slice() {
         ["this", possessive, label] if is_this_spell_possessive_word(possessive) => {
+            named_paid_cost_label_from_word(label)?
+        }
+        [possessive, label] if is_paid_cost_possessive_word(possessive) => {
             named_paid_cost_label_from_word(label)?
         }
         words => mana_cost_label_from_words(words)?,

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/parser_semantic_lowering.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/parser_semantic_lowering.rs
@@ -50,6 +50,8 @@ const ADDITIONAL_LAND_PLAY_STATIC_TAIL_PATTERN: ClauseShape<'static> = clause_sh
             &["additional", "lands", "on", "each", "of", "your", "turns"],
         ]
 );
+const OPTIONAL_WATERBEND_PREFIX_PATTERN: ClauseShape<'static> =
+    clause_shape!(prefix & ["you", "may", "waterbend"]);
 const SELF_ENTERS_WITH_SINGLE_PLUS_ONE_COUNTER_PATTERN: ClauseShape<'static> = clause_shape!(
     exact_any
         & [
@@ -2305,6 +2307,9 @@ pub(crate) fn lower_keyword_special_cases(
     if let Some(chunk) = try_lower_optional_behold_additional_cost(line, parse_tokens)? {
         return Ok(Some(chunk));
     }
+    if let Some(chunk) = try_lower_optional_waterbend_additional_cost(line, parse_tokens)? {
+        return Ok(Some(chunk));
+    }
     Ok(None)
 }
 
@@ -2663,6 +2668,69 @@ pub(crate) fn try_lower_optional_behold_additional_cost(
     Ok(Some(LineAst::OptionalCost(
         OptionalCost::custom(line.info.raw_line.trim(), total_cost).into(),
     )))
+}
+
+pub(crate) fn try_lower_optional_waterbend_additional_cost(
+    line: &RewriteKeywordLine,
+    parse_tokens: &[OwnedLexToken],
+) -> Result<Option<LineAst>, CardTextError> {
+    if line.kind != RewriteKeywordLineKind::AdditionalCost {
+        return Ok(None);
+    }
+
+    let Some(effect_tokens) = additional_cost_tail_tokens(parse_tokens) else {
+        return Ok(None);
+    };
+    let stripped = trim_lexed_commas(effect_tokens);
+    let words = token_word_refs(stripped);
+    if !OPTIONAL_WATERBEND_PREFIX_PATTERN.matches_words(&words) {
+        return Ok(None);
+    }
+
+    let total_cost = parse_activation_cost(&stripped[2..])?;
+    let Some(mana_cost) = total_cost.mana_cost().cloned() else {
+        return Ok(None);
+    };
+    let generic = mana_cost.generic_mana_total();
+    if generic == 0 || mana_cost.reduce_generic(generic).pip_count() != 0 {
+        return Ok(None);
+    }
+
+    let mut branches = Vec::new();
+    for tapped in 0..=generic {
+        let mut costs = Vec::new();
+        let remaining_mana = mana_cost.reduce_generic(tapped);
+        if !remaining_mana.is_empty() {
+            costs.push(Cost::mana(remaining_mana));
+        }
+        if tapped > 0 {
+            costs.extend(waterbend_tap_costs(tapped));
+        }
+        branches.push(TotalCost::from_costs(costs));
+    }
+
+    Ok(Some(LineAst::OptionalCost(
+        OptionalCost::custom(line.info.raw_line.trim(), TotalCost::one_of(branches)).into(),
+    )))
+}
+
+fn waterbend_tap_costs(count: u32) -> Vec<Cost> {
+    let tag = format!("waterbend_cost_{count}");
+    let mut filter = ObjectFilter::default();
+    filter.controller = Some(PlayerFilter::You);
+    filter.zone = Some(Zone::Battlefield);
+    filter.untapped = true;
+    filter.any_of = vec![ObjectFilter::artifact(), ObjectFilter::creature()];
+
+    vec![
+        Cost::validated_effect(crate::effect::Effect::choose_objects(
+            filter,
+            ChoiceCount::exactly(count as usize),
+            PlayerFilter::You,
+            tag.clone(),
+        )),
+        Cost::validated_effect(crate::effect::Effect::tap(ChooseSpec::tagged(tag))),
+    ]
 }
 
 fn additional_cost_tail_tokens(tokens: &[OwnedLexToken]) -> Option<&[OwnedLexToken]> {

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sacrifice_discard.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sacrifice_discard.rs
@@ -114,6 +114,53 @@ fn trim_trailing_discard_alternative_action(tokens: &[OwnedLexToken]) -> Vec<Own
     trim_commas(tokens)
 }
 
+fn parse_trailing_discard_unless_predicate(
+    trailing_tokens: &[OwnedLexToken],
+    player: PlayerAst,
+    count: Value,
+    any_number: bool,
+    discard_filter: Option<ObjectFilter>,
+) -> Result<Option<EffectAst>, CardTextError> {
+    let trailing_tokens =
+        crate::runtime_backend::front_end::shared::util::trim_edge_punctuation_tokens(
+            trailing_tokens,
+        );
+    let Some((first, predicate_tokens)) = trailing_tokens.split_first() else {
+        return Ok(None);
+    };
+    if !SACRIFICE_UNLESS_WORD_PATTERN.matches_token(first) {
+        return Ok(None);
+    }
+
+    let predicate_tokens =
+        crate::runtime_backend::front_end::shared::util::trim_edge_punctuation_tokens(
+            predicate_tokens,
+        );
+    if predicate_tokens.is_empty() {
+        return Err(CardTextError::ParseError(
+            "missing predicate after trailing discard unless".to_string(),
+        ));
+    }
+    let predicate =
+        crate::runtime_backend::front_end::grammar::structure::parse_predicate_with_grammar_entrypoint_lexed(
+            predicate_tokens,
+        )?;
+    let discard = EffectAst::subject_verb_discard(
+        player,
+        count,
+        false,
+        any_number,
+        discard_filter,
+        None,
+    );
+
+    Ok(Some(EffectAst::Conditional {
+        predicate: PredicateAst::Not(Box::new(predicate)),
+        if_true: vec![discard],
+        if_false: Vec::new(),
+    }))
+}
+
 fn discard_value_from_choice_count(count: crate::effect::ChoiceCount) -> Option<(Value, bool)> {
     if count.is_any_number() {
         return Some((Value::Fixed(0), true));
@@ -589,6 +636,15 @@ pub(crate) fn parse_discard(
         ));
     }
     let trailing_words = crate::runtime_backend::token_word_refs(trailing_tokens);
+    if let Some(effect) = parse_trailing_discard_unless_predicate(
+        trailing_tokens,
+        player,
+        count.clone(),
+        any_number,
+        discard_filter.clone(),
+    )? {
+        return Ok(effect);
+    }
     let random = DISCARD_AT_RANDOM_PATTERN.matches_words(&trailing_words);
     if !trailing_words.is_empty() && !random {
         let trailing_filter = if let Ok(filter) = parse_object_filter(trailing_tokens, false) {

--- a/crates/ironsmith-core/src/cost_model.rs
+++ b/crates/ironsmith-core/src/cost_model.rs
@@ -860,6 +860,10 @@ impl OptionalCostsPaid {
                 && stored
                     .to_ascii_lowercase()
                     .starts_with("as an additional cost to cast this spell, you may behold "))
+            || (query.eq_ignore_ascii_case("Additional")
+                && stored
+                    .to_ascii_lowercase()
+                    .starts_with("as an additional cost to cast this spell, you may "))
     }
 
     pub fn new(num_optional_costs: usize) -> Self {

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -336,6 +336,259 @@ fn consulate_surveillance_activation_cost_requires_and_spends_two_energy() {
 }
 
 #[test]
+fn katara_seeking_revenge_strict_parser_and_compiled_text_regression() {
+    assert_oracle_card_parses_strict("Katara, Seeking Revenge");
+    let def = parse_oracle_card_definition("Katara, Seeking Revenge");
+    let rendered = unprocessed_compiled_lines(&def).join("\n");
+    let raw = format!("{def:#?}");
+
+    assert!(
+        rendered.contains("As an additional cost to cast this spell, you may waterbend {2}.")
+            && rendered.contains(
+                "When Katara enters, draw a card, then discard a card unless its additional cost was paid",
+            )
+            && rendered.contains("Katara gets +1/+1 for each Lesson card in your graveyard"),
+        "Katara, Seeking Revenge compiled text should preserve waterbend, conditional discard, and Lesson scaling, got {rendered}"
+    );
+    assert!(
+        raw.contains("ThisSpellPaidLabel")
+            && raw.contains("Additional")
+            && raw.contains("ConditionalEffect")
+            && raw.contains("DiscardEffect")
+            && raw.contains("waterbend_cost_2"),
+        "Katara, Seeking Revenge should structurally lower waterbend and unless-paid discard, got {raw}"
+    );
+}
+
+#[test]
+fn katara_seeking_revenge_waterbend_optional_cost_has_mana_and_tap_branches() {
+    let def = parse_oracle_card_definition("Katara, Seeking Revenge");
+    assert_eq!(
+        def.optional_costs.len(),
+        1,
+        "Katara should have one optional waterbend cost"
+    );
+    assert!(
+        def.optional_costs[0]
+            .label
+            .to_ascii_lowercase()
+            .contains("waterbend {2}"),
+        "Katara optional cost label should preserve waterbend, got {:?}",
+        def.optional_costs[0].label
+    );
+
+    let branches = def.optional_costs[0]
+        .cost
+        .as_one_of()
+        .expect("waterbend {2} should lower to alternative payment branches");
+    assert_eq!(
+        branches.len(),
+        3,
+        "waterbend {{2}} should have 0, 1, and 2 tap branches"
+    );
+    assert_eq!(
+        branches[0].mana_cost().map(ManaCost::to_oracle),
+        Some("{2}".to_string()),
+        "first waterbend branch should be ordinary mana"
+    );
+    assert_eq!(
+        branches[1].mana_cost().map(ManaCost::to_oracle),
+        Some("{1}".to_string()),
+        "second waterbend branch should require one remaining generic mana"
+    );
+    assert!(
+        branches[2].mana_cost().is_none(),
+        "third waterbend branch should be fully paid by tapping"
+    );
+
+    for (branch, expected_count) in [(&branches[1], 1), (&branches[2], 2)] {
+        let choose = branch
+            .costs()
+            .iter()
+            .filter_map(|cost| cost.effect_ref())
+            .find_map(|effect| effect.downcast_ref::<ChooseObjectsEffect>())
+            .expect("waterbend tap branch should choose objects to tap");
+        assert_eq!(choose.count.min, expected_count);
+        assert_eq!(choose.count.max, Some(expected_count));
+        assert!(choose.filter.untapped, "waterbend choices must be untapped");
+        assert_eq!(choose.filter.controller, Some(PlayerFilter::You));
+        assert!(
+            choose
+                .filter
+                .any_of
+                .iter()
+                .any(|filter| filter.card_types.contains(&CardType::Artifact))
+                && choose
+                    .filter
+                    .any_of
+                    .iter()
+                    .any(|filter| filter.card_types.contains(&CardType::Creature)),
+            "waterbend choices should be artifacts or creatures, got {:?}",
+            choose.filter
+        );
+    }
+}
+
+#[test]
+fn katara_seeking_revenge_waterbend_tap_cost_taps_chosen_artifact_and_creature() {
+    struct ChooseFirstLegalObjects;
+
+    impl crate::decision::DecisionMaker for ChooseFirstLegalObjects {
+        fn decide_objects(
+            &mut self,
+            _game: &crate::game_state::GameState,
+            ctx: &crate::decisions::context::SelectObjectsContext,
+        ) -> Vec<ObjectId> {
+            ctx.candidates
+                .iter()
+                .filter(|candidate| candidate.legal)
+                .map(|candidate| candidate.id)
+                .take(ctx.max.unwrap_or(ctx.min) as usize)
+                .collect()
+        }
+    }
+
+    let def = parse_oracle_card_definition("Katara, Seeking Revenge");
+    let tap_branch = &def.optional_costs[0]
+        .cost
+        .as_one_of()
+        .expect("waterbend cost should have branches")[2];
+    let mut game = crate::game_state::GameState::new(vec!["Alice".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    let source = game.create_object_from_definition(&def, alice, Zone::Stack);
+    let artifact = game.create_object_from_definition(
+        &CardDefinitionBuilder::new(CardId::new(), "Katara Waterbend Artifact")
+            .card_types(vec![CardType::Artifact])
+            .build(),
+        alice,
+        Zone::Battlefield,
+    );
+    let creature = game.create_object_from_definition(
+        &CardDefinitionBuilder::new(CardId::new(), "Katara Waterbend Creature")
+            .card_types(vec![CardType::Creature])
+            .power_toughness(PowerToughness::fixed(1, 1))
+            .build(),
+        alice,
+        Zone::Battlefield,
+    );
+
+    let mut dm = ChooseFirstLegalObjects;
+    let mut ctx = crate::costs::CostContext::new(source, alice, &mut dm);
+    for cost in tap_branch.costs() {
+        cost.pay(&mut game, &mut ctx)
+            .expect("waterbend tap cost branch should be payable");
+    }
+
+    assert!(
+        game.is_tapped(artifact),
+        "waterbend should tap the chosen artifact"
+    );
+    assert!(
+        game.is_tapped(creature),
+        "waterbend should tap the chosen creature"
+    );
+}
+
+#[test]
+fn katara_seeking_revenge_unpaid_additional_cost_discards_and_paid_cost_skips() {
+    fn hand_card(game: &mut crate::game_state::GameState, player: PlayerId, name: &str) {
+        let card = CardDefinitionBuilder::new(CardId::new(), name)
+            .card_types(vec![CardType::Instant])
+            .build();
+        game.create_object_from_definition(&card, player, Zone::Hand);
+    }
+
+    fn etb_conditional(def: &CardDefinition) -> crate::effects::ConditionalEffect {
+        def.abilities
+            .iter()
+            .find_map(|ability| match &ability.kind {
+                AbilityKind::Triggered(triggered) => triggered
+                    .effects
+                    .flattened_default_effects()
+                    .iter()
+                    .find_map(|effect| {
+                        effect
+                            .downcast_ref::<crate::effects::ConditionalEffect>()
+                            .cloned()
+                    }),
+                _ => None,
+            })
+            .expect("Katara ETB should include an unless-paid conditional discard")
+    }
+
+    let def = parse_oracle_card_definition("Katara, Seeking Revenge");
+    let conditional = etb_conditional(&def);
+
+    let mut game = crate::game_state::GameState::new(vec!["Alice".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    let katara = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    hand_card(&mut game, alice, "Katara Revenge Fodder");
+    let mut ctx = crate::effects::ExecutionContext::new_default(katara, alice);
+    conditional
+        .execute(&mut game, &mut ctx)
+        .expect("unpaid Katara discard branch should resolve");
+    assert_eq!(game.player(alice).expect("Alice exists").hand.len(), 0);
+    assert_eq!(game.player(alice).expect("Alice exists").graveyard.len(), 1);
+
+    let mut game = crate::game_state::GameState::new(vec!["Alice".to_string()], 20);
+    let katara = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    game.object_mut(katara)
+        .expect("Katara object exists")
+        .optional_costs_paid
+        .mark_label_paid(&def.optional_costs[0].label);
+    hand_card(&mut game, alice, "Katara Revenge Kept Card");
+    let mut ctx = crate::effects::ExecutionContext::new_default(katara, alice);
+    conditional
+        .execute(&mut game, &mut ctx)
+        .expect("paid Katara discard branch should resolve");
+    assert_eq!(
+        game.player(alice).expect("Alice exists").hand.len(),
+        1,
+        "paying Katara's waterbend additional cost should skip the discard"
+    );
+    assert_eq!(game.player(alice).expect("Alice exists").graveyard.len(), 0);
+}
+
+#[test]
+fn katara_seeking_revenge_counts_lesson_cards_in_its_controllers_graveyard() {
+    let oracle_text = oracle_text_by_name()
+        .get("Katara, Seeking Revenge")
+        .expect("Katara oracle text should exist")
+        .clone();
+    let def = CardDefinitionBuilder::new(CardId::new(), "Katara, Seeking Revenge")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(3, 3))
+        .parse_text(oracle_text)
+        .expect("Katara oracle text should parse for runtime P/T check");
+    let mut game = crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let katara = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let lesson = CardDefinitionBuilder::new(CardId::new(), "Katara Lesson")
+        .card_types(vec![CardType::Sorcery])
+        .subtypes(vec![Subtype::Lesson])
+        .build();
+    let non_lesson = CardDefinitionBuilder::new(CardId::new(), "Katara Non-Lesson")
+        .card_types(vec![CardType::Sorcery])
+        .build();
+
+    let chars = game
+        .calculated_characteristics(katara)
+        .expect("Katara should have calculated characteristics");
+    assert_eq!((chars.power, chars.toughness), (Some(3), Some(3)));
+
+    game.create_object_from_definition(&lesson, alice, Zone::Graveyard);
+    game.create_object_from_definition(&lesson, alice, Zone::Graveyard);
+    game.create_object_from_definition(&lesson, bob, Zone::Graveyard);
+    game.create_object_from_definition(&non_lesson, alice, Zone::Graveyard);
+
+    let chars = game
+        .calculated_characteristics(katara)
+        .expect("Katara should have calculated characteristics");
+    assert_eq!((chars.power, chars.toughness), (Some(5), Some(5)));
+}
+
+#[test]
 fn katara_waterbending_master_strict_parser_and_compiled_text_regression() {
     assert_oracle_card_parses_strict("Katara, Waterbending Master");
     let def = parse_oracle_card_definition("Katara, Waterbending Master");

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -17649,6 +17649,9 @@ fn describe_static_ability_with_subject(
     static_ability: &crate::static_abilities::StaticAbility,
     subject: &str,
 ) -> String {
+    if let Some(line) = describe_anthem_static_ability_with_subject(static_ability, subject) {
+        return line;
+    }
     if static_ability.id() == crate::static_abilities::StaticAbilityId::ChooseColorAsEnters {
         let mut line = format!("As {subject} enters, choose a color");
         if let Some(excluded) = static_ability
@@ -17769,6 +17772,56 @@ fn describe_static_ability_with_subject(
     }
 
     line
+}
+
+fn describe_anthem_static_ability_with_subject(
+    static_ability: &crate::static_abilities::StaticAbility,
+    subject: &str,
+) -> Option<String> {
+    let anthem = static_ability.anthem_payload()?;
+    if anthem.filter.is_some() || anthem.condition.is_some() {
+        return None;
+    }
+    let (
+        crate::static_abilities::AnthemValue::PerCount {
+            multiplier: power_multiplier,
+            count: power_count,
+        },
+        crate::static_abilities::AnthemValue::PerCount {
+            multiplier: toughness_multiplier,
+            count: toughness_count,
+        },
+    ) = (&anthem.power, &anthem.toughness)
+    else {
+        return None;
+    };
+    if *power_multiplier != 1 || *toughness_multiplier != 1 || power_count != toughness_count {
+        return None;
+    }
+
+    let for_each_text = match power_count {
+        crate::static_abilities::AnthemCountExpression::MatchingFilter(filter) => {
+            describe_for_each_count_filter(filter)
+        }
+        crate::static_abilities::AnthemCountExpression::BasicLandTypesAmong(filter) => {
+            describe_basic_land_types_among(filter).replace("basic land types", "basic land type")
+        }
+        crate::static_abilities::AnthemCountExpression::CreatureTypesAmong(filter) => {
+            format!(
+                "creature type among {}",
+                describe_count_filter_value_subject(filter)
+            )
+        }
+        crate::static_abilities::AnthemCountExpression::CountersOnSource(counter_type) => {
+            format!("{} counter on it", counter_type.description())
+        }
+        _ => return None,
+    };
+
+    Some(format!(
+        "{} gets +1/+1 for each {for_each_text}",
+        capitalize_first(subject)
+    ))
 }
 
 fn subject_text_uses_have(subject: &str) -> bool {
@@ -18395,6 +18448,24 @@ fn normalize_redundant_short_name_etb_surface(
     };
     if triggered_has_you_difference_draw(triggered) {
         return line;
+    }
+
+    for prefix in [
+        "When this creature enters,",
+        "When this permanent enters,",
+        "When this enters the battlefield,",
+    ] {
+        if let Some(start) = line.find(prefix)
+            && (start == 0 || line[..start].ends_with(": "))
+        {
+            let rest = &line[start + prefix.len()..];
+            if !rest
+                .to_ascii_lowercase()
+                .contains(surface.to_ascii_lowercase().as_str())
+            {
+                return format!("{}When {surface} enters,{rest}", &line[..start]);
+            }
+        }
     }
 
     let Some((start, prefix_len)) = [
@@ -35099,6 +35170,29 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
                     describe_condition(&conditional.condition)
                 );
             }
+            if let crate::effect::Condition::Not(inner) = &conditional.condition
+                && matches!(inner.as_ref(), crate::effect::Condition::ThisSpellPaidLabel(_))
+                && !true_branch.contains(". ")
+                && !true_branch.starts_with("If ")
+                && !true_branch.starts_with("When ")
+                && !true_branch.starts_with("Whenever ")
+                && !true_branch.starts_with("At ")
+            {
+                let branch = true_branch
+                    .strip_prefix("You discard ")
+                    .or_else(|| true_branch.strip_prefix("you discard "))
+                    .map(|rest| format!("discard {rest}"))
+                    .unwrap_or_else(|| true_branch.clone());
+                let condition = match inner.as_ref() {
+                    crate::effect::Condition::ThisSpellPaidLabel(label)
+                        if label.eq_ignore_ascii_case("additional") =>
+                    {
+                        "its additional cost was paid".to_string()
+                    }
+                    _ => describe_condition(inner),
+                };
+                return format!("{branch} unless {condition}");
+            }
             let condition_text = describe_condition(&conditional.condition);
             if condition_text.starts_with("the sacrificed ")
                 && !true_branch.contains(". ")
@@ -42296,6 +42390,7 @@ pub(super) fn describe_ability(
             line = normalize_ability_self_reference_surface(&line, subject);
             line = normalize_graveyard_source_return_surface(&line, ability);
             line = normalize_ability_self_reference_surface(&line, subject);
+            line = normalize_redundant_short_name_etb_surface(line, triggered, subject);
             vec![line]
         }
         AbilityKind::Activated(activated) if activated.is_mana_ability() => {
@@ -43201,7 +43296,6 @@ pub(super) fn describe_imprint_from_hand_phrase(
 
 pub(super) fn describe_optional_cost_line(cost: &crate::cost::OptionalCost) -> String {
     let label = cost.label.as_str();
-    let cost_text = describe_cost_list(cost.cost.costs());
     if label
         .to_ascii_lowercase()
         .starts_with("as an additional cost to cast this spell")
@@ -43211,6 +43305,7 @@ pub(super) fn describe_optional_cost_line(cost: &crate::cost::OptionalCost) -> S
     if label.to_ascii_lowercase().starts_with("gift ") {
         return label.trim().to_string();
     }
+    let cost_text = describe_cost_list(cost.cost.costs());
     if label == "Conspire" || label.starts_with("Conspire ") {
         let reminder_cost = cost_text
             .trim()

--- a/crates/ironsmith-runtime/src/static_abilities/mod.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/mod.rs
@@ -749,6 +749,11 @@ pub trait StaticAbilityKind: std::fmt::Debug + Send + Sync + StaticAbilityKindCl
         false
     }
 
+    /// Returns structured anthem data when this ability is backed by the core anthem model.
+    fn anthem_payload(&self) -> Option<&ironsmith_core::Anthem> {
+        None
+    }
+
     /// Returns true if this grants abilities to other permanents.
     fn grants_abilities(&self) -> bool {
         false
@@ -1580,6 +1585,10 @@ impl StaticAbility {
 
     pub fn is_anthem(&self) -> bool {
         self.0.is_anthem()
+    }
+
+    pub fn anthem_payload(&self) -> Option<&ironsmith_core::Anthem> {
+        self.0.anthem_payload()
     }
 
     pub fn grants_abilities(&self) -> bool {

--- a/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
@@ -2103,6 +2103,13 @@ impl StaticAbilityKind for StaticAbilityModelInterpreter {
         )
     }
 
+    fn anthem_payload(&self) -> Option<&ironsmith_core::Anthem> {
+        match self.payload() {
+            ironsmith_core::StaticAbilityPayload::Anthem(anthem) => Some(anthem),
+            _ => None,
+        }
+    }
+
     fn grants_abilities(&self) -> bool {
         matches!(
             self.payload(),


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Katara, Seeking Revenge
Initial parse error:
```
unsupported trailing discard clause (clause: 'a card unless her additional cost was paid'); oracle-only fallback also failed: unsupported trailing discard clause (clause: 'a card unless her additional cost was paid')
```

Current worker: i-030ac376072508843
Branch: codex/aws-card-fix-katara-seeking-revenge
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260604T121212Z-controller-dev-loop-wave0019
