### PR TITLE
Fix Ironsmith parse failure: Octavia, Living Thesis

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -7212,7 +7212,14 @@ pub(crate) fn parse_spells_cost_modifier_line(
         });
     let remaining_tokens = &amount_tokens[used..];
     let remaining_words = crate::runtime_backend::token_word_refs(remaining_tokens);
-    let Some(direction) = parse_cost_modifier_direction(&remaining_words) else {
+    let direction_words = if let Some(if_idx) = find_index(&remaining_words, |word| {
+        IF_PREFIX_PATTERN.matches_word(word)
+    }) {
+        &remaining_words[..if_idx]
+    } else {
+        &remaining_words
+    };
+    let Some(direction) = parse_cost_modifier_direction(direction_words) else {
         return Ok(None);
     };
 

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_cst_parsing.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_cst_parsing.rs
@@ -369,6 +369,9 @@ pub(super) fn parse_static_line_cst(
     if parse_if_this_spell_costs_less_to_cast_line_lexed(&lexed)?.is_some() {
         return Ok(Some(make_static(None)));
     }
+    if parse_spells_cost_modifier_line(&lexed)?.is_some() {
+        return Ok(Some(make_static(None)));
+    }
 
     if is_activate_only_once_each_turn_line_lexed(&lexed) {
         return Ok(Some(make_static(None)));
@@ -450,6 +453,10 @@ fn parse_split_static_item_count(tokens: &[OwnedLexToken]) -> Result<Option<usiz
     let mut item_count = 0usize;
     for sentence in sentences {
         if parse_if_this_spell_costs_less_to_cast_line_lexed(sentence)?.is_some() {
+            item_count += 1;
+            continue;
+        }
+        if parse_spells_cost_modifier_line(sentence)?.is_some() {
             item_count += 1;
             continue;
         }

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/mod.rs
@@ -36,7 +36,9 @@ use super::grammar::primitives as grammar;
 use super::grammar::structure::split_lexed_sentences;
 use super::ir::{RewriteSemanticDocument, RewriteSemanticItem};
 use super::keyword_registry::{parse_keyword_line_cst, rewrite_keyword_dash_parse_tokens};
-use super::keyword_static::parse_if_this_spell_costs_less_to_cast_line_lexed;
+use super::keyword_static::{
+    parse_if_this_spell_costs_less_to_cast_line_lexed, parse_spells_cost_modifier_line,
+};
 use super::leaf::{lower_activation_cost_cst, parse_activation_cost_tokens_rewrite};
 use super::lexer::{
     LexStream, OwnedLexToken, TokenKind, TokenWordPiece, TokenWordView,

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/mod.rs
@@ -99,7 +99,8 @@ use super::ir::{
     RewriteStaticLine, RewriteTriggeredLine,
 };
 use super::keyword_static::{
-    parse_if_this_spell_costs_less_to_cast_line_lexed, parse_value_binding_clause,
+    parse_if_this_spell_costs_less_to_cast_line_lexed, parse_spells_cost_modifier_line,
+    parse_value_binding_clause,
 };
 use super::lexer::{
     OwnedLexToken, TokenKind, TokenWordView, contains_token_word_sequence, lex_line,

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/parser_semantic_lowering.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/parser_semantic_lowering.rs
@@ -1647,6 +1647,12 @@ fn lower_rewrite_static_to_chunk_impl(
             chosen_option_label,
         );
     }
+    if let Some(ability) = parse_spells_cost_modifier_line(&lexed)? {
+        return wrap_chosen_option_static_chunk(
+            LineAst::StaticAbility(ability.into()),
+            chosen_option_label,
+        );
+    }
     if let Some(chunk) = lower_compound_buff_and_unblockable_static_chunk(line, parse_tokens)? {
         return wrap_chosen_option_static_chunk(chunk, chosen_option_label);
     }

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -5680,6 +5680,16 @@ fn rewrite_lexed_keyword_line_and_static_cost_probe_work_natively() {
         ),
         Ok(Some(_))
     ));
+
+    let trailing_cost_tokens = lex_line(
+        "This spell costs {8} less to cast if you have eight or more instant and/or sorcery cards in your graveyard.",
+        0,
+    )
+    .expect("rewrite lexer should classify trailing conditional this-spell cost line");
+    match super::keyword_static::parse_spells_cost_modifier_line(&trailing_cost_tokens) {
+        Ok(Some(_)) => {}
+        other => panic!("expected trailing conditional cost modifier to parse, got {other:?}"),
+    }
 }
 
 #[test]

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -34521,6 +34521,142 @@ fn shadow_of_mortality_compiled_text_keeps_life_difference_clause() {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn octavia_living_thesis_definition() -> CardDefinition {
+    let oracle = oracle_text_by_name()
+        .get("Octavia, Living Thesis")
+        .expect("Octavia, Living Thesis should exist in cards.json")
+        .clone();
+    CardDefinitionBuilder::new(CardId::from_raw(658_547), "Octavia, Living Thesis")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(8)],
+            vec![ManaSymbol::Blue],
+            vec![ManaSymbol::Blue],
+        ]))
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Elemental, Subtype::Octopus])
+        .power_toughness(PowerToughness::fixed(8, 8))
+        .parse_text(oracle)
+        .expect("Octavia, Living Thesis should parse strictly")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn create_octavia_graveyard_card(
+    game: &mut crate::game_state::GameState,
+    controller: PlayerId,
+    name: &str,
+    card_types: Vec<CardType>,
+) {
+    let card = crate::card::CardBuilder::new(CardId::new(), name)
+        .card_types(card_types)
+        .build();
+    game.create_object_from_card(&card, controller, Zone::Graveyard);
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn octavia_living_thesis_strict_parser_and_compiled_text_regression() {
+    assert_oracle_card_parses_strict("Octavia, Living Thesis");
+    let def = octavia_living_thesis_definition();
+
+    let reduction = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Static(static_ability) => static_ability.this_spell_cost_reduction(),
+            _ => None,
+        })
+        .expect("Octavia should have a this-spell cost reduction");
+    assert!(matches!(reduction.reduction, crate::effect::Value::Fixed(8)));
+    assert!(matches!(
+        &reduction.condition,
+        crate::static_abilities::ThisSpellCostCondition::YouHaveCardsOfTypesInYourGraveyardOrMore {
+            count: 8,
+            card_types,
+        } if card_types == &vec![CardType::Instant, CardType::Sorcery]
+    ));
+
+    let rendered = crate::compiled_text::compiled_text_lines(&def);
+    assert_eq!(
+        rendered.first().map(String::as_str),
+        Some(
+            "This spell costs {8} less to cast if you have 8 or more instant and/or sorcery cards in your graveyard."
+        ),
+        "Octavia compiled text should preserve the conditional instant/sorcery graveyard cost reduction, got {rendered:?}"
+    );
+    assert!(
+        rendered.iter().any(|line| line == "Ward {8}"),
+        "Octavia compiled text should preserve ward, got {rendered:?}"
+    );
+    assert!(
+        rendered.iter().any(|line| line.contains("Magecraft")
+            && line.contains("instant or sorcery spell")
+            && line.contains("base power and toughness 8/8 until end of turn")),
+        "Octavia compiled text should preserve magecraft base-8/8 effect, got {rendered:?}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn octavia_living_thesis_cost_reduction_requires_matching_cards_in_your_graveyard() {
+    let def = octavia_living_thesis_definition();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let mut game = crate::tests::test_helpers::setup_two_player_game();
+    let octavia_id = game.create_object_from_definition(&def, alice, Zone::Hand);
+
+    for idx in 0..7 {
+        create_octavia_graveyard_card(
+            &mut game,
+            alice,
+            &format!("Alice Instant {idx}"),
+            vec![CardType::Instant],
+        );
+    }
+    create_octavia_graveyard_card(
+        &mut game,
+        alice,
+        "Alice Creature",
+        vec![CardType::Creature],
+    );
+    for idx in 0..8 {
+        create_octavia_graveyard_card(
+            &mut game,
+            bob,
+            &format!("Bob Instant {idx}"),
+            vec![CardType::Instant],
+        );
+    }
+
+    let octavia = game
+        .object(octavia_id)
+        .expect("Octavia should be in Alice's hand");
+    let base_cost = octavia.mana_cost.as_ref().expect("Octavia has a mana cost");
+    assert_eq!(
+        crate::decision::calculate_effective_mana_cost(&game, alice, octavia, base_cost)
+            .to_oracle(),
+        "{8}{U}{U}",
+        "Octavia should not count nonmatching cards or an opponent's graveyard"
+    );
+
+    create_octavia_graveyard_card(
+        &mut game,
+        alice,
+        "Alice Sorcery",
+        vec![CardType::Sorcery],
+    );
+    let octavia = game
+        .object(octavia_id)
+        .expect("Octavia should still be in Alice's hand");
+    let base_cost = octavia.mana_cost.as_ref().expect("Octavia has a mana cost");
+    assert_eq!(
+        crate::decision::calculate_effective_mana_cost(&game, alice, octavia, base_cost)
+            .to_oracle(),
+        "{U}{U}",
+        "Octavia should cost {{8}} less with eight instant and/or sorcery cards in your graveyard"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn parse_this_spell_cost_reduction_counts_creature_types_with_cap() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Valiant Changeling Variant")

--- a/crates/ironsmith-runtime/src/static_abilities/cost_modifiers.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/cost_modifiers.rs
@@ -63,6 +63,20 @@ fn join_with_or(items: &[String]) -> String {
     }
 }
 
+fn join_with_and_or(items: &[String]) -> String {
+    match items.len() {
+        0 => String::new(),
+        1 => items[0].clone(),
+        2 => format!("{} and/or {}", items[0], items[1]),
+        _ => {
+            let mut out = items[..items.len() - 1].join(", ");
+            out.push_str(", and/or ");
+            out.push_str(items.last().map(String::as_str).unwrap_or_default());
+            out
+        }
+    }
+}
+
 fn strip_indefinite_article(text: &str) -> &str {
     text.strip_prefix("a ")
         .or_else(|| text.strip_prefix("an "))
@@ -1428,7 +1442,7 @@ pub fn describe_this_spell_cost_condition(condition: &ThisSpellCostCondition) ->
                 .collect::<Vec<_>>();
             Some(format!(
                 "you have {count} or more {} cards in your graveyard",
-                join_with_and(&type_text)
+                join_with_and_or(&type_text)
             ))
         }
         ThisSpellCostCondition::OnlyCreatureCardsInHandNamed(name) => Some(format!(


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Octavia, Living Thesis
Initial parse error:
```
parser does not yet support line family: 'This spell costs {8} less to cast if you have eight or more instant and/or sorcery cards in your graveyard.'; oracle-only fallback also failed: parser does not yet support line family: 'This spell costs {8} less to cast if you have eight or more instant and/or sorcery cards in your graveyard.'
```

Current worker: i-0477e4e1889f23961
Branch: codex/aws-card-fix-octavia-living-thesis
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260604T121212Z-controller-dev-loop-wave0019
