### PR TITLE
Fix Ironsmith parse failure: Hargilde, Kindly Runechanter

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/abilities.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/abilities.rs
@@ -111,6 +111,11 @@ struct FilterManaUsageCastRestriction<'a> {
     grant_uncounterable: bool,
 }
 
+struct CastOrActivateManaUsageRestriction<'a> {
+    spell_spec_tokens: &'a [OwnedLexToken],
+    ability_source_tokens: &'a [OwnedLexToken],
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct ManaSpendBonusSentence<'a> {
     spec_tokens: &'a [OwnedLexToken],
@@ -774,10 +779,68 @@ pub(crate) fn is_spend_mana_restriction_sentence_lexed(tokens: &[OwnedLexToken])
 pub(crate) fn parse_mana_usage_restriction_sentence_lexed(
     tokens: &[OwnedLexToken],
 ) -> Option<ManaUsageRestriction> {
-    parse_legacy_mana_usage_restriction_sentence_lexed(tokens)
+    parse_cast_or_activate_mana_usage_restriction_sentence_lexed(tokens)
+        .or_else(|| parse_legacy_mana_usage_restriction_sentence_lexed(tokens))
         .or_else(|| parse_activate_ability_mana_usage_restriction_sentence_lexed(tokens))
         .or_else(|| parse_cant_be_spent_to_cast_sentence_lexed(tokens))
         .or_else(|| parse_filter_mana_usage_restriction_sentence_lexed(tokens))
+}
+
+fn parse_cast_or_activate_mana_usage_restriction_sentence_lexed(
+    tokens: &[OwnedLexToken],
+) -> Option<ManaUsageRestriction> {
+    let parsed = parse_cast_or_activate_mana_usage_restriction_tokens(tokens)?;
+    let spell_tokens = trim_lexed_commas(parsed.spell_spec_tokens);
+    let source_tokens = trim_mana_usage_ability_source_tokens(trim_lexed_commas(
+        parsed.ability_source_tokens,
+    ));
+    if spell_tokens.is_empty() || source_tokens.is_empty() {
+        return None;
+    }
+
+    let spell_filter = parse_spell_filter_with_grammar_entrypoint(spell_tokens);
+    let source_filter = parse_spell_filter_with_grammar_entrypoint(source_tokens);
+    if spell_filter == ObjectFilter::default() || spell_filter != source_filter {
+        return None;
+    }
+
+    Some(ManaUsageRestriction::CastSpellOrActivateAbilityMatching {
+        filter: spell_filter,
+    })
+}
+
+fn parse_cast_or_activate_mana_usage_restriction_tokens<'a>(
+    tokens: &'a [OwnedLexToken],
+) -> Option<CastOrActivateManaUsageRestriction<'a>> {
+    const CAST_OR_ACTIVATE_PATTERN: LexPattern<'static> = LexPattern::new(&[
+        LexPattern::any_phrase(SPEND_MANA_CAST_PREFIXES),
+        LexPattern::object(
+            "spell_spec",
+            LexCaptureKind::UntilPhrase(&["or", "activate", "abilities", "of"]),
+        ),
+        LexPattern::phrase(&["or", "activate", "abilities", "of"]),
+        LexPattern::subject("ability_source", LexCaptureKind::OneOrMoreWords),
+    ]);
+
+    let clause = LexedClause::new(tokens);
+    let matched = CAST_OR_ACTIVATE_PATTERN.match_clause(clause)?;
+    let spell_spec = matched.capture_clause_by_role(LexCaptureRole::Object, clause)?;
+    let ability_source = matched.capture_clause_by_role(LexCaptureRole::Subject, clause)?;
+    Some(CastOrActivateManaUsageRestriction {
+        spell_spec_tokens: spell_spec.tokens(),
+        ability_source_tokens: ability_source.tokens(),
+    })
+}
+
+fn trim_mana_usage_ability_source_tokens(tokens: &[OwnedLexToken]) -> &[OwnedLexToken] {
+    let Some(last) = tokens.last() else {
+        return tokens;
+    };
+    if last.is_word("source") || last.is_word("sources") {
+        &tokens[..tokens.len() - 1]
+    } else {
+        tokens
+    }
 }
 
 fn parse_cant_be_spent_to_cast_sentence_lexed(

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -2573,6 +2573,24 @@ fn rewrite_lexed_mana_restrictions_parse_supported_spell_filter_shapes() {
 }
 
 #[test]
+fn rewrite_lexed_mana_restriction_parses_cast_or_activate_matching_source() {
+    let tokens = lex_line(
+        "Spend this mana only to cast artifact spells or activate abilities of artifacts.",
+        0,
+    )
+    .expect("rewrite lexer should classify cast-or-activate mana restriction");
+
+    match parse_mana_usage_restriction_sentence_lexed(&tokens) {
+        Some(crate::ability::ManaUsageRestriction::CastSpellOrActivateAbilityMatching {
+            filter,
+        }) => {
+            assert_eq!(filter.card_types, vec![CardType::Artifact]);
+        }
+        other => panic!("expected cast-or-activate artifact restriction, got {other:?}"),
+    }
+}
+
+#[test]
 fn rewrite_spell_mana_restriction_wraps_preceding_mana_effect() {
     let tokens = lex_line(
         "Add one mana of any one color. Spend this mana only to cast creature spells.",

--- a/crates/ironsmith-core/src/ability_model.rs
+++ b/crates/ironsmith-core/src/ability_model.rs
@@ -38,6 +38,9 @@ pub enum ManaUsageRestriction {
         enters_with_counters: Vec<(crate::CounterType, u32)>,
         granted_abilities: Vec<StaticAbilityId>,
     },
+    CastSpellOrActivateAbilityMatching {
+        filter: ObjectFilter,
+    },
     ActivateAbility,
 }
 

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -57006,6 +57006,46 @@ fn jetfire_ingenious_scientist_mana_ability_restricts_nonartifact_spells() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn hargilde_kindly_runechanter_strict_parser_and_compiled_text_regression() {
+    assert_oracle_card_parses_strict("Hargilde, Kindly Runechanter");
+    let def = parse_oracle_card_definition("Hargilde, Kindly Runechanter");
+    let rendered = canonical_compiled_lines(&def).join(" ");
+    let rendered_lower = rendered.to_ascii_lowercase();
+
+    assert!(
+        rendered_lower.contains(
+            "spend this mana only to cast artifact spells or activate abilities of artifacts"
+        ),
+        "expected Hargilde compiled text to preserve artifact cast-or-activate mana restriction, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn hargilde_kindly_runechanter_models_cast_or_activate_artifact_mana_restriction() {
+    let def = parse_oracle_card_definition("Hargilde, Kindly Runechanter");
+    let activated = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Activated(activated) if activated.mana_output.is_some() => Some(activated),
+            _ => None,
+        })
+        .expect("Hargilde should have a mana ability");
+
+    let [crate::ability::ManaUsageRestriction::CastSpellOrActivateAbilityMatching { filter }] =
+        activated.mana_usage_restrictions.as_slice()
+    else {
+        panic!(
+            "expected Hargilde mana ability to carry one cast-or-activate usage restriction, got {:?}",
+            activated.mana_usage_restrictions
+        );
+    };
+    assert_eq!(filter.card_types, vec![CardType::Artifact]);
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn oran_rief_the_vastwood_compiled_text_keeps_entered_this_turn_green_filter() {
     let def = parse_oracle_card_definition("Oran-Rief, the Vastwood");
     let rendered = canonical_compiled_lines(&def)

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -38950,6 +38950,13 @@ fn describe_mana_usage_restriction(
             line.push_str(&bonuses.join(" and "));
             Some(line)
         }
+        crate::ability::ManaUsageRestriction::CastSpellOrActivateAbilityMatching { filter } => {
+            let spell_text = describe_mana_usage_spell_filter_plural_target(filter)?;
+            let source_text = describe_mana_usage_ability_source_filter(filter)?;
+            Some(format!(
+                "Spend this mana only to cast {spell_text} or activate abilities of {source_text}"
+            ))
+        }
         crate::ability::ManaUsageRestriction::ActivateAbility => {
             Some("Spend this mana only to activate abilities".to_string())
         }
@@ -39034,6 +39041,38 @@ fn describe_mana_usage_spell_filter_target_with_options(
         "a"
     };
     Some(format!("{article} {described}"))
+}
+
+fn describe_mana_usage_spell_filter_plural_target(filter: &ObjectFilter) -> Option<String> {
+    if let Some(special) = describe_special_mana_usage_spell_filter_target(filter, true) {
+        return Some(special);
+    }
+    let described = describe_simple_mana_usage_spell_filter(filter)
+        .unwrap_or_else(|| describe_cast_limit_spell_filter(filter));
+    if described.is_empty() {
+        return None;
+    }
+    if described == "spell" {
+        return Some("spells".to_string());
+    }
+    if let Some(singular) = described.strip_suffix(" spell") {
+        return Some(format!("{singular} spells"));
+    }
+    Some(pluralize_noun_phrase(&described))
+}
+
+fn describe_mana_usage_ability_source_filter(filter: &ObjectFilter) -> Option<String> {
+    if let Some(described) = describe_simple_mana_usage_spell_filter(filter)
+        && let Some(source) = described.strip_suffix(" spell")
+    {
+        return Some(pluralize_noun_phrase(source));
+    }
+    let described = describe_cast_limit_spell_filter(filter);
+    if described.is_empty() {
+        None
+    } else {
+        Some(pluralize_noun_phrase(&described))
+    }
 }
 
 fn describe_special_mana_usage_spell_filter_target(

--- a/crates/ironsmith-runtime/src/game_loop/priority_mana.rs
+++ b/crates/ironsmith-runtime/src/game_loop/priority_mana.rs
@@ -696,6 +696,7 @@ fn restriction_requires_matching_spell(restriction: &crate::ability::ManaUsageRe
             restrict_to_matching_spell,
             ..
         } => *restrict_to_matching_spell,
+        crate::ability::ManaUsageRestriction::CastSpellOrActivateAbilityMatching { .. } => true,
         crate::ability::ManaUsageRestriction::ActivateAbility => true,
     }
 }
@@ -744,6 +745,7 @@ fn restriction_bonus_applies_to_payment_source(
             }
             cast_spell_filter_matches_payment_source(game, unit, filter, payment_source)
         }
+        crate::ability::ManaUsageRestriction::CastSpellOrActivateAbilityMatching { .. } => false,
         crate::ability::ManaUsageRestriction::ActivateAbility => false,
     }
 }
@@ -808,6 +810,18 @@ pub(super) fn payment_source_matches_restriction(
                 return true;
             }
             cast_spell_filter_matches_payment_source(game, unit, filter, Some(source_obj.id))
+        }
+        crate::ability::ManaUsageRestriction::CastSpellOrActivateAbilityMatching { filter } => {
+            if source_obj.zone == Zone::Stack {
+                cast_spell_filter_matches_payment_source(game, unit, filter, Some(source_obj.id))
+            } else {
+                let Some(mana_source) = game.object(unit.source) else {
+                    return false;
+                };
+                let filter_ctx =
+                    game.filter_context_for(game.controller_of(mana_source), Some(unit.source));
+                filter.matches(source_obj, &filter_ctx, game)
+            }
         }
         crate::ability::ManaUsageRestriction::ActivateAbility => source_obj.zone != Zone::Stack,
     }
@@ -948,6 +962,9 @@ pub(super) fn apply_spent_mana_bonuses(
                 enters_with_counters,
                 granted_abilities,
             ),
+            crate::ability::ManaUsageRestriction::CastSpellOrActivateAbilityMatching { .. } => {
+                continue;
+            }
             crate::ability::ManaUsageRestriction::ActivateAbility => continue,
         };
 
@@ -4807,6 +4824,80 @@ mod priority_mana_tests {
         assert!(
             spend_pool_symbol(&mut game, alice, ManaSymbol::Colorless, Some(spell_id)).is_none(),
             "James restricted mana should not be spendable to cast spells"
+        );
+    }
+
+    #[test]
+    fn hargilde_kindly_runechanter_restricted_mana_pays_only_artifact_spells_or_artifact_abilities()
+    {
+        let hargilde = CardDefinitionBuilder::new(CardId::new(), "Hargilde, Kindly Runechanter")
+            .card_types(vec![CardType::Creature])
+            .parse_text(
+                "{T}: Add {C}{C}. Spend this mana only to cast artifact spells or activate abilities of artifacts.",
+            )
+            .expect("Hargilde mana ability text should parse");
+        let restriction = hargilde
+            .abilities
+            .iter()
+            .find_map(|ability| match &ability.kind {
+                AbilityKind::Activated(activated)
+                    if !activated.mana_usage_restrictions.is_empty() =>
+                {
+                    activated.mana_usage_restrictions.first().cloned()
+                }
+                _ => None,
+            })
+            .expect("Hargilde mana ability should include a usage restriction");
+
+        let mut game = setup_game();
+        let alice = PlayerId::from_index(0);
+        let source_id = game.create_object_from_definition(&hargilde, alice, Zone::Battlefield);
+        let unit = RestrictedManaUnit {
+            symbol: ManaSymbol::Colorless,
+            source: source_id,
+            source_chosen_creature_type: None,
+            restrictions: vec![restriction],
+        };
+
+        let artifact_spell = CardDefinitionBuilder::new(CardId::new(), "Artifact Spell")
+            .card_types(vec![CardType::Artifact])
+            .build();
+        let artifact_spell_id =
+            game.create_object_from_definition(&artifact_spell, alice, Zone::Stack);
+        assert!(
+            restricted_unit_is_payable(&game, &unit, Some(artifact_spell_id)),
+            "Hargilde mana should pay for artifact spells"
+        );
+
+        let artifact_source = CardDefinitionBuilder::new(CardId::new(), "Artifact Ability Source")
+            .card_types(vec![CardType::Artifact])
+            .build();
+        let artifact_source_id =
+            game.create_object_from_definition(&artifact_source, alice, Zone::Battlefield);
+        assert!(
+            restricted_unit_is_payable(&game, &unit, Some(artifact_source_id)),
+            "Hargilde mana should pay for abilities of artifacts"
+        );
+
+        let instant_spell = CardDefinitionBuilder::new(CardId::new(), "Nonartifact Spell")
+            .card_types(vec![CardType::Instant])
+            .build();
+        let instant_spell_id =
+            game.create_object_from_definition(&instant_spell, alice, Zone::Stack);
+        assert!(
+            !restricted_unit_is_payable(&game, &unit, Some(instant_spell_id)),
+            "Hargilde mana should reject nonartifact spells"
+        );
+
+        let creature_source =
+            CardDefinitionBuilder::new(CardId::new(), "Nonartifact Ability Source")
+                .card_types(vec![CardType::Creature])
+                .build();
+        let creature_source_id =
+            game.create_object_from_definition(&creature_source, alice, Zone::Battlefield);
+        assert!(
+            !restricted_unit_is_payable(&game, &unit, Some(creature_source_id)),
+            "Hargilde mana should reject abilities of nonartifacts"
         );
     }
 


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Hargilde, Kindly Runechanter
Initial parse error:
```
compiled text dropped required semantic marker: spend-this-mana-only
```

Current worker: i-0b3d6ef7bf85c48fb
Branch: codex/aws-card-fix-hargilde-kindly-runechanter
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260604T121212Z-controller-dev-loop-wave0020
