### PR TITLE
Fix Ironsmith parse failure: Netherese Puzzle-Ward

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/trigger_clause_core.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/trigger_clause_core.rs
@@ -3719,6 +3719,12 @@ pub(crate) fn parse_trigger_clause_lexed(
             } else {
                 result_words
             };
+            if matches!(
+                result_words,
+                ["die's" | "dies", "highest", "natural", "result"]
+            ) {
+                return Ok(TriggerSpec::PlayerRollsHighestNaturalResult { player });
+            }
             if let Some((result, used)) = ironsmith_core::parse_cardinal_words(result_words)
                 && used == result_words.len()
             {

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/trigger_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/trigger_support.rs
@@ -148,6 +148,9 @@ pub(crate) fn compile_trigger_spec(trigger: TriggerSpec) -> Trigger {
         TriggerSpec::PlayerRollsResult { player, result } => {
             Trigger::player_rolls_result(player, result)
         }
+        TriggerSpec::PlayerRollsHighestNaturalResult { player } => {
+            Trigger::player_rolls_highest_natural_result(player)
+        }
         TriggerSpec::AbilityActivated {
             activator,
             filter,
@@ -514,6 +517,7 @@ fn trigger_binds_iterated_player(trigger: &TriggerSpec) -> bool {
         | TriggerSpec::PlayerShufflesLibrary { .. }
         | TriggerSpec::PlayerTapsForMana { .. }
         | TriggerSpec::PlayerRollsResult { .. }
+        | TriggerSpec::PlayerRollsHighestNaturalResult { .. }
         | TriggerSpec::PlayerSacrifices { .. }
         | TriggerSpec::ThisDealsDamageToPlayer { .. }
         | TriggerSpec::DealsDamageToPlayer { .. }
@@ -587,7 +591,8 @@ pub(crate) fn inferred_trigger_player_filter(trigger: &TriggerSpec) -> Option<Pl
         TriggerSpec::PlayerSearchesLibrary(_) => Some(PlayerFilter::IteratedPlayer),
         TriggerSpec::PlayerShufflesLibrary { .. } => Some(PlayerFilter::IteratedPlayer),
         TriggerSpec::PlayerTapsForMana { .. } => Some(PlayerFilter::IteratedPlayer),
-        TriggerSpec::PlayerRollsResult { .. } => Some(PlayerFilter::IteratedPlayer),
+        TriggerSpec::PlayerRollsResult { .. }
+        | TriggerSpec::PlayerRollsHighestNaturalResult { .. } => Some(PlayerFilter::IteratedPlayer),
         TriggerSpec::AbilityActivated { .. } => Some(PlayerFilter::IteratedPlayer),
         TriggerSpec::PlayerSacrifices { .. } => Some(PlayerFilter::IteratedPlayer),
         TriggerSpec::ThisDealsDamageToPlayer { .. }

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -211,6 +211,9 @@ pub(crate) enum TriggerSpec {
         player: PlayerFilter,
         result: u32,
     },
+    PlayerRollsHighestNaturalResult {
+        player: PlayerFilter,
+    },
     AbilityActivated {
         activator: PlayerFilter,
         filter: ObjectFilter,

--- a/crates/ironsmith-core/src/trigger_model.rs
+++ b/crates/ironsmith-core/src/trigger_model.rs
@@ -176,6 +176,9 @@ pub enum TriggerKind {
         player: PlayerFilter,
         result: u32,
     },
+    PlayerRollsHighestNaturalResult {
+        player: PlayerFilter,
+    },
     AbilityActivatedQualified {
         activator: PlayerFilter,
         filter: ObjectFilter,
@@ -748,6 +751,12 @@ impl Trigger {
         Self::typed(
             "player_rolls_result",
             TriggerKind::PlayerRollsResult { player, result },
+        )
+    }
+    pub fn player_rolls_highest_natural_result(player: PlayerFilter) -> Self {
+        Self::typed(
+            "player_rolls_highest_natural_result",
+            TriggerKind::PlayerRollsHighestNaturalResult { player },
         )
     }
     pub fn ability_activated_qualified(

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -9765,6 +9765,32 @@ fn test_parse_complaints_clerk_roll_one_trigger_creates_clown_robot() {
     );
 }
 
+#[test]
+fn netherese_puzzle_ward_strict_parser_compiled_text_and_structure_regression() {
+    let def = parse_oracle_card_definition("Netherese Puzzle-Ward");
+    let rendered = unprocessed_compiled_lines(&def).join("\n");
+    assert!(
+        rendered.contains("At the beginning of your upkeep")
+            && rendered.contains("roll a d4")
+            && rendered.contains("Scry X, where X is the result"),
+        "expected Focus Beam upkeep roll-and-scry text, got {rendered}"
+    );
+    assert!(
+        rendered.contains("Whenever you roll a die's highest natural result, draw a card"),
+        "expected Perfect Illumination highest-natural-result trigger text, got {rendered}"
+    );
+
+    let debug = format!("{:#?}", def.abilities);
+    assert!(
+        debug.contains("RollDieEffect") && debug.contains("sides: 4"),
+        "expected Netherese Puzzle-Ward to roll a d4, got {debug}"
+    );
+    assert!(
+        debug.contains("PlayerRollsHighestNaturalResult") && debug.contains("DrawCardsEffect"),
+        "expected highest-natural-result die-roll trigger to draw a card, got {debug}"
+    );
+}
+
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn test_parse_sevinnes_reclamation_flashback_copy_clause() {

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -5585,6 +5585,37 @@ fn describe_roll_die_with_numeric_result_table(effects: &[Effect]) -> Option<Str
     Some(lines.join("\n"))
 }
 
+fn describe_roll_die_then_scry_result(effects: &[Effect]) -> Option<String> {
+    let [roll_effect, scry_effect] = effects else {
+        return None;
+    };
+    let roll_with_id = roll_effect.downcast_ref::<crate::effects::WithIdEffect>()?;
+    let roll = roll_with_id
+        .effect
+        .downcast_ref::<crate::effects::RollDieEffect>()?;
+    let scry = scry_effect.downcast_ref::<crate::effects::ScryEffect>()?;
+    if roll.player != scry.player
+        || !value_prefers_where_x(&scry.count)
+        || !matches!(scry.count.unhinted(), Value::EffectValue(id) if *id == roll_with_id.id)
+    {
+        return None;
+    }
+
+    let scry_text = if scry.player == PlayerFilter::You {
+        "Scry X, where X is the result".to_string()
+    } else {
+        let player = describe_player_filter(&scry.player);
+        format!(
+            "{player} {} X, where X is the result",
+            player_verb(&player, "scry", "scries")
+        )
+    };
+    Some(format!(
+        "{}. {scry_text}",
+        describe_effect(roll_effect).trim_end_matches('.')
+    ))
+}
+
 fn describe_group_pump_then_conditional_untap(effects: &[Effect]) -> Option<String> {
     let [pump_effect, conditional_effect] = effects else {
         return None;
@@ -5670,6 +5701,9 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
         return compact;
     }
     if let Some(compact) = describe_group_pump_then_conditional_untap(effects) {
+        return compact;
+    }
+    if let Some(compact) = describe_roll_die_then_scry_result(effects) {
         return compact;
     }
     if let Some(compact) = describe_roll_die_with_numeric_result_table(effects) {
@@ -16623,6 +16657,10 @@ pub(super) fn describe_effect_clause_list(effects: &[Effect]) -> Option<String> 
         return Some(cleanup_decompiled_text(&lowercase_first(
             compact_trimmed.trim_end_matches('.'),
         )));
+    }
+
+    if let Some(compact) = describe_roll_die_then_scry_result(effects) {
+        return Some(compact);
     }
 
     let mut parts = Vec::with_capacity(effects.len());

--- a/crates/ironsmith-runtime/src/effects/player/roll_die.rs
+++ b/crates/ironsmith-runtime/src/effects/player/roll_die.rs
@@ -61,7 +61,9 @@ impl EffectExecutor for RollDieEffect {
             game.turn_store.turn_history.record_die_roll(player, adjusted);
             return Ok(EffectOutcome::count(adjusted as i32)
                 .with_event(crate::triggers::TriggerEvent::new_with_provenance(
-                    DieRolledEvent::new(player, ctx.source, adjusted, self.sides),
+                    DieRolledEvent::new_with_natural_result(
+                        player, ctx.source, result, adjusted, self.sides,
+                    ),
                     ctx.provenance,
                 ))
                 .with_execution_fact(ExecutionFact::ChosenNumber(adjusted)));
@@ -76,7 +78,9 @@ impl EffectExecutor for RollDieEffect {
         game.turn_store.turn_history.record_die_roll(player, adjusted);
         Ok(EffectOutcome::count(adjusted as i32)
             .with_event(crate::triggers::TriggerEvent::new_with_provenance(
-                DieRolledEvent::new(player, ctx.source, adjusted, self.sides),
+                DieRolledEvent::new_with_natural_result(
+                    player, ctx.source, result, adjusted, self.sides,
+                ),
                 ctx.provenance,
             ))
             .with_execution_fact(ExecutionFact::ChosenNumber(adjusted)))
@@ -408,6 +412,7 @@ mod tests {
             .and_then(|event| event.downcast::<DieRolledEvent>())
             .expect("roll should emit a die-rolled event");
         assert_eq!(outcome.as_count(), Some(7));
+        assert_eq!(die_event.natural_result, 6);
         assert_eq!(die_event.result, 7);
         assert!(
             game.turn_store

--- a/crates/ironsmith-runtime/src/events/other/die_rolled.rs
+++ b/crates/ironsmith-runtime/src/events/other/die_rolled.rs
@@ -11,15 +11,27 @@ use crate::ids::{ObjectId, PlayerId};
 pub struct DieRolledEvent {
     pub player: PlayerId,
     pub source: ObjectId,
+    pub natural_result: u32,
     pub result: u32,
     pub sides: u32,
 }
 
 impl DieRolledEvent {
     pub fn new(player: PlayerId, source: ObjectId, result: u32, sides: u32) -> Self {
+        Self::new_with_natural_result(player, source, result, result, sides)
+    }
+
+    pub fn new_with_natural_result(
+        player: PlayerId,
+        source: ObjectId,
+        natural_result: u32,
+        result: u32,
+        sides: u32,
+    ) -> Self {
         Self {
             player,
             source,
+            natural_result,
             result,
             sides,
         }

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -30732,6 +30732,184 @@ fn complaints_clerk_opponent_roll_one_does_not_trigger() {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn netherese_puzzle_ward_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(531_506), "Netherese Puzzle-Ward")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(3)],
+            vec![ManaSymbol::Blue],
+        ]))
+        .card_types(vec![CardType::Enchantment])
+        .parse_text(
+            "Focus Beam — At the beginning of your upkeep, roll a d4. Scry X, where X is the result.\n\
+             Perfect Illumination — Whenever you roll a die's highest natural result, draw a card.",
+        )
+        .expect("Netherese Puzzle-Ward should parse")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn resolve_netherese_puzzle_ward_roll(
+    game: &mut GameState,
+    trigger_queue: &mut TriggerQueue,
+    source: ObjectId,
+    roller: PlayerId,
+    roll: u32,
+) {
+    game.force_next_die_roll(roll);
+    let mut ctx = crate::effects::ExecutionContext::new_default(source, roller);
+    let outcome = crate::effects::execute_effect(
+        game,
+        &Effect::roll_die(4, PlayerFilter::Specific(roller)),
+        &mut ctx,
+    )
+    .expect("die roll should resolve");
+    for event in outcome.events {
+        queue_triggers_from_event(game, trigger_queue, event, false);
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+struct NethereseRollAdjustmentDecisionMaker;
+
+#[cfg(ironsmith_runtime_parser_tests)]
+impl DecisionMaker for NethereseRollAdjustmentDecisionMaker {
+    fn decide_boolean(
+        &mut self,
+        _game: &GameState,
+        _ctx: &crate::decisions::context::BooleanContext,
+    ) -> bool {
+        true
+    }
+
+    fn decide_options(
+        &mut self,
+        _game: &GameState,
+        _ctx: &crate::decisions::context::SelectOptionsContext,
+    ) -> Vec<usize> {
+        vec![0]
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn add_netherese_roll_adjustment_source(game: &mut GameState, controller: PlayerId) {
+    let card = CardDefinitionBuilder::new(CardId::new(), "Die Adjustment Source")
+        .card_types(vec![CardType::Enchantment])
+        .with_ability(Ability::static_ability(
+            StaticAbility::die_roll_result_adjustment(
+                PlayerFilter::You,
+                1,
+                1,
+                true,
+                "After you roll a die, you may pay 1 life. If you do, increase or decrease the result by 1. Do this only once each turn.",
+            ),
+        ))
+        .build();
+    game.create_object_from_definition(&card, controller, Zone::Battlefield);
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn netherese_puzzle_ward_highest_natural_result_draws_a_card() {
+    let mut game = setup_game();
+    let mut trigger_queue = TriggerQueue::new();
+    let alice = PlayerId::from_index(0);
+    put_test_cards_in_zone(&mut game, alice, Zone::Library, 1);
+    let ward = netherese_puzzle_ward_definition();
+    let ward_id = game.create_object_from_definition(&ward, alice, Zone::Battlefield);
+
+    resolve_netherese_puzzle_ward_roll(&mut game, &mut trigger_queue, ward_id, alice, 4);
+    assert_eq!(
+        trigger_queue.entries.len(),
+        1,
+        "Netherese Puzzle-Ward should trigger when its controller rolls the d4's highest natural result"
+    );
+
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Netherese Puzzle-Ward roll trigger should go on the stack");
+    resolve_stack_entry(&mut game).expect("Netherese Puzzle-Ward roll trigger should resolve");
+    assert_eq!(
+        game.player(alice).expect("Alice exists").hand.len(),
+        1,
+        "highest natural result should draw one card"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn netherese_puzzle_ward_non_highest_result_does_not_trigger() {
+    let mut game = setup_game();
+    let mut trigger_queue = TriggerQueue::new();
+    let alice = PlayerId::from_index(0);
+    put_test_cards_in_zone(&mut game, alice, Zone::Library, 1);
+    let ward = netherese_puzzle_ward_definition();
+    let ward_id = game.create_object_from_definition(&ward, alice, Zone::Battlefield);
+
+    resolve_netherese_puzzle_ward_roll(&mut game, &mut trigger_queue, ward_id, alice, 3);
+    assert!(
+        trigger_queue.entries.is_empty(),
+        "Netherese Puzzle-Ward should not trigger for a non-highest d4 result"
+    );
+    assert_eq!(game.player(alice).expect("Alice exists").hand.len(), 0);
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn netherese_puzzle_ward_adjusted_high_result_does_not_trigger() {
+    let mut game = setup_game();
+    let mut trigger_queue = TriggerQueue::new();
+    let alice = PlayerId::from_index(0);
+    put_test_cards_in_zone(&mut game, alice, Zone::Library, 1);
+    add_netherese_roll_adjustment_source(&mut game, alice);
+    let ward = netherese_puzzle_ward_definition();
+    let ward_id = game.create_object_from_definition(&ward, alice, Zone::Battlefield);
+
+    game.force_next_die_roll(3);
+    let mut decisions = NethereseRollAdjustmentDecisionMaker;
+    let mut ctx = crate::effects::ExecutionContext::new_default(ward_id, alice)
+        .with_decision_maker(&mut decisions);
+    let outcome = crate::effects::execute_effect(
+        &mut game,
+        &Effect::roll_die(4, PlayerFilter::Specific(alice)),
+        &mut ctx,
+    )
+    .expect("die roll should resolve");
+    let die_event = outcome
+        .events
+        .first()
+        .and_then(|event| event.downcast::<crate::events::other::DieRolledEvent>())
+        .expect("roll should emit a die-rolled event");
+    assert_eq!(die_event.natural_result, 3);
+    assert_eq!(die_event.result, 4);
+    for event in outcome.events {
+        queue_triggers_from_event(&mut game, &mut trigger_queue, event, false);
+    }
+
+    assert!(
+        trigger_queue.entries.is_empty(),
+        "Netherese Puzzle-Ward should not trigger when an adjusted result, not the natural result, is highest"
+    );
+    assert_eq!(game.player(alice).expect("Alice exists").hand.len(), 0);
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn netherese_puzzle_ward_opponent_highest_result_does_not_trigger() {
+    let mut game = setup_game();
+    let mut trigger_queue = TriggerQueue::new();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    put_test_cards_in_zone(&mut game, alice, Zone::Library, 1);
+    let ward = netherese_puzzle_ward_definition();
+    let ward_id = game.create_object_from_definition(&ward, alice, Zone::Battlefield);
+
+    resolve_netherese_puzzle_ward_roll(&mut game, &mut trigger_queue, ward_id, bob, 4);
+    assert!(
+        trigger_queue.entries.is_empty(),
+        "Netherese Puzzle-Ward should not trigger when another player rolls the highest natural result"
+    );
+    assert_eq!(game.player(alice).expect("Alice exists").hand.len(), 0);
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 fn arden_angel_definition() -> crate::cards::CardDefinition {
     CardDefinitionBuilder::new(CardId::new(), "Arden Angel")
         .card_types(vec![CardType::Creature])

--- a/crates/ironsmith-runtime/src/triggers/mod.rs
+++ b/crates/ironsmith-runtime/src/triggers/mod.rs
@@ -819,6 +819,11 @@ impl Trigger {
         Self::new(PlayerRollsResultTrigger::new(player, result))
     }
 
+    /// Create a "whenever [player] rolls a die's highest natural result" trigger.
+    pub fn player_rolls_highest_natural_result(player: PlayerFilter) -> Self {
+        Self::new(PlayerRollsHighestNaturalResultTrigger::new(player))
+    }
+
     /// Create a "whenever mana is added to [player]'s mana pool" trigger.
     pub fn mana_added(player: PlayerFilter) -> Self {
         Self::new(ManaAddedTrigger::new(player))

--- a/crates/ironsmith-runtime/src/triggers/model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/triggers/model_interpreter.rs
@@ -258,6 +258,9 @@ pub(crate) fn interpret_trigger_model(
         TriggerKind::PlayerRollsResult { player, result } => {
             crate::triggers::Trigger::player_rolls_result(player, result)
         }
+        TriggerKind::PlayerRollsHighestNaturalResult { player } => {
+            crate::triggers::Trigger::player_rolls_highest_natural_result(player)
+        }
         TriggerKind::AbilityActivatedQualified {
             activator,
             filter,

--- a/crates/ironsmith-runtime/src/triggers/other/mod.rs
+++ b/crates/ironsmith-runtime/src/triggers/other/mod.rs
@@ -33,7 +33,7 @@ pub use permanent_turned_face_up::PermanentTurnedFaceUpTrigger;
 pub use player_gives_gift::PlayerGivesGiftTrigger;
 pub use player_plays_land::PlayerPlaysLandTrigger;
 pub use player_reveals_card::PlayerRevealsCardTrigger;
-pub use player_rolls_result::PlayerRollsResultTrigger;
+pub use player_rolls_result::{PlayerRollsHighestNaturalResultTrigger, PlayerRollsResultTrigger};
 pub use player_sacrifices::PlayerSacrificesTrigger;
 pub use player_searches_library::PlayerSearchesLibraryTrigger;
 pub use player_shuffles_library::PlayerShufflesLibraryTrigger;

--- a/crates/ironsmith-runtime/src/triggers/other/player_rolls_result.rs
+++ b/crates/ironsmith-runtime/src/triggers/other/player_rolls_result.rs
@@ -12,9 +12,20 @@ pub struct PlayerRollsResultTrigger {
     pub result: u32,
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub struct PlayerRollsHighestNaturalResultTrigger {
+    pub player: PlayerFilter,
+}
+
 impl PlayerRollsResultTrigger {
     pub fn new(player: PlayerFilter, result: u32) -> Self {
         Self { player, result }
+    }
+}
+
+impl PlayerRollsHighestNaturalResultTrigger {
+    pub fn new(player: PlayerFilter) -> Self {
+        Self { player }
     }
 }
 
@@ -42,6 +53,41 @@ impl TriggerMatcher for PlayerRollsResultTrigger {
             PlayerFilter::Active => format!("Whenever the active player rolls a {result}"),
             PlayerFilter::Specific(_) => format!("Whenever that player rolls a {result}"),
             _ => format!("Whenever a player rolls a {result}"),
+        }
+    }
+}
+
+impl TriggerMatcher for PlayerRollsHighestNaturalResultTrigger {
+    fn matches(&self, event: &TriggerEvent, ctx: &TriggerContext) -> bool {
+        if event.kind() != EventKind::DieRolled {
+            return false;
+        }
+        let Some(e) = event.downcast::<DieRolledEvent>() else {
+            return false;
+        };
+        if e.natural_result != e.sides {
+            return false;
+        }
+
+        player_filter_matches_with_context(&self.player, e.player, ctx.controller, ctx.game, None)
+    }
+
+    fn display(&self) -> String {
+        match &self.player {
+            PlayerFilter::You => "Whenever you roll a die's highest natural result".to_string(),
+            PlayerFilter::Opponent => {
+                "Whenever an opponent rolls a die's highest natural result".to_string()
+            }
+            PlayerFilter::Any => {
+                "Whenever a player rolls a die's highest natural result".to_string()
+            }
+            PlayerFilter::Active => {
+                "Whenever the active player rolls a die's highest natural result".to_string()
+            }
+            PlayerFilter::Specific(_) => {
+                "Whenever that player rolls a die's highest natural result".to_string()
+            }
+            _ => "Whenever a player rolls a die's highest natural result".to_string(),
         }
     }
 }


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Netherese Puzzle-Ward
Initial parse error:
```
parser does not yet support line family: 'Perfect Illumination — Whenever you roll a die's highest natural result, draw a card.'; oracle-only fallback also failed: parser does not yet support line family: 'Perfect Illumination — Whenever you roll a die's highest natural result, draw a card.'
```

Current worker: i-094fa2382dffd0359
Branch: codex/aws-card-fix-netherese-puzzle-ward
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260604T121212Z-controller-dev-loop-wave0021
