### PR TITLE
Fix Ironsmith parse failure: Scroll of Isildur

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
@@ -6395,6 +6395,7 @@ where
     let you_value = per_player_partition_value_for_filter(you_value, &PlayerFilter::You);
     let mut prelude_effects = Vec::new();
     let mut merged_choices = choices.clone();
+    collect_value_player_target_choices(&value, &mut merged_choices);
     if let Some(spec) = value_object_target_spec(&value)
         && ctx.auto_tag_object_targets
     {
@@ -6418,6 +6419,137 @@ where
         push_choice(&mut merged_choices, choice);
     }
     Ok((prelude_effects, merged_choices))
+}
+
+fn collect_value_player_target_choices(value: &Value, choices: &mut Vec<ChooseSpec>) {
+    match value {
+        Value::SurfaceHinted { value, .. } => collect_value_player_target_choices(value, choices),
+        Value::Add(left, right) | Value::Min(left, right) => {
+            collect_value_player_target_choices(left, choices);
+            collect_value_player_target_choices(right, choices);
+        }
+        Value::Scaled(inner, _)
+        | Value::DividedRoundedDown(inner, _)
+        | Value::HalfRoundedDown(inner) => collect_value_player_target_choices(inner, choices),
+        Value::Count(filter)
+        | Value::CountScaled(filter, _)
+        | Value::GreatestCount(filter)
+        | Value::TotalPower(filter)
+        | Value::TotalToughness(filter)
+        | Value::TotalManaValue(filter)
+        | Value::GreatestPower(filter)
+        | Value::GreatestToughness(filter)
+        | Value::GreatestManaValue(filter)
+        | Value::BasicLandTypesAmong(filter)
+        | Value::CreatureTypesAmong(filter)
+        | Value::CardTypesAmong(filter)
+        | Value::ColorsAmong(filter)
+        | Value::DistinctNames(filter)
+        | Value::DistinctPowers(filter)
+        | Value::PlayersWhoControlMoreThanYou(filter) => {
+            collect_object_filter_player_target_choices(filter, choices);
+        }
+        Value::SpellsCastThisTurnMatching { player, filter, .. } => {
+            collect_player_filter_target_choice(player, choices);
+            collect_object_filter_player_target_choices(filter, choices);
+        }
+        Value::Devotion { player, .. }
+        | Value::CountPlayers(player)
+        | Value::PartySize(player)
+        | Value::LifeTotal(player)
+        | Value::LifeTotalAsTurnBegan(player)
+        | Value::LifeTotalDifference(player)
+        | Value::Speed(player)
+        | Value::StartingLifeTotal(player)
+        | Value::DevotionToChosenColor(player)
+        | Value::LifeGainedThisTurn(player)
+        | Value::LifeLostThisTurn(player)
+        | Value::CardsDiscardedThisTurn(player)
+        | Value::DamageDealtToPlayersThisTurn(player)
+        | Value::NoncombatDamageDealtToPlayersThisTurn(player)
+        | Value::MaxCardsDrawnThisTurn(player)
+        | Value::LandsEnteredBattlefieldThisTurn(player)
+        | Value::MaxCardsInHand(player)
+        | Value::CardsInHand(player)
+        | Value::CardsInLibrary(player)
+        | Value::CardsInGraveyard(player)
+        | Value::SpellsCastThisTurn(player)
+        | Value::SpellsCastBeforeThisTurn(player)
+        | Value::CommanderCastCount(player)
+        | Value::CardTypesInGraveyard(player)
+        | Value::HalfLifeTotalRoundedUp(player)
+        | Value::HalfLifeTotalRoundedDown(player)
+        | Value::HalfStartingLifeTotalRoundedUp(player)
+        | Value::HalfStartingLifeTotalRoundedDown(player)
+        | Value::CreaturesDiedThisTurnControlledBy(player)
+        | Value::PlayerCounters(player, _)
+        | Value::PlayerVoteCount(player) => {
+            collect_player_filter_target_choice(player, choices);
+        }
+        Value::NoncombatDamageDealtBySourcesControlledThisTurn { player, .. } => {
+            collect_player_filter_target_choice(player, choices);
+        }
+        Value::PowerOf(spec)
+        | Value::ToughnessOf(spec)
+        | Value::ManaValueOf(spec)
+        | Value::CountersOn(spec, _) => collect_choose_spec_player_target_choices(spec, choices),
+        _ => {}
+    }
+}
+
+fn collect_choose_spec_player_target_choices(spec: &ChooseSpec, choices: &mut Vec<ChooseSpec>) {
+    match spec {
+        ChooseSpec::SurfaceHinted { spec, .. }
+        | ChooseSpec::Target(spec)
+        | ChooseSpec::WithCount(spec, _) => collect_choose_spec_player_target_choices(spec, choices),
+        ChooseSpec::Player(player)
+        | ChooseSpec::PlayerOrPlaneswalker(player)
+        | ChooseSpec::EachPlayer(player) => collect_player_filter_target_choice(player, choices),
+        ChooseSpec::Object(filter) | ChooseSpec::All(filter) => {
+            collect_object_filter_player_target_choices(filter, choices)
+        }
+        _ => {}
+    }
+}
+
+fn collect_object_filter_player_target_choices(
+    filter: &ObjectFilter,
+    choices: &mut Vec<ChooseSpec>,
+) {
+    for player in [
+        filter.controller.as_ref(),
+        filter.cast_by.as_ref(),
+        filter.owner.as_ref(),
+        filter.targets_player.as_ref(),
+        filter.targets_only_player.as_ref(),
+        filter.attacking_player_or_planeswalker_controlled_by.as_ref(),
+        filter.attached_to_player.as_ref(),
+        filter.entered_battlefield_controller.as_ref(),
+        filter.dealt_damage_to_player_this_turn.as_ref(),
+    ]
+    .into_iter()
+    .flatten()
+    {
+        collect_player_filter_target_choice(player, choices);
+    }
+    if let Some(targets) = filter.targets_object.as_deref() {
+        collect_object_filter_player_target_choices(targets, choices);
+    }
+    if let Some(targets) = filter.targets_only_object.as_deref() {
+        collect_object_filter_player_target_choices(targets, choices);
+    }
+    for option in &filter.any_of {
+        collect_object_filter_player_target_choices(option, choices);
+    }
+}
+
+fn collect_player_filter_target_choice(player: &PlayerFilter, choices: &mut Vec<ChooseSpec>) {
+    if let PlayerFilter::Target(inner) = player {
+        push_choice(
+            choices,
+            ChooseSpec::target(ChooseSpec::Player((**inner).clone())),
+        );
+    }
 }
 
 fn value_object_target_spec(value: &Value) -> Option<ChooseSpec> {

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/control_copy_attach_verbs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/control_copy_attach_verbs.rs
@@ -69,7 +69,14 @@ const CCA_FOR_AS_LONG_AS_MARKER_PATTERN: ClauseShape<'static> =
 const CCA_YOU_CONTROL_SOURCE_MARKER_PATTERN: ClauseShape<'static> =
     ClauseShape::new()
         .contains_words(&["you", "control"])
-        .contains_any_words(&[&["this"], &["thiss"], &["source"], &["creature"], &["permanent"]]);
+        .contains_any_words(&[
+            &["this"],
+            &["thiss"],
+            &["source"],
+            &["creature"],
+            &["permanent"],
+            &["saga"],
+        ]);
 const CCA_DURING_NEXT_TURN_MARKER_PATTERN: ClauseShape<'static> =
     clause_shape!(contains_words & ["during", "next", "turn"]);
 const CCA_UNTIL_END_NEXT_TURN_MARKER_PATTERN: ClauseShape<'static> =
@@ -119,6 +126,20 @@ const CCA_AMONG_THEM_MARKER_PATTERN: ClauseShape<'static> =
 const CCA_PERMANENT_MARKER_PATTERN: ClauseShape<'static> =
     clause_shape!(contains_words & ["permanent"]);
 const CCA_STICKER_MARKER_PATTERN: ClauseShape<'static> = clause_shape!(contains_words & ["sticker"]);
+
+fn cca_words_are_you_control_source_duration(words: &[&str]) -> bool {
+    if CCA_YOU_CONTROL_SOURCE_MARKER_PATTERN.matches_words(words) {
+        return true;
+    }
+
+    let Some(control_idx) = words.iter().position(|word| *word == "control") else {
+        return false;
+    };
+    let source_words = &words[control_idx + 1..];
+    !source_words.is_empty()
+        && (this_source_surface_for_words(source_words).is_some()
+            || source_reference_surface_for_words(source_words).is_some())
+}
 
 fn parse_put_choice_count_prefix(
     tokens: &[OwnedLexToken],
@@ -474,7 +495,7 @@ pub(crate) fn parse_control_duration(
 
     let words = crate::runtime_backend::token_word_refs(tokens);
     if CCA_FOR_AS_LONG_AS_MARKER_PATTERN.matches_words(&words)
-        && CCA_YOU_CONTROL_SOURCE_MARKER_PATTERN.matches_words(&words)
+        && cca_words_are_you_control_source_duration(&words)
     {
         return Ok(ControlDurationAst::AsLongAsYouControlSource);
     }

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/mod.rs
@@ -41,7 +41,8 @@ use super::super::util::{
     parse_choice_count_token_prefix_consumed, parse_mana_symbol, parse_number,
     parse_number_word_u32, parse_quantity_comparison_prefix, parse_target_count_range_prefix,
     parse_target_phrase, parse_value, parse_value_expr_words, replace_unbound_x_with_value,
-    span_from_tokens, strip_leading_article_word_refs, token_index_for_word_index, trim_commas,
+    source_reference_surface_for_words, span_from_tokens, strip_leading_article_word_refs,
+    this_source_surface_for_words, token_index_for_word_index, trim_commas,
     value_contains_unbound_x, words, wrap_target_count,
 };
 use super::super::value_helpers::{

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -59665,6 +59665,36 @@ fn parse_oracle_gwen_stacy_ghost_spider_compiled_text_regression() {
 }
 
 #[test]
+fn scroll_of_isildur_strict_parser_and_compiled_text_regression() {
+    assert_oracle_card_parses_strict("Scroll of Isildur");
+    let def = parse_oracle_card_definition("Scroll of Isildur");
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+    let debug = format!("{:#?}", def.abilities);
+
+    assert!(
+        rendered.contains(
+            "Gain control of up to one target artifact for as long as you control this Saga"
+        ),
+        "expected Scroll of Isildur chapter I to render the source-control duration, got {rendered}"
+    );
+    assert!(
+        rendered.to_ascii_lowercase().contains("ring tempts you"),
+        "expected Scroll of Isildur chapter I to render the Ring tempts clause, got {rendered}"
+    );
+    assert!(
+        rendered.contains("Tap up to two target creatures. Put a stun counter on each of them"),
+        "expected Scroll of Isildur chapter II to render counters on the tapped targets, got {rendered}"
+    );
+    assert!(
+        debug.contains("YouStopControllingThis")
+            && debug.contains("RingTemptsYouEffect")
+            && debug.contains("ForEachObject")
+            && debug.contains("Stun"),
+        "expected Scroll of Isildur to keep source-control, Ring, and tagged stun-counter structures, got {debug}"
+    );
+}
+
+#[test]
 fn creepy_puppeteer_regression_renders_base_power_toughness_followup() {
     let def = parse_oracle_card_definition("Creepy Puppeteer");
     let rendered = unprocessed_compiled_lines(&def)

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -10411,7 +10411,7 @@ pub(super) fn describe_until(until: &Until) -> String {
             "for as long as this source remains on the battlefield".to_string()
         }
         Until::SourceUntaps => "for as long as this source remains tapped".to_string(),
-        Until::YouStopControllingThis => "while you control this source".to_string(),
+        Until::YouStopControllingThis => "for as long as you control this source".to_string(),
         Until::TurnsPass(turns) => format!("for {} turn(s)", describe_value(turns)),
     }
 }

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -3894,6 +3894,39 @@ fn describe_choose_then_put_counter_on_each(effects: &[&Effect]) -> Option<Strin
     }
 }
 
+fn describe_tagged_effect_then_put_counter_on_each(effects: &[Effect]) -> Option<String> {
+    let [tagged_effect, for_each_effect] = effects else {
+        return None;
+    };
+    let tagged = tagged_effect.downcast_ref::<crate::effects::TaggedEffect>()?;
+    let for_each = for_each_effect.downcast_ref::<crate::effects::ForEachObject>()?;
+    let [put_effect] = for_each.effects.as_slice() else {
+        return None;
+    };
+    let put = put_effect.downcast_ref::<crate::effects::PutCountersEffect>()?;
+    if !matches!(put.target, ChooseSpec::Iterated)
+        || put.target_count.is_some()
+        || put.distributed
+    {
+        return None;
+    }
+    if !for_each.filter.tagged_constraints.iter().any(|constraint| {
+        constraint.tag == tagged.tag
+            && matches!(
+                constraint.relation,
+                crate::filter::TaggedOpbjectRelation::IsTaggedObject
+            )
+    }) {
+        return None;
+    }
+
+    Some(format!(
+        "{}. Put {} on each of them",
+        describe_effect(&tagged.effect),
+        describe_put_counter_phrase(&put.amount, put.counter_type)
+    ))
+}
+
 fn describe_structural_multisentence_effect_list(effects: &[Effect]) -> Option<String> {
     if let [first, rest @ ..] = effects
         && first
@@ -3944,6 +3977,10 @@ fn describe_structural_multisentence_effect_list(effects: &[Effect]) -> Option<S
     }
 
     if let Some(compact) = describe_put_counters_then_gain_suspend(effects) {
+        return Some(compact);
+    }
+
+    if let Some(compact) = describe_tagged_effect_then_put_counter_on_each(effects) {
         return Some(compact);
     }
 

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -53801,6 +53801,182 @@ fn test_read_ahead_enters_with_choice_and_skips_lower_chapters() {
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn scroll_of_isildur_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(993_001), "Scroll of Isildur")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(2)],
+            vec![ManaSymbol::Blue],
+        ]))
+        .card_types(vec![CardType::Enchantment])
+        .subtypes(vec![Subtype::Saga])
+        .parse_text(
+            "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\n\
+             I — Gain control of up to one target artifact for as long as you control this Saga. The Ring tempts you.\n\
+             II — Tap up to two target creatures. Put a stun counter on each of them.\n\
+             III — Draw a card for each tapped creature target opponent controls.",
+        )
+        .expect("Scroll of Isildur should parse for runtime tests")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn scroll_of_isildur_chapter_one_steals_artifact_until_saga_not_controlled_and_tempts_ring() {
+    let mut game = GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let mut trigger_queue = TriggerQueue::new();
+    let mut dm = SelectFirstDecisionMaker;
+
+    let scroll_id = game.create_object_from_definition(
+        &scroll_of_isildur_definition(),
+        alice,
+        Zone::Battlefield,
+    );
+    let relic = CardBuilder::new(CardId::from_raw(993_002), "Bob's Relic")
+        .card_types(vec![CardType::Artifact])
+        .build();
+    let relic_id = game.create_object_from_card(&relic, bob, Zone::Battlefield);
+    let bearer = CardBuilder::new(CardId::from_raw(993_003), "Ring Candidate")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .build();
+    let bearer_id = game.create_object_from_card(&bearer, alice, Zone::Battlefield);
+
+    add_lore_counter_and_check_chapters(&mut game, scroll_id, &mut trigger_queue);
+    put_triggers_on_stack_with_dm(&mut game, &mut trigger_queue, &mut dm)
+        .expect("Scroll of Isildur chapter I should go on the stack with an artifact target");
+    resolve_stack_entry_with_dm_and_triggers(&mut game, &mut dm, &mut trigger_queue)
+        .expect("Scroll of Isildur chapter I should resolve");
+
+    assert_eq!(
+        game.current_controller(relic_id),
+        Some(alice),
+        "chapter I should give Alice control of the targeted artifact"
+    );
+    assert_eq!(
+        game.ring_temptations(alice),
+        1,
+        "chapter I should make the Ring tempt Alice"
+    );
+    assert_eq!(
+        game.current_ring_bearer(alice),
+        Some(bearer_id),
+        "chapter I should choose Alice's only creature as Ring-bearer"
+    );
+
+    game.set_current_controller(scroll_id, bob);
+    game.refresh_continuous_state();
+    assert_eq!(
+        game.current_controller(relic_id),
+        Some(bob),
+        "the control-changing effect should expire once Alice no longer controls the Saga"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn scroll_of_isildur_chapters_two_and_three_target_tap_stun_and_draw_count() {
+    let mut game = GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let mut trigger_queue = TriggerQueue::new();
+    let mut dm = SelectFirstDecisionMaker;
+
+    let scroll_id = game.create_object_from_definition(
+        &scroll_of_isildur_definition(),
+        alice,
+        Zone::Battlefield,
+    );
+    game.object_mut(scroll_id)
+        .expect("Scroll of Isildur should exist")
+        .add_counters(crate::object::CounterType::Lore, 1);
+
+    let creature = |id, name| {
+        CardBuilder::new(CardId::from_raw(id), name)
+            .card_types(vec![CardType::Creature])
+            .power_toughness(PowerToughness::fixed(2, 2))
+            .build()
+    };
+    let bob_first = game.create_object_from_card(
+        &creature(993_004, "First Bob Creature"),
+        bob,
+        Zone::Battlefield,
+    );
+    let bob_second = game.create_object_from_card(
+        &creature(993_005, "Second Bob Creature"),
+        bob,
+        Zone::Battlefield,
+    );
+    let bob_third = game.create_object_from_card(
+        &creature(993_006, "Third Bob Creature"),
+        bob,
+        Zone::Battlefield,
+    );
+    let alice_creature = game.create_object_from_card(
+        &creature(993_007, "Alice Creature"),
+        alice,
+        Zone::Battlefield,
+    );
+    for idx in 0..4 {
+        let card = CardBuilder::new(CardId::from_raw(993_010 + idx), &format!("Draw Card {idx}"))
+            .build();
+        game.create_object_from_card(&card, alice, Zone::Library);
+    }
+    let initial_hand_size = game.player(alice).expect("Alice exists").hand.len();
+
+    add_lore_counter_and_check_chapters(&mut game, scroll_id, &mut trigger_queue);
+    put_triggers_on_stack_with_dm(&mut game, &mut trigger_queue, &mut dm)
+        .expect("Scroll of Isildur chapter II should go on the stack with creature targets");
+    resolve_stack_entry_with_dm_and_triggers(&mut game, &mut dm, &mut trigger_queue)
+        .expect("Scroll of Isildur chapter II should resolve");
+
+    assert!(
+        game.is_tapped(bob_first),
+        "chapter II should tap the first chosen creature"
+    );
+    assert!(
+        game.is_tapped(bob_second),
+        "chapter II should tap the second chosen creature"
+    );
+    assert!(
+        !game.is_tapped(bob_third),
+        "chapter II is up to two targets and should not tap a third creature"
+    );
+    assert!(
+        !game.is_tapped(alice_creature),
+        "chapter II should only affect the two targets chosen by the decision maker"
+    );
+    assert_eq!(
+        game.counter_count(bob_first, crate::object::CounterType::Stun),
+        1,
+        "chapter II should put a stun counter on the first tapped target"
+    );
+    assert_eq!(
+        game.counter_count(bob_second, crate::object::CounterType::Stun),
+        1,
+        "chapter II should put a stun counter on the second tapped target"
+    );
+    assert_eq!(
+        game.counter_count(bob_third, crate::object::CounterType::Stun),
+        0,
+        "chapter II should not put a stun counter on an unchosen creature"
+    );
+
+    game.tap(alice_creature);
+    add_lore_counter_and_check_chapters(&mut game, scroll_id, &mut trigger_queue);
+    put_triggers_on_stack_with_dm(&mut game, &mut trigger_queue, &mut dm)
+        .expect("Scroll of Isildur chapter III should go on the stack");
+    resolve_stack_entry_with_dm_and_triggers(&mut game, &mut dm, &mut trigger_queue)
+        .expect("Scroll of Isildur chapter III should resolve");
+
+    assert_eq!(
+        game.player(alice).expect("Alice exists").hand.len(),
+        initial_hand_size + 2,
+        "chapter III should draw for tapped creatures the target opponent controls, not Alice's tapped creature"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 fn the_aesir_escape_valhalla_definition() -> crate::cards::CardDefinition {
     CardDefinitionBuilder::new(CardId::from_raw(992_001), "The Aesir Escape Valhalla")
         .mana_cost(ManaCost::from_pips(vec![


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Scroll of Isildur
Initial parse error:
```
unsupported control duration; oracle-only fallback also failed: unsupported control duration
```

Current worker: i-0deb8ac520120ec4c
Branch: codex/aws-card-fix-scroll-of-isildur
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260604T121212Z-controller-dev-loop-wave0021
