### PR TITLE
Fix Ironsmith parse failure: Creeping Peeper

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/abilities.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/abilities.rs
@@ -774,11 +774,39 @@ pub(crate) fn is_spend_mana_restriction_sentence_lexed(tokens: &[OwnedLexToken])
 pub(crate) fn parse_mana_usage_restriction_sentence_lexed(
     tokens: &[OwnedLexToken],
 ) -> Option<ManaUsageRestriction> {
-    parse_cast_or_activate_source_mana_usage_restriction_sentence_lexed(tokens)
+    parse_cast_or_unlock_or_turn_face_up_mana_usage_restriction_sentence_lexed(tokens)
+        .or_else(|| parse_cast_or_activate_source_mana_usage_restriction_sentence_lexed(tokens))
         .or_else(|| parse_legacy_mana_usage_restriction_sentence_lexed(tokens))
         .or_else(|| parse_activate_ability_mana_usage_restriction_sentence_lexed(tokens))
         .or_else(|| parse_cant_be_spent_to_cast_sentence_lexed(tokens))
         .or_else(|| parse_filter_mana_usage_restriction_sentence_lexed(tokens))
+}
+
+fn parse_cast_or_unlock_or_turn_face_up_mana_usage_restriction_sentence_lexed(
+    tokens: &[OwnedLexToken],
+) -> Option<ManaUsageRestriction> {
+    const UNLOCK_DOOR_PHRASES: &[&[&str]] = &[&["unlock", "a", "door"]];
+    const TURN_FACE_UP_PHRASES: &[&[&str]] = &[
+        &["or", "turn", "a", "permanent", "face", "up"],
+        &["or", "turn", "permanents", "face", "up"],
+    ];
+    const CAST_OR_UNLOCK_OR_TURN_FACE_UP_PATTERN: LexPattern<'static> = LexPattern::new(&[
+        LexPattern::any_phrase(SPEND_MANA_CAST_PREFIXES),
+        LexPattern::object(
+            "spell_spec",
+            LexCaptureKind::UntilAnyPhrase(UNLOCK_DOOR_PHRASES),
+        ),
+        LexPattern::any_phrase(UNLOCK_DOOR_PHRASES),
+        LexPattern::any_phrase(TURN_FACE_UP_PHRASES),
+    ]);
+
+    let clause = LexedClause::new(tokens);
+    let matched = CAST_OR_UNLOCK_OR_TURN_FACE_UP_PATTERN.match_clause(clause)?;
+    let spell_clause = matched.capture_clause("spell_spec", clause)?;
+    let spell_tokens = trim_lexed_commas(spell_clause.tokens());
+    let spell_filter = parse_mana_usage_spell_filter_tokens(spell_tokens)?;
+
+    Some(ManaUsageRestriction::CastSpellOrUnlockDoorOrTurnFaceUp { spell_filter })
 }
 
 fn parse_cast_or_activate_source_mana_usage_restriction_sentence_lexed(

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -2630,6 +2630,24 @@ fn rewrite_cast_or_activate_source_mana_restriction_parses() {
 }
 
 #[test]
+fn rewrite_cast_unlock_or_turn_face_up_mana_restriction_parses() {
+    let tokens = lex_line(
+        "Spend this mana only to cast an enchantment spell, unlock a door, or turn a permanent face up.",
+        0,
+    )
+    .expect("rewrite lexer should classify cast/unlock/turn-face-up mana restriction");
+
+    match parse_mana_usage_restriction_sentence_lexed(&tokens) {
+        Some(crate::ability::ManaUsageRestriction::CastSpellOrUnlockDoorOrTurnFaceUp {
+            spell_filter,
+        }) => {
+            assert_eq!(spell_filter.card_types, vec![CardType::Enchantment]);
+        }
+        other => panic!("expected cast/unlock/turn-face-up restriction, got {other:?}"),
+    }
+}
+
+#[test]
 fn rewrite_cant_be_spent_mana_restriction_parses_as_positive_filter() {
     let tokens = lex_line("This mana can't be spent to cast nonartifact spells.", 0)
         .expect("rewrite lexer should classify negative mana restriction");

--- a/crates/ironsmith-core/src/ability_model.rs
+++ b/crates/ironsmith-core/src/ability_model.rs
@@ -42,6 +42,9 @@ pub enum ManaUsageRestriction {
         spell_filter: ObjectFilter,
         ability_source_filter: ObjectFilter,
     },
+    CastSpellOrUnlockDoorOrTurnFaceUp {
+        spell_filter: ObjectFilter,
+    },
     ActivateAbility,
 }
 

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -57103,6 +57103,178 @@ fn jasmine_dragon_tea_shop_strict_parser_compiled_text_and_model_regression() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn creeping_peeper_strict_parser_compiled_text_and_model_regression() {
+    assert_oracle_card_parses_strict("Creeping Peeper");
+    let def = parse_oracle_card_definition("Creeping Peeper");
+    let rendered = canonical_compiled_lines(&def).join(" ");
+    let rendered_lower = rendered.to_ascii_lowercase();
+
+    assert!(
+        rendered_lower.contains(
+            "spend this mana only to cast an enchantment spell, unlock a door, or turn a permanent face up",
+        ),
+        "expected Creeping Peeper compiled text to preserve the full restricted-mana clause, got {rendered}"
+    );
+
+    let mana_activated = def
+        .abilities
+        .iter()
+        .find_map(|ability| {
+            let AbilityKind::Activated(activated) = &ability.kind else {
+                return None;
+            };
+            activated
+                .mana_usage_restrictions
+                .iter()
+                .any(|restriction| {
+                    matches!(
+                        restriction,
+                        crate::ability::ManaUsageRestriction::CastSpellOrUnlockDoorOrTurnFaceUp {
+                            ..
+                        }
+                    )
+                })
+                .then_some(activated)
+        })
+        .expect("Creeping Peeper should have a restricted mana ability");
+
+    let has_enchantment_unlock_turn_up_restriction = mana_activated
+        .mana_usage_restrictions
+        .iter()
+        .any(|restriction| {
+            matches!(
+                restriction,
+                crate::ability::ManaUsageRestriction::CastSpellOrUnlockDoorOrTurnFaceUp {
+                    spell_filter,
+                } if spell_filter.card_types == vec![CardType::Enchantment]
+            )
+        });
+    assert!(
+        has_enchantment_unlock_turn_up_restriction,
+        "Creeping Peeper mana should be restricted to enchantment spells, unlocking doors, or turning permanents face up"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn creeping_peeper_restricted_mana_runtime_branches() {
+    let def = parse_oracle_card_definition("Creeping Peeper");
+    let restriction = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Activated(activated) => activated
+                .mana_usage_restrictions
+                .iter()
+                .find(|restriction| {
+                    matches!(
+                        restriction,
+                        crate::ability::ManaUsageRestriction::CastSpellOrUnlockDoorOrTurnFaceUp {
+                            ..
+                        }
+                    )
+                })
+                .cloned(),
+            _ => None,
+        })
+        .expect("Creeping Peeper should carry its special mana usage restriction");
+
+    let alice = PlayerId::from_index(0);
+    let mut game = crate::game_state::GameState::new(vec!["Alice".to_string()], 20);
+    let peeper_id = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    game.player_mut(alice)
+        .expect("alice exists")
+        .add_restricted_mana(crate::ability::RestrictedManaUnit {
+            symbol: ManaSymbol::Blue,
+            source: peeper_id,
+            source_chosen_creature_type: None,
+            restrictions: vec![restriction.clone()],
+        });
+
+    let blue_cost = ManaCost::from_pips(vec![vec![ManaSymbol::Blue]]);
+    let enchantment_spell = CardDefinitionBuilder::new(CardId::new(), "Enchantment Spell")
+        .card_types(vec![CardType::Enchantment])
+        .build();
+    let enchantment_spell_id =
+        game.create_object_from_definition(&enchantment_spell, alice, Zone::Stack);
+    assert!(
+        game.can_pay_mana_cost_with_reason(
+            alice,
+            Some(enchantment_spell_id),
+            &blue_cost,
+            0,
+            crate::costs::PaymentReason::CastSpell,
+        ),
+        "Creeping Peeper mana should pay for enchantment spells"
+    );
+
+    let instant_spell = CardDefinitionBuilder::new(CardId::new(), "Instant Spell")
+        .card_types(vec![CardType::Instant])
+        .build();
+    let instant_spell_id = game.create_object_from_definition(&instant_spell, alice, Zone::Stack);
+    assert!(
+        !game.can_pay_mana_cost_with_reason(
+            alice,
+            Some(instant_spell_id),
+            &blue_cost,
+            0,
+            crate::costs::PaymentReason::CastSpell,
+        ),
+        "Creeping Peeper mana should not pay for non-enchantment spells"
+    );
+
+    let ability_source = CardDefinitionBuilder::new(CardId::new(), "Ordinary Ability Source")
+        .card_types(vec![CardType::Artifact])
+        .parse_text("{U}: You gain 1 life.")
+        .expect("ordinary ability source should parse");
+    let ability_source_id =
+        game.create_object_from_definition(&ability_source, alice, Zone::Battlefield);
+    assert!(
+        !game.can_pay_mana_cost_with_reason(
+            alice,
+            Some(ability_source_id),
+            &blue_cost,
+            0,
+            crate::costs::PaymentReason::ActivateAbility,
+        ),
+        "Creeping Peeper mana should not pay for unrelated activated abilities"
+    );
+
+    let face_up_probe = CardDefinitionBuilder::new(CardId::new(), "Face-Up Probe")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    let face_up_probe_id =
+        game.create_object_from_definition(&face_up_probe, alice, Zone::Battlefield);
+    game.object_mut(face_up_probe_id)
+        .expect("face-up probe should exist")
+        .abilities
+        .push(Ability::static_ability(
+            crate::static_abilities::StaticAbility::morph(crate::cost::TotalCost::mana(
+                blue_cost.clone(),
+            )),
+        ));
+    game.set_face_down(face_up_probe_id);
+
+    let mut dm = crate::decision::SelectFirstDecisionMaker;
+    crate::special_actions::perform(
+        crate::special_actions::SpecialAction::TurnFaceUp {
+            permanent_id: face_up_probe_id,
+            method: crate::special_actions::TurnFaceUpMethod::TurnFaceUpAbility,
+        },
+        &mut game,
+        alice,
+        &mut dm,
+    )
+    .expect("Creeping Peeper mana should pay to turn a permanent face up");
+    assert!(
+        !game.is_face_down(face_up_probe_id),
+        "turn-face-up special action should leave the permanent face up"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn jasmine_dragon_tea_shop_token_activation_creates_white_ally() {
     let def = parse_oracle_card_definition("Jasmine Dragon Tea Shop");
     let token_activated = def

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -57266,7 +57266,59 @@ fn creeping_peeper_restricted_mana_runtime_branches() {
         "Creeping Peeper mana should not pay ordinary activated costs, even from a Room source"
     );
 
+    let ordinary_room = CardDefinitionBuilder::new(CardId::new(), "Ordinary Room Ability Probe")
+        .card_types(vec![CardType::Enchantment])
+        .subtypes(vec![Subtype::Room])
+        .parse_text("{U}: You gain 1 life.")
+        .expect("ordinary Room activated ability should parse");
+    let ordinary_room_id =
+        game.create_object_from_definition(&ordinary_room, alice, Zone::Battlefield);
+    game.turn.phase = crate::game_state::Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+    let ordinary_room_ability_index = game
+        .object(ordinary_room_id)
+        .expect("ordinary Room should exist")
+        .abilities
+        .iter()
+        .position(|ability| matches!(ability.kind, AbilityKind::Activated(_)))
+        .expect("ordinary Room should have an activated ability");
+    let ordinary_room_action = crate::decision::compute_legal_actions(&game, alice)
+        .into_iter()
+        .find(|action| {
+            matches!(
+                action,
+                crate::decision::LegalAction::ActivateAbility { source, ability_index }
+                    if *source == ordinary_room_id && *ability_index == ordinary_room_ability_index
+            )
+        })
+        .expect("ordinary Room activation should enter the real activation path");
     let mut dm = crate::decision::SelectFirstDecisionMaker;
+    let mut trigger_queue = crate::triggers::TriggerQueue::new();
+    let mut state = crate::game_loop::PriorityLoopState::new(game.players_in_game());
+    let room_activation = crate::game_loop::apply_priority_response_with_dm(
+        &mut game,
+        &mut trigger_queue,
+        &mut state,
+        &crate::PriorityResponse::PriorityAction(ordinary_room_action),
+        &mut dm,
+    );
+    assert!(
+        room_activation.is_err(),
+        "Creeping Peeper mana must not be offered for ordinary activated abilities on Room permanents"
+    );
+    assert!(
+        game.can_pay_mana_cost_with_reason(
+            alice,
+            Some(room_id),
+            &blue_cost,
+            0,
+            crate::costs::PaymentReason::UnlockDoor,
+        ),
+        "failed Room activation should leave Creeping Peeper mana available for a real unlock-door payment"
+    );
+
     crate::special_actions::pay_total_cost_with_choice(
         &mut game,
         alice,

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -57240,6 +57240,52 @@ fn creeping_peeper_restricted_mana_runtime_branches() {
         "Creeping Peeper mana should not pay for unrelated activated abilities"
     );
 
+    let room = CardDefinitionBuilder::new(CardId::new(), "Locked Door Probe")
+        .card_types(vec![CardType::Enchantment])
+        .subtypes(vec![Subtype::Room])
+        .build();
+    let room_id = game.create_object_from_definition(&room, alice, Zone::Battlefield);
+    assert!(
+        game.can_pay_mana_cost_with_reason(
+            alice,
+            Some(room_id),
+            &blue_cost,
+            0,
+            crate::costs::PaymentReason::UnlockDoor,
+        ),
+        "Creeping Peeper mana should pay to unlock a Room door"
+    );
+    assert!(
+        !game.can_pay_mana_cost_with_reason(
+            alice,
+            Some(room_id),
+            &blue_cost,
+            0,
+            crate::costs::PaymentReason::ActivateAbility,
+        ),
+        "Creeping Peeper mana should not pay ordinary activated costs, even from a Room source"
+    );
+
+    let mut dm = crate::decision::SelectFirstDecisionMaker;
+    crate::special_actions::pay_total_cost_with_choice(
+        &mut game,
+        alice,
+        room_id,
+        &crate::cost::TotalCost::mana(blue_cost.clone()),
+        crate::costs::PaymentReason::UnlockDoor,
+        &mut dm,
+    )
+    .expect("Creeping Peeper mana should be spendable on the unlock-door payment path");
+
+    game.player_mut(alice)
+        .expect("alice exists")
+        .add_restricted_mana(crate::ability::RestrictedManaUnit {
+            symbol: ManaSymbol::Blue,
+            source: peeper_id,
+            source_chosen_creature_type: None,
+            restrictions: vec![restriction],
+        });
+
     let face_up_probe = CardDefinitionBuilder::new(CardId::new(), "Face-Up Probe")
         .card_types(vec![CardType::Creature])
         .power_toughness(PowerToughness::fixed(2, 2))
@@ -57256,7 +57302,6 @@ fn creeping_peeper_restricted_mana_runtime_branches() {
         ));
     game.set_face_down(face_up_probe_id);
 
-    let mut dm = crate::decision::SelectFirstDecisionMaker;
     crate::special_actions::perform(
         crate::special_actions::SpecialAction::TurnFaceUp {
             permanent_id: face_up_probe_id,

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -57240,10 +57240,42 @@ fn creeping_peeper_restricted_mana_runtime_branches() {
         "Creeping Peeper mana should not pay for unrelated activated abilities"
     );
 
-    let room = CardDefinitionBuilder::new(CardId::new(), "Locked Door Probe")
+    let non_lockable_room = CardDefinitionBuilder::new(CardId::new(), "Non-Lockable Room Probe")
         .card_types(vec![CardType::Enchantment])
         .subtypes(vec![Subtype::Room])
         .build();
+    let non_lockable_room_id =
+        game.create_object_from_definition(&non_lockable_room, alice, Zone::Battlefield);
+    assert!(
+        !game.can_pay_mana_cost_with_reason(
+            alice,
+            Some(non_lockable_room_id),
+            &blue_cost,
+            0,
+            crate::costs::PaymentReason::UnlockDoor,
+        ),
+        "Creeping Peeper mana should not pay unlock-door costs for a Room with no locked door"
+    );
+
+    let room_front_id = CardId::from_raw(571_600_001);
+    let room_back_id = CardId::from_raw(571_600_002);
+    let room = CardDefinitionBuilder::new(room_front_id, "Locked Door Probe")
+        .card_types(vec![CardType::Enchantment])
+        .subtypes(vec![Subtype::Room])
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(1)]]))
+        .other_face(room_back_id)
+        .other_face_name("Other Locked Door Probe")
+        .linked_face_layout(crate::card::LinkedFaceLayout::Split)
+        .build();
+    let other_room_door = CardDefinitionBuilder::new(room_back_id, "Other Locked Door Probe")
+        .card_types(vec![CardType::Enchantment])
+        .subtypes(vec![Subtype::Room])
+        .mana_cost(blue_cost.clone())
+        .other_face(room_front_id)
+        .other_face_name("Locked Door Probe")
+        .linked_face_layout(crate::card::LinkedFaceLayout::Split)
+        .build();
+    game.register_linked_face_definition(&other_room_door);
     let room_id = game.create_object_from_definition(&room, alice, Zone::Battlefield);
     assert!(
         game.can_pay_mana_cost_with_reason(
@@ -57253,7 +57285,7 @@ fn creeping_peeper_restricted_mana_runtime_branches() {
             0,
             crate::costs::PaymentReason::UnlockDoor,
         ),
-        "Creeping Peeper mana should pay to unlock a Room door"
+        "Creeping Peeper mana should pay to unlock a genuinely locked Room door"
     );
     assert!(
         !game.can_pay_mana_cost_with_reason(
@@ -57319,15 +57351,35 @@ fn creeping_peeper_restricted_mana_runtime_branches() {
         "failed Room activation should leave Creeping Peeper mana available for a real unlock-door payment"
     );
 
-    crate::special_actions::pay_total_cost_with_choice(
+    let unlock_room_action = crate::decision::compute_legal_actions(&game, alice)
+        .into_iter()
+        .find(|action| {
+            matches!(
+                action,
+                crate::decision::LegalAction::SpecialAction(
+                    crate::special_actions::SpecialAction::UnlockRoomDoor { room_id: action_room }
+                ) if *action_room == room_id
+            )
+        })
+        .expect("locked Room should expose a real unlock-door special action");
+    crate::game_loop::apply_priority_response_with_dm(
         &mut game,
-        alice,
-        room_id,
-        &crate::cost::TotalCost::mana(blue_cost.clone()),
-        crate::costs::PaymentReason::UnlockDoor,
+        &mut trigger_queue,
+        &mut state,
+        &crate::PriorityResponse::PriorityAction(unlock_room_action),
         &mut dm,
     )
-    .expect("Creeping Peeper mana should be spendable on the unlock-door payment path");
+    .expect("Creeping Peeper mana should be spendable through the real unlock-door action path");
+    assert!(
+        !game.can_pay_mana_cost_with_reason(
+            alice,
+            Some(room_id),
+            &blue_cost,
+            0,
+            crate::costs::PaymentReason::UnlockDoor,
+        ),
+        "fully unlocked Rooms should no longer accept unlock-door restricted mana"
+    );
 
     game.player_mut(alice)
         .expect("alice exists")

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -39044,6 +39044,15 @@ fn describe_mana_usage_restriction(
                 "Spend this mana only to cast {spell_text} or activate an ability of {source_text}"
             ))
         }
+        crate::ability::ManaUsageRestriction::CastSpellOrUnlockDoorOrTurnFaceUp {
+            spell_filter,
+        } => {
+            let spell_text =
+                describe_mana_usage_spell_filter_target_with_options(spell_filter, false)?;
+            Some(format!(
+                "Spend this mana only to cast {spell_text}, unlock a door, or turn a permanent face up"
+            ))
+        }
         crate::ability::ManaUsageRestriction::ActivateAbility => {
             Some("Spend this mana only to activate abilities".to_string())
         }

--- a/crates/ironsmith-runtime/src/costs/payer_trait.rs
+++ b/crates/ironsmith-runtime/src/costs/payer_trait.rs
@@ -21,6 +21,8 @@ pub enum PaymentReason {
     ActivateAbility,
     /// Activating a mana ability.
     ActivateManaAbility,
+    /// Paying the cost to unlock a locked Room door.
+    UnlockDoor,
     /// Turning a face-down permanent face up.
     TurnFaceUp,
     /// Paying a cost during effect or triggered-ability resolution.

--- a/crates/ironsmith-runtime/src/decision/io.rs
+++ b/crates/ironsmith-runtime/src/decision/io.rs
@@ -2695,6 +2695,13 @@ pub(crate) fn format_action_short(game: &GameState, action: &LegalAction) -> Str
             crate::special_actions::SpecialAction::ActivateManaAbility { .. } => {
                 "Activate mana ability".to_string()
             }
+            crate::special_actions::SpecialAction::UnlockRoomDoor { room_id } => {
+                let name = game.object(*room_id).map(|o| o.name.as_str()).unwrap_or("?");
+                let cost_prefix = crate::special_actions::room_unlock_cost_display(game, *room_id)
+                    .map(|cost| format!("{cost}: "))
+                    .unwrap_or_default();
+                format!("{cost_prefix}Unlock a door. ({name})")
+            }
         },
     }
 }

--- a/crates/ironsmith-runtime/src/decision/legal_actions.rs
+++ b/crates/ironsmith-runtime/src/decision/legal_actions.rs
@@ -795,6 +795,10 @@ fn add_battlefield_actions(
                 }
             }
         }
+        let unlock_action = SpecialAction::UnlockRoomDoor { room_id: perm_id };
+        if can_perform_check(&unlock_action, game, player).is_ok() {
+            actions.push(LegalAction::SpecialAction(unlock_action));
+        }
     }
 
     let simple_mana_analysis = view.simple_battlefield_mana_analysis(player);

--- a/crates/ironsmith-runtime/src/decision/legal_actions.rs
+++ b/crates/ironsmith-runtime/src/decision/legal_actions.rs
@@ -1470,7 +1470,7 @@ fn activation_precheck_with_view(
             return None;
         }
 
-        let reason = game.activation_payment_reason(source);
+        let reason = crate::costs::PaymentReason::ActivateAbility;
         let costs = activated.mana_cost.costs();
         if !activation_printed_costs_precheck_with_view(
             game,
@@ -1540,7 +1540,7 @@ fn activation_precheck_with_view(
         return None;
     }
 
-    let reason = game.activation_payment_reason(source);
+    let reason = crate::costs::PaymentReason::ActivateAbility;
     let costs = activated.mana_cost.costs();
     if !activation_printed_costs_precheck_with_view(
         game,
@@ -1609,7 +1609,7 @@ fn activation_cost_is_payable_with_view(
     cost: &crate::costs::Cost,
     _view: &DerivedGameView<'_>,
 ) -> bool {
-    let reason = game.activation_payment_reason(source);
+    let reason = crate::costs::PaymentReason::ActivateAbility;
     if game
         .validate_cost_for_payment_reason(controller, source, cost, reason)
         .is_err()

--- a/crates/ironsmith-runtime/src/decision/legal_actions.rs
+++ b/crates/ironsmith-runtime/src/decision/legal_actions.rs
@@ -1470,13 +1470,14 @@ fn activation_precheck_with_view(
             return None;
         }
 
+        let reason = game.activation_payment_reason(source);
         let costs = activated.mana_cost.costs();
         if !activation_printed_costs_precheck_with_view(
             game,
             controller,
             source,
             costs,
-            crate::costs::PaymentReason::ActivateAbility,
+            reason,
             view,
         ) {
             if let Some(perf_ctx) = perf_ctx {
@@ -1539,13 +1540,14 @@ fn activation_precheck_with_view(
         return None;
     }
 
+    let reason = game.activation_payment_reason(source);
     let costs = activated.mana_cost.costs();
     if !activation_printed_costs_precheck_with_view(
         game,
         controller,
         source,
         costs,
-        crate::costs::PaymentReason::ActivateAbility,
+        reason,
         view,
     ) {
         if let Some(perf_ctx) = perf_ctx {
@@ -1607,7 +1609,7 @@ fn activation_cost_is_payable_with_view(
     cost: &crate::costs::Cost,
     _view: &DerivedGameView<'_>,
 ) -> bool {
-    let reason = crate::costs::PaymentReason::ActivateAbility;
+    let reason = game.activation_payment_reason(source);
     if game
         .validate_cost_for_payment_reason(controller, source, cost, reason)
         .is_err()

--- a/crates/ironsmith-runtime/src/game_loop/priority_apply.rs
+++ b/crates/ironsmith-runtime/src/game_loop/priority_apply.rs
@@ -792,7 +792,7 @@ pub fn apply_priority_response_with_dm(
             let cost = crate::decision::calculate_effective_activation_total_cost(
                 game, player, *source, &base_cost,
             );
-            let payment_reason = game.activation_payment_reason(*source);
+            let payment_reason = crate::costs::PaymentReason::ActivateAbility;
             let activation_provenance =
                 game.provenance_graph_mut()
                     .alloc_root(ProvenanceNodeKind::EffectExecution {

--- a/crates/ironsmith-runtime/src/game_loop/priority_apply.rs
+++ b/crates/ironsmith-runtime/src/game_loop/priority_apply.rs
@@ -792,6 +792,7 @@ pub fn apply_priority_response_with_dm(
             let cost = crate::decision::calculate_effective_activation_total_cost(
                 game, player, *source, &base_cost,
             );
+            let payment_reason = game.activation_payment_reason(*source);
             let activation_provenance =
                 game.provenance_graph_mut()
                     .alloc_root(ProvenanceNodeKind::EffectExecution {
@@ -824,7 +825,7 @@ pub fn apply_priority_response_with_dm(
                         player,
                         Some(*source),
                         &resolved,
-                        crate::costs::PaymentReason::ActivateAbility,
+                        payment_reason,
                     ));
                     continue;
                 }
@@ -890,6 +891,7 @@ pub fn apply_priority_response_with_dm(
                     effects,
                     target_requirements,
                     mana_cost_to_pay,
+                    payment_reason,
                     payment_trace,
                     remaining_cost_steps,
                     std::collections::HashMap::new(),

--- a/crates/ironsmith-runtime/src/game_loop/priority_cast.rs
+++ b/crates/ironsmith-runtime/src/game_loop/priority_cast.rs
@@ -1805,6 +1805,7 @@ pub(super) fn continue_spell_cast_mana_payment(
         &mana_spend_policy,
         allow_black_life,
         Some(source),
+        crate::costs::PaymentReason::CastSpell,
         &mut *decision_maker,
     );
 
@@ -1823,6 +1824,7 @@ pub(super) fn continue_spell_cast_mana_payment(
             trigger_queue,
             player_id,
             Some(source),
+            crate::costs::PaymentReason::CastSpell,
             &pip,
             &mana_spend_policy,
             &action,
@@ -3350,6 +3352,7 @@ pub(super) fn continue_activation(
                 &mana_spend_policy,
                 allow_black_life,
                 Some(source),
+                pending.payment_reason,
                 &mut *decision_maker,
             );
 
@@ -3368,6 +3371,7 @@ pub(super) fn continue_activation(
                     trigger_queue,
                     player_id,
                     Some(source),
+                    pending.payment_reason,
                     &pip,
                     &mana_spend_policy,
                     &action,

--- a/crates/ironsmith-runtime/src/game_loop/priority_cast.rs
+++ b/crates/ironsmith-runtime/src/game_loop/priority_cast.rs
@@ -2954,6 +2954,7 @@ pub(super) fn continue_activation_cost_payment(
 
             let mut cost_ctx =
                 CostContext::new(pending.source, pending.activator, &mut *decision_maker)
+                    .with_reason(pending.payment_reason)
                     .with_provenance(pending.provenance);
             cost_ctx.tagged_objects = pending.tagged_objects.clone();
             cost_ctx.x_value = pending.x_value.and_then(|x| u32::try_from(x).ok());
@@ -3016,7 +3017,7 @@ pub(super) fn continue_activation_cost_payment(
                 pending.activator,
                 pending.source,
                 filter,
-                crate::costs::PaymentReason::ActivateAbility,
+                pending.payment_reason,
             );
 
             if legal_targets.is_empty() {
@@ -3123,7 +3124,7 @@ pub(super) fn continue_activation(
                 let allow_black_life = game.player_can_pay_black_with_life_for_reason(
                     pending.activator,
                     Some(pending.source),
-                    crate::costs::PaymentReason::ActivateAbility,
+                    pending.payment_reason,
                 );
                 compute_potential_mana(game, pending.activator)
                     .max_x_for_cost_with_mana_spend_policy_and_black_life(
@@ -3337,7 +3338,7 @@ pub(super) fn continue_activation(
             let allow_black_life = game.player_can_pay_black_with_life_for_reason(
                 player_id,
                 Some(source),
-                crate::costs::PaymentReason::ActivateAbility,
+                pending.payment_reason,
             );
             let display_pip =
                 current_display_pip(&pending.display_mana_pips, &pending.remaining_mana_pips);

--- a/crates/ironsmith-runtime/src/game_loop/priority_mana.rs
+++ b/crates/ironsmith-runtime/src/game_loop/priority_mana.rs
@@ -857,6 +857,7 @@ pub(super) fn payment_source_matches_restriction(
         } => {
             cast_spell_filter_matches_payment_source(game, unit, spell_filter, Some(source_obj.id))
                 || matches_allowed_turn_face_up_payment_source(game, source_obj.id)
+                || matches_allowed_unlock_door_payment_source(game, source_obj.id)
         }
         crate::ability::ManaUsageRestriction::ActivateAbility => source_obj.zone != Zone::Stack,
     }
@@ -867,6 +868,10 @@ fn matches_allowed_turn_face_up_payment_source(game: &GameState, source_id: Obje
         return false;
     };
     source_obj.zone == Zone::Battlefield && game.is_face_down(source_id)
+}
+
+fn matches_allowed_unlock_door_payment_source(game: &GameState, source_id: ObjectId) -> bool {
+    game.object_is_room_unlock_payment_source(source_id)
 }
 
 pub(super) fn restricted_unit_is_payable(
@@ -2187,7 +2192,7 @@ pub(super) fn apply_mana_payment_response_activation(
                 Some(pending.source),
                 cost,
                 x_value,
-                crate::costs::PaymentReason::ActivateAbility,
+                pending.payment_reason,
             )
         {
             return Err(GameLoopError::InvalidState(
@@ -2203,7 +2208,7 @@ pub(super) fn apply_mana_payment_response_activation(
                 Some(pending.source),
                 cost,
                 x_value,
-                crate::costs::PaymentReason::ActivateAbility,
+                pending.payment_reason,
             ) {
                 return Err(GameLoopError::InvalidState(
                     "Cannot pay mana cost - insufficient mana".to_string(),
@@ -2242,7 +2247,7 @@ pub(super) fn apply_pip_payment_response_activation(
     let allow_black_life = game.player_can_pay_black_with_life_for_reason(
         pending.activator,
         Some(pending.source),
-        crate::costs::PaymentReason::ActivateAbility,
+        pending.payment_reason,
     );
     let options = build_pip_payment_options(
         game,
@@ -2533,7 +2538,7 @@ pub(super) fn apply_sacrifice_target_response(
                 pending.activator,
                 pending.source,
                 &filter,
-                crate::costs::PaymentReason::ActivateAbility,
+                pending.payment_reason,
             );
             if !legal_targets.contains(&target_id) {
                 return Err(GameLoopError::InvalidState(
@@ -2551,7 +2556,7 @@ pub(super) fn apply_sacrifice_target_response(
                 &cost,
                 pending.source,
                 pending.activator,
-                crate::costs::PaymentReason::ActivateAbility,
+                pending.payment_reason,
                 pending.provenance,
                 target_id,
                 Some(&choice_tag),
@@ -2599,7 +2604,7 @@ pub(super) fn apply_sacrifice_target_response(
                         &cost,
                         pending.source,
                         pending.activator,
-                        crate::costs::PaymentReason::ActivateAbility,
+                        pending.payment_reason,
                         pending.provenance,
                         target_id,
                         None,
@@ -2629,7 +2634,7 @@ pub(super) fn apply_sacrifice_target_response(
                         &cost,
                         pending.source,
                         pending.activator,
-                        crate::costs::PaymentReason::ActivateAbility,
+                        pending.payment_reason,
                         pending.provenance,
                         target_id,
                         None,
@@ -2655,7 +2660,7 @@ pub(super) fn apply_sacrifice_target_response(
                         &cost,
                         pending.source,
                         pending.activator,
-                        crate::costs::PaymentReason::ActivateAbility,
+                        pending.payment_reason,
                         pending.provenance,
                         target_id,
                         None,
@@ -2690,7 +2695,7 @@ pub(super) fn apply_sacrifice_target_response(
                         &cost,
                         pending.source,
                         pending.activator,
-                        crate::costs::PaymentReason::ActivateAbility,
+                        pending.payment_reason,
                         pending.provenance,
                         target_id,
                         Some(&choice_tag),
@@ -2724,7 +2729,7 @@ pub(super) fn apply_sacrifice_target_response(
                         &cost,
                         pending.source,
                         pending.activator,
-                        crate::costs::PaymentReason::ActivateAbility,
+                        pending.payment_reason,
                         pending.provenance,
                         target_id,
                         None,
@@ -2756,7 +2761,7 @@ pub(super) fn apply_sacrifice_target_response(
                         &cost,
                         pending.source,
                         pending.activator,
-                        crate::costs::PaymentReason::ActivateAbility,
+                        pending.payment_reason,
                         pending.provenance,
                         target_id,
                         choice_tag.as_ref(),
@@ -2791,7 +2796,7 @@ pub(super) fn apply_sacrifice_target_response(
                         &cost,
                         pending.source,
                         pending.activator,
-                        crate::costs::PaymentReason::ActivateAbility,
+                        pending.payment_reason,
                         pending.provenance,
                         target_id,
                         Some(&choice_tag),

--- a/crates/ironsmith-runtime/src/game_loop/priority_mana.rs
+++ b/crates/ironsmith-runtime/src/game_loop/priority_mana.rs
@@ -722,6 +722,7 @@ fn restriction_requires_matching_spell(restriction: &crate::ability::ManaUsageRe
         crate::ability::ManaUsageRestriction::CastSpellOrActivateAbilitySourceMatching {
             ..
         } => true,
+        crate::ability::ManaUsageRestriction::CastSpellOrUnlockDoorOrTurnFaceUp { .. } => true,
         crate::ability::ManaUsageRestriction::ActivateAbility => true,
     }
 }
@@ -773,6 +774,7 @@ fn restriction_bonus_applies_to_payment_source(
         crate::ability::ManaUsageRestriction::CastSpellOrActivateAbilitySourceMatching {
             ..
         } => false,
+        crate::ability::ManaUsageRestriction::CastSpellOrUnlockDoorOrTurnFaceUp { .. } => false,
         crate::ability::ManaUsageRestriction::ActivateAbility => false,
     }
 }
@@ -850,8 +852,21 @@ pub(super) fn payment_source_matches_restriction(
                     Some(source_obj.id),
                 )
         }
+        crate::ability::ManaUsageRestriction::CastSpellOrUnlockDoorOrTurnFaceUp {
+            spell_filter,
+        } => {
+            cast_spell_filter_matches_payment_source(game, unit, spell_filter, Some(source_obj.id))
+                || matches_allowed_turn_face_up_payment_source(game, source_obj.id)
+        }
         crate::ability::ManaUsageRestriction::ActivateAbility => source_obj.zone != Zone::Stack,
     }
+}
+
+fn matches_allowed_turn_face_up_payment_source(game: &GameState, source_id: ObjectId) -> bool {
+    let Some(source_obj) = game.object(source_id) else {
+        return false;
+    };
+    source_obj.zone == Zone::Battlefield && game.is_face_down(source_id)
 }
 
 pub(super) fn restricted_unit_is_payable(
@@ -992,6 +1007,9 @@ pub(super) fn apply_spent_mana_bonuses(
             crate::ability::ManaUsageRestriction::CastSpellOrActivateAbilitySourceMatching {
                 ..
             } => continue,
+            crate::ability::ManaUsageRestriction::CastSpellOrUnlockDoorOrTurnFaceUp { .. } => {
+                continue;
+            }
             crate::ability::ManaUsageRestriction::ActivateAbility => continue,
         };
 

--- a/crates/ironsmith-runtime/src/game_loop/priority_mana.rs
+++ b/crates/ironsmith-runtime/src/game_loop/priority_mana.rs
@@ -244,6 +244,7 @@ pub(super) fn build_pip_payment_options(
     mana_spend_policy: &crate::player::ManaSpendPolicy,
     allow_black_life: bool,
     source_for_pip_alternatives: Option<ObjectId>,
+    payment_reason: crate::costs::PaymentReason,
     decision_maker: &mut impl DecisionMaker,
 ) -> Vec<ManaPipPaymentOption> {
     use crate::mana::ManaSymbol;
@@ -264,6 +265,7 @@ pub(super) fn build_pip_payment_options(
                     player,
                     ManaSymbol::White,
                     source_for_pip_alternatives,
+                    payment_reason,
                     mana_spend_policy,
                     &mut options,
                     &mut index,
@@ -276,6 +278,7 @@ pub(super) fn build_pip_payment_options(
                     player,
                     ManaSymbol::Blue,
                     source_for_pip_alternatives,
+                    payment_reason,
                     mana_spend_policy,
                     &mut options,
                     &mut index,
@@ -288,6 +291,7 @@ pub(super) fn build_pip_payment_options(
                     player,
                     ManaSymbol::Black,
                     source_for_pip_alternatives,
+                    payment_reason,
                     mana_spend_policy,
                     &mut options,
                     &mut index,
@@ -300,6 +304,7 @@ pub(super) fn build_pip_payment_options(
                     player,
                     ManaSymbol::Red,
                     source_for_pip_alternatives,
+                    payment_reason,
                     mana_spend_policy,
                     &mut options,
                     &mut index,
@@ -312,6 +317,7 @@ pub(super) fn build_pip_payment_options(
                     player,
                     ManaSymbol::Green,
                     source_for_pip_alternatives,
+                    payment_reason,
                     mana_spend_policy,
                     &mut options,
                     &mut index,
@@ -324,6 +330,7 @@ pub(super) fn build_pip_payment_options(
                     player,
                     ManaSymbol::Colorless,
                     source_for_pip_alternatives,
+                    payment_reason,
                     mana_spend_policy,
                     &mut options,
                     &mut index,
@@ -336,6 +343,7 @@ pub(super) fn build_pip_payment_options(
                     game,
                     player,
                     source_for_pip_alternatives,
+                    payment_reason,
                     &mut options,
                     &mut index,
                 );
@@ -419,11 +427,12 @@ pub(super) fn build_pip_payment_options(
                 perm_id,
             );
             // Check if this ability produces mana that can pay this pip
-            if mana_ability_can_pay_pip(
+            if mana_ability_can_pay_pip_with_reason(
                 game,
                 perm_id,
                 ability_index,
                 source_for_pip_alternatives,
+                payment_reason,
                 pip,
                 &source_policy,
             ) {
@@ -526,12 +535,13 @@ pub(super) fn add_any_color_pool_options(
     game: &GameState,
     player: PlayerId,
     payment_source: Option<ObjectId>,
+    payment_reason: crate::costs::PaymentReason,
     options: &mut Vec<ManaPipPaymentOption>,
     index: &mut usize,
 ) {
     use crate::mana::ManaSymbol;
 
-    if pool_symbol_count(game, player, ManaSymbol::White, payment_source) > 0 {
+    if pool_symbol_count_with_reason(game, player, ManaSymbol::White, payment_source, payment_reason) > 0 {
         options.push(ManaPipPaymentOption {
             index: *index,
             description: "Use {W} from mana pool".to_string(),
@@ -539,7 +549,7 @@ pub(super) fn add_any_color_pool_options(
         });
         *index += 1;
     }
-    if pool_symbol_count(game, player, ManaSymbol::Blue, payment_source) > 0 {
+    if pool_symbol_count_with_reason(game, player, ManaSymbol::Blue, payment_source, payment_reason) > 0 {
         options.push(ManaPipPaymentOption {
             index: *index,
             description: "Use {U} from mana pool".to_string(),
@@ -547,7 +557,7 @@ pub(super) fn add_any_color_pool_options(
         });
         *index += 1;
     }
-    if pool_symbol_count(game, player, ManaSymbol::Black, payment_source) > 0 {
+    if pool_symbol_count_with_reason(game, player, ManaSymbol::Black, payment_source, payment_reason) > 0 {
         options.push(ManaPipPaymentOption {
             index: *index,
             description: "Use {B} from mana pool".to_string(),
@@ -555,7 +565,7 @@ pub(super) fn add_any_color_pool_options(
         });
         *index += 1;
     }
-    if pool_symbol_count(game, player, ManaSymbol::Red, payment_source) > 0 {
+    if pool_symbol_count_with_reason(game, player, ManaSymbol::Red, payment_source, payment_reason) > 0 {
         options.push(ManaPipPaymentOption {
             index: *index,
             description: "Use {R} from mana pool".to_string(),
@@ -563,7 +573,7 @@ pub(super) fn add_any_color_pool_options(
         });
         *index += 1;
     }
-    if pool_symbol_count(game, player, ManaSymbol::Green, payment_source) > 0 {
+    if pool_symbol_count_with_reason(game, player, ManaSymbol::Green, payment_source, payment_reason) > 0 {
         options.push(ManaPipPaymentOption {
             index: *index,
             description: "Use {G} from mana pool".to_string(),
@@ -571,7 +581,7 @@ pub(super) fn add_any_color_pool_options(
         });
         *index += 1;
     }
-    if pool_symbol_count(game, player, ManaSymbol::Colorless, payment_source) > 0 {
+    if pool_symbol_count_with_reason(game, player, ManaSymbol::Colorless, payment_source, payment_reason) > 0 {
         options.push(ManaPipPaymentOption {
             index: *index,
             description: "Use {C} from mana pool".to_string(),
@@ -586,6 +596,7 @@ fn add_policy_pool_options_for_required(
     player: PlayerId,
     required: crate::mana::ManaSymbol,
     payment_source: Option<ObjectId>,
+    payment_reason: crate::costs::PaymentReason,
     mana_spend_policy: &crate::player::ManaSpendPolicy,
     options: &mut Vec<ManaPipPaymentOption>,
     index: &mut usize,
@@ -603,7 +614,8 @@ fn add_policy_pool_options_for_required(
     ] {
         if added_symbols.contains(&symbol)
             || !mana_spend_policy.can_pay_symbol(symbol, required)
-            || pool_symbol_count(game, player, symbol, payment_source) == 0
+            || pool_symbol_count_with_reason(game, player, symbol, payment_source, payment_reason)
+                == 0
         {
             continue;
         }
@@ -884,11 +896,45 @@ pub(super) fn restricted_unit_is_payable(
     })
 }
 
+#[cfg(test)]
 pub(super) fn pool_symbol_count(
     game: &GameState,
     player: PlayerId,
     symbol: crate::mana::ManaSymbol,
     payment_source: Option<ObjectId>,
+) -> u32 {
+    pool_symbol_count_source_only(game, player, symbol, payment_source)
+}
+
+#[cfg(test)]
+fn pool_symbol_count_source_only(
+    game: &GameState,
+    player: PlayerId,
+    symbol: crate::mana::ManaSymbol,
+    payment_source: Option<ObjectId>,
+) -> u32 {
+    pool_symbol_count_filtered(game, player, symbol, |unit| {
+        restricted_unit_is_payable(game, unit, payment_source)
+    })
+}
+
+fn pool_symbol_count_with_reason(
+    game: &GameState,
+    player: PlayerId,
+    symbol: crate::mana::ManaSymbol,
+    payment_source: Option<ObjectId>,
+    payment_reason: crate::costs::PaymentReason,
+) -> u32 {
+    pool_symbol_count_filtered(game, player, symbol, |unit| {
+        game.restricted_mana_unit_is_payable_for_reason(unit, payment_source, payment_reason)
+    })
+}
+
+fn pool_symbol_count_filtered(
+    game: &GameState,
+    player: PlayerId,
+    symbol: crate::mana::ManaSymbol,
+    mut restricted_is_payable: impl FnMut(&crate::ability::RestrictedManaUnit) -> bool,
 ) -> u32 {
     let Some(player_obj) = game.player(player) else {
         return 0;
@@ -908,7 +954,7 @@ pub(super) fn pool_symbol_count(
         .restricted_mana
         .iter()
         .filter(|unit| unit.symbol == symbol)
-        .filter(|unit| restricted_unit_is_payable(game, unit, payment_source))
+        .filter(|unit| restricted_is_payable(unit))
         .count() as u32;
 
     total
@@ -916,11 +962,42 @@ pub(super) fn pool_symbol_count(
         .saturating_add(restricted_payable)
 }
 
+#[cfg(test)]
 pub(super) fn spend_pool_symbol(
     game: &mut GameState,
     player: PlayerId,
     symbol: crate::mana::ManaSymbol,
     payment_source: Option<ObjectId>,
+) -> Option<SpentManaInfo> {
+    spend_pool_symbol_source_only(game, player, symbol, payment_source)
+}
+
+#[cfg(test)]
+fn spend_pool_symbol_source_only(
+    game: &mut GameState,
+    player: PlayerId,
+    symbol: crate::mana::ManaSymbol,
+    payment_source: Option<ObjectId>,
+) -> Option<SpentManaInfo> {
+    spend_pool_symbol_common(game, player, symbol, payment_source, None)
+}
+
+fn spend_pool_symbol_with_reason(
+    game: &mut GameState,
+    player: PlayerId,
+    symbol: crate::mana::ManaSymbol,
+    payment_source: Option<ObjectId>,
+    payment_reason: crate::costs::PaymentReason,
+) -> Option<SpentManaInfo> {
+    spend_pool_symbol_common(game, player, symbol, payment_source, Some(payment_reason))
+}
+
+fn spend_pool_symbol_common(
+    game: &mut GameState,
+    player: PlayerId,
+    symbol: crate::mana::ManaSymbol,
+    payment_source: Option<ObjectId>,
+    payment_reason: Option<crate::costs::PaymentReason>,
 ) -> Option<SpentManaInfo> {
     let unrestricted_available = game.player(player).is_some_and(|player_obj| {
         let total = player_obj.mana_pool.amount(symbol);
@@ -938,7 +1015,16 @@ pub(super) fn spend_pool_symbol(
             .iter()
             .enumerate()
             .filter(|(_, unit)| {
-                unit.symbol == symbol && restricted_unit_is_payable(game, unit, payment_source)
+                unit.symbol == symbol
+                    && if let Some(reason) = payment_reason {
+                        game.restricted_mana_unit_is_payable_for_reason(
+                            unit,
+                            payment_source,
+                            reason,
+                        )
+                    } else {
+                        restricted_unit_is_payable(game, unit, payment_source)
+                    }
             })
             .min_by_key(|(_, unit)| restricted_unit_priority(game, unit, payment_source))
             .map(|(idx, unit)| (idx, restricted_unit_priority(game, unit, payment_source)))
@@ -1057,6 +1143,7 @@ pub(super) fn apply_spent_mana_bonuses(
 }
 
 /// Check if a mana ability can produce mana that pays the given pip.
+#[cfg(test)]
 pub(super) fn mana_ability_can_pay_pip(
     game: &GameState,
     perm_id: ObjectId,
@@ -1064,6 +1151,71 @@ pub(super) fn mana_ability_can_pay_pip(
     payment_source: Option<ObjectId>,
     pip: &[crate::mana::ManaSymbol],
     mana_spend_policy: &crate::player::ManaSpendPolicy,
+) -> bool {
+    mana_ability_can_pay_pip_source_only(
+        game,
+        perm_id,
+        ability_index,
+        payment_source,
+        pip,
+        mana_spend_policy,
+    )
+}
+
+#[cfg(test)]
+fn mana_ability_can_pay_pip_source_only(
+    game: &GameState,
+    perm_id: ObjectId,
+    ability_index: usize,
+    payment_source: Option<ObjectId>,
+    pip: &[crate::mana::ManaSymbol],
+    mana_spend_policy: &crate::player::ManaSpendPolicy,
+) -> bool {
+    mana_ability_can_pay_pip_filtered(
+        game,
+        perm_id,
+        ability_index,
+        payment_source,
+        pip,
+        mana_spend_policy,
+        |game, unit, payment_source| restricted_unit_is_payable(game, unit, payment_source),
+    )
+}
+
+fn mana_ability_can_pay_pip_with_reason(
+    game: &GameState,
+    perm_id: ObjectId,
+    ability_index: usize,
+    payment_source: Option<ObjectId>,
+    payment_reason: crate::costs::PaymentReason,
+    pip: &[crate::mana::ManaSymbol],
+    mana_spend_policy: &crate::player::ManaSpendPolicy,
+) -> bool {
+    mana_ability_can_pay_pip_filtered(
+        game,
+        perm_id,
+        ability_index,
+        payment_source,
+        pip,
+        mana_spend_policy,
+        |game, unit, payment_source| {
+            game.restricted_mana_unit_is_payable_for_reason(unit, payment_source, payment_reason)
+        },
+    )
+}
+
+fn mana_ability_can_pay_pip_filtered(
+    game: &GameState,
+    perm_id: ObjectId,
+    ability_index: usize,
+    payment_source: Option<ObjectId>,
+    pip: &[crate::mana::ManaSymbol],
+    mana_spend_policy: &crate::player::ManaSpendPolicy,
+    restricted_is_payable: impl Fn(
+        &GameState,
+        &crate::ability::RestrictedManaUnit,
+        Option<ObjectId>,
+    ) -> bool,
 ) -> bool {
     use crate::ability::AbilityKind;
     use crate::mana::ManaSymbol;
@@ -1089,7 +1241,7 @@ pub(super) fn mana_ability_can_pay_pip(
             source_chosen_creature_type: game.chosen_creature_type(perm_id),
             restrictions: mana_ability.mana_usage_restrictions.clone(),
         };
-        if !restricted_unit_is_payable(game, &unit, payment_source) {
+        if !restricted_is_payable(game, &unit, payment_source) {
             return false;
         }
     }
@@ -1259,6 +1411,7 @@ pub(super) fn execute_pip_payment_action(
     trigger_queue: &mut TriggerQueue,
     player: PlayerId,
     source: Option<ObjectId>,
+    payment_reason: crate::costs::PaymentReason,
     pip: &[crate::mana::ManaSymbol],
     mana_spend_policy: &crate::player::ManaSpendPolicy,
     action: &ManaPipPaymentAction,
@@ -1268,7 +1421,14 @@ pub(super) fn execute_pip_payment_action(
 ) -> Result<bool, GameLoopError> {
     match action {
         ManaPipPaymentAction::UseFromPool(symbol) => {
-            let spent_info = spend_pool_symbol(game, player, *symbol, source).ok_or_else(|| {
+            let spent_info = spend_pool_symbol_with_reason(
+                game,
+                player,
+                *symbol,
+                source,
+                payment_reason,
+            )
+            .ok_or_else(|| {
                 GameLoopError::InvalidState(format!(
                     "Not enough {} mana in the pool",
                     crate::mana::ManaCost::from_symbols(vec![*symbol]).to_oracle()
@@ -1317,10 +1477,11 @@ pub(super) fn execute_pip_payment_action(
                 })
                 .unwrap_or_default();
 
-            if let Some(spent_info) = spend_pool_mana_for_pip(
+            if let Some(spent_info) = spend_pool_mana_for_pip_with_reason(
                 game,
                 player,
                 source,
+                payment_reason,
                 pip,
                 &source_policy,
                 &produced_symbols,
@@ -1396,13 +1557,41 @@ pub(super) fn mana_pool_delta_symbols(
     produced
 }
 
-pub(super) fn spend_pool_mana_for_pip(
+fn spend_pool_mana_for_pip_with_reason(
+    game: &mut GameState,
+    player: PlayerId,
+    payment_source: Option<ObjectId>,
+    payment_reason: crate::costs::PaymentReason,
+    pip: &[crate::mana::ManaSymbol],
+    mana_spend_policy: &crate::player::ManaSpendPolicy,
+    preferred_symbols: &[crate::mana::ManaSymbol],
+) -> Option<SpentManaInfo> {
+    spend_pool_mana_for_pip_filtered(
+        game,
+        player,
+        payment_source,
+        pip,
+        mana_spend_policy,
+        preferred_symbols,
+        |game, player, symbol, payment_source| {
+            spend_pool_symbol_with_reason(game, player, symbol, payment_source, payment_reason)
+        },
+    )
+}
+
+fn spend_pool_mana_for_pip_filtered(
     game: &mut GameState,
     player: PlayerId,
     payment_source: Option<ObjectId>,
     pip: &[crate::mana::ManaSymbol],
     mana_spend_policy: &crate::player::ManaSpendPolicy,
     preferred_symbols: &[crate::mana::ManaSymbol],
+    mut spend_symbol: impl FnMut(
+        &mut GameState,
+        PlayerId,
+        crate::mana::ManaSymbol,
+        Option<ObjectId>,
+    ) -> Option<SpentManaInfo>,
 ) -> Option<SpentManaInfo> {
     use crate::mana::ManaSymbol;
 
@@ -1439,7 +1628,7 @@ pub(super) fn spend_pool_mana_for_pip(
     }
 
     for symbol in candidates {
-        if let Some(spent_info) = spend_pool_symbol(game, player, symbol, payment_source) {
+        if let Some(spent_info) = spend_symbol(game, player, symbol, payment_source) {
             return Some(spent_info);
         }
     }
@@ -2257,6 +2446,7 @@ pub(super) fn apply_pip_payment_response_activation(
         &mana_spend_policy,
         allow_black_life,
         Some(pending.source),
+        pending.payment_reason,
         &mut *decision_maker,
     );
 
@@ -2276,6 +2466,7 @@ pub(super) fn apply_pip_payment_response_activation(
         trigger_queue,
         pending.activator,
         Some(pending.source),
+        pending.payment_reason,
         &pip,
         &mana_spend_policy,
         action,
@@ -2355,6 +2546,7 @@ pub(super) fn apply_pip_payment_response_cast(
             &mana_spend_policy,
             allow_black_life,
             Some(pending.spell_id),
+            crate::costs::PaymentReason::CastSpell,
             &mut *decision_maker,
         )
     } else {
@@ -2380,6 +2572,7 @@ pub(super) fn apply_pip_payment_response_cast(
         trigger_queue,
         pending.caster,
         Some(pending.spell_id),
+        crate::costs::PaymentReason::CastSpell,
         &pip,
         &mana_spend_policy,
         action,
@@ -5434,6 +5627,7 @@ mod priority_mana_tests {
             &mut trigger_queue,
             alice,
             None,
+            crate::costs::PaymentReason::Other,
             &black_pip,
             &crate::player::ManaSpendPolicy::default(),
             &action,
@@ -5489,6 +5683,7 @@ mod priority_mana_tests {
             &crate::player::ManaSpendPolicy::default(),
             false,
             Some(yawgmoth_id),
+            crate::costs::PaymentReason::ActivateAbility,
             &mut dm,
         );
 
@@ -5582,6 +5777,7 @@ mod priority_mana_tests {
                 crate::costs::PaymentReason::CastSpell,
             ),
             None,
+            crate::costs::PaymentReason::CastSpell,
             &mut dm,
         );
 
@@ -5607,6 +5803,7 @@ mod priority_mana_tests {
             &crate::player::ManaSpendPolicy::default(),
             true,
             None,
+            crate::costs::PaymentReason::CastSpell,
             &mut dm,
         );
 

--- a/crates/ironsmith-runtime/src/game_loop/priority_state.rs
+++ b/crates/ironsmith-runtime/src/game_loop/priority_state.rs
@@ -664,6 +664,8 @@ pub struct PendingActivation {
     pub remaining_requirements: Vec<TargetRequirement>,
     /// The computed mana cost to pay.
     pub mana_cost_to_pay: Option<crate::mana::ManaCost>,
+    /// Why this activation's costs are being paid.
+    pub payment_reason: crate::costs::PaymentReason,
     /// Stable display pips for the mana payment overlay.
     ///
     /// Unlike `remaining_mana_pips`, this is not mutated as payment proceeds so
@@ -724,6 +726,7 @@ impl PendingActivation {
         effects: crate::resolution::ResolutionProgram,
         remaining_requirements: Vec<TargetRequirement>,
         mana_cost_to_pay: Option<crate::mana::ManaCost>,
+        payment_reason: crate::costs::PaymentReason,
         payment_trace: Vec<CostStep>,
         remaining_cost_steps: Vec<ActivationCostStep>,
         tagged_objects: std::collections::HashMap<crate::tag::TagKey, Vec<ObjectSnapshot>>,
@@ -748,6 +751,7 @@ impl PendingActivation {
             chosen_target_assignments: Vec::new(),
             remaining_requirements,
             mana_cost_to_pay,
+            payment_reason,
             display_mana_pips: Vec::new(),
             payment_trace,
             undo_locked_by_mana: false,

--- a/crates/ironsmith-runtime/src/game_state.rs
+++ b/crates/ironsmith-runtime/src/game_state.rs
@@ -25,7 +25,7 @@ use crate::events::{Event, EventKind, KeywordActionKind};
 use crate::filter::PlayerFilterExt;
 use crate::ids::{ObjectId, PlayerId, StableId, reset_runtime_id_counters};
 use crate::object::{AttachmentTarget, AuraAttachmentFilter, Object};
-use crate::player::Player;
+use crate::player::{ManaPool, Player};
 use crate::prevention::PreventionEffectManager;
 use crate::provenance::{ProvNodeId, ProvenanceGraph, ProvenanceNodeKind};
 use crate::replacement::{ReplacementEffectId, ReplacementEffectManager};
@@ -6742,6 +6742,249 @@ impl GameState {
         )
     }
 
+    fn cast_spell_mana_rule_matches_payment_source(
+        &self,
+        unit: &crate::ability::RestrictedManaUnit,
+        card_types: &[CardType],
+        subtype_requirement: &Option<crate::ability::ManaUsageSubtypeRequirement>,
+        payment_source: Option<ObjectId>,
+    ) -> bool {
+        let Some(source_id) = payment_source else {
+            return false;
+        };
+        let Some(source_obj) = self.object(source_id) else {
+            return false;
+        };
+        if source_obj.zone != Zone::Stack {
+            return false;
+        }
+        if !card_types
+            .iter()
+            .all(|card_type| self.current_has_card_type(source_obj.id, *card_type))
+        {
+            return false;
+        }
+
+        let required_subtype = match subtype_requirement {
+            Some(crate::ability::ManaUsageSubtypeRequirement::Exact(subtype)) => Some(*subtype),
+            Some(crate::ability::ManaUsageSubtypeRequirement::ChosenTypeOfSource) => {
+                unit.source_chosen_creature_type
+            }
+            None => None,
+        };
+        required_subtype.is_none_or(|subtype| self.current_has_subtype(source_obj.id, subtype))
+    }
+
+    fn cast_spell_filter_matches_payment_source(
+        &self,
+        unit: &crate::ability::RestrictedManaUnit,
+        filter: &crate::target::ObjectFilter,
+        payment_source: Option<ObjectId>,
+    ) -> bool {
+        let Some(source_id) = payment_source else {
+            return false;
+        };
+        let Some(source_obj) = self.object(source_id) else {
+            return false;
+        };
+        if source_obj.zone != Zone::Stack {
+            return false;
+        }
+
+        let Some(mana_source) = self.object(unit.source) else {
+            return false;
+        };
+        let filter_ctx =
+            self.filter_context_for(self.controller_of(mana_source), Some(unit.source));
+        filter.matches(source_obj, &filter_ctx, self)
+    }
+
+    fn activate_ability_source_filter_matches_payment_source(
+        &self,
+        unit: &crate::ability::RestrictedManaUnit,
+        filter: &crate::target::ObjectFilter,
+        payment_source: Option<ObjectId>,
+    ) -> bool {
+        let Some(source_id) = payment_source else {
+            return false;
+        };
+        let Some(source_obj) = self.object(source_id) else {
+            return false;
+        };
+        if source_obj.zone == Zone::Stack {
+            return false;
+        }
+
+        let Some(mana_source) = self.object(unit.source) else {
+            return false;
+        };
+        let filter_ctx =
+            self.filter_context_for(self.controller_of(mana_source), Some(unit.source));
+        filter.matches(source_obj, &filter_ctx, self)
+    }
+
+    fn restricted_mana_unit_is_payable_for_reason(
+        &self,
+        unit: &crate::ability::RestrictedManaUnit,
+        payment_source: Option<ObjectId>,
+        reason: crate::costs::PaymentReason,
+    ) -> bool {
+        unit.restrictions.iter().all(|restriction| match restriction {
+            crate::ability::ManaUsageRestriction::CastSpell {
+                card_types,
+                subtype_requirement,
+                restrict_to_matching_spell,
+                ..
+            } => {
+                !*restrict_to_matching_spell
+                    || (reason == crate::costs::PaymentReason::CastSpell
+                        && self.cast_spell_mana_rule_matches_payment_source(
+                            unit,
+                            card_types,
+                            subtype_requirement,
+                            payment_source,
+                        ))
+            }
+            crate::ability::ManaUsageRestriction::CastSpellMatching {
+                filter,
+                restrict_to_matching_spell,
+                ..
+            } => {
+                !*restrict_to_matching_spell
+                    || (reason == crate::costs::PaymentReason::CastSpell
+                        && self.cast_spell_filter_matches_payment_source(
+                            unit,
+                            filter,
+                            payment_source,
+                        ))
+            }
+            crate::ability::ManaUsageRestriction::CastSpellOrActivateAbilitySourceMatching {
+                spell_filter,
+                ability_source_filter,
+            } => {
+                (reason == crate::costs::PaymentReason::CastSpell
+                    && self.cast_spell_filter_matches_payment_source(
+                        unit,
+                        spell_filter,
+                        payment_source,
+                    ))
+                    || (matches!(
+                        reason,
+                        crate::costs::PaymentReason::ActivateAbility
+                            | crate::costs::PaymentReason::ActivateManaAbility
+                    ) && self.activate_ability_source_filter_matches_payment_source(
+                        unit,
+                        ability_source_filter,
+                        payment_source,
+                    ))
+            }
+            crate::ability::ManaUsageRestriction::CastSpellOrUnlockDoorOrTurnFaceUp {
+                spell_filter,
+            } => {
+                (reason == crate::costs::PaymentReason::CastSpell
+                    && self.cast_spell_filter_matches_payment_source(
+                        unit,
+                        spell_filter,
+                        payment_source,
+                    ))
+                    || (reason == crate::costs::PaymentReason::TurnFaceUp
+                        && payment_source.is_some_and(|source_id| {
+                            self.object(source_id)
+                                .is_some_and(|source_obj| source_obj.zone == Zone::Battlefield)
+                                && self.is_face_down(source_id)
+                        }))
+            }
+            crate::ability::ManaUsageRestriction::ActivateAbility => {
+                matches!(
+                    reason,
+                    crate::costs::PaymentReason::ActivateAbility
+                        | crate::costs::PaymentReason::ActivateManaAbility
+                ) && payment_source.is_some_and(|source_id| {
+                    self.object(source_id)
+                        .is_some_and(|source_obj| source_obj.zone != Zone::Stack)
+                })
+            }
+        })
+    }
+
+    fn remove_unpayable_restricted_mana_from_pool(
+        &self,
+        pool: &mut ManaPool,
+        payer: PlayerId,
+        payment_source: Option<ObjectId>,
+        reason: crate::costs::PaymentReason,
+    ) -> Vec<crate::mana::ManaSymbol> {
+        let Some(player) = self.player(payer) else {
+            return Vec::new();
+        };
+        let mut removed = Vec::new();
+        for unit in &player.restricted_mana {
+            if self.restricted_mana_unit_is_payable_for_reason(unit, payment_source, reason) {
+                continue;
+            }
+            if pool.remove(unit.symbol, 1) {
+                removed.push(unit.symbol);
+            }
+        }
+        removed
+    }
+
+    fn restricted_mana_indices_spent(
+        &self,
+        payer: PlayerId,
+        before: &ManaPool,
+        after: &ManaPool,
+        payment_source: Option<ObjectId>,
+        reason: crate::costs::PaymentReason,
+    ) -> Vec<usize> {
+        let Some(player) = self.player(payer) else {
+            return Vec::new();
+        };
+        let symbols = [
+            crate::mana::ManaSymbol::White,
+            crate::mana::ManaSymbol::Blue,
+            crate::mana::ManaSymbol::Black,
+            crate::mana::ManaSymbol::Red,
+            crate::mana::ManaSymbol::Green,
+            crate::mana::ManaSymbol::Colorless,
+        ];
+        let mut indices = Vec::new();
+        for symbol in symbols {
+            let spent = before.amount(symbol).saturating_sub(after.amount(symbol));
+            if spent == 0 {
+                continue;
+            }
+            let restricted_total = player
+                .restricted_mana
+                .iter()
+                .filter(|unit| unit.symbol == symbol)
+                .count() as u32;
+            let unrestricted_total = before.amount(symbol).saturating_sub(restricted_total);
+            let mut restricted_to_remove = spent.saturating_sub(unrestricted_total);
+            if restricted_to_remove == 0 {
+                continue;
+            }
+            for (idx, unit) in player.restricted_mana.iter().enumerate() {
+                if unit.symbol == symbol
+                    && self.restricted_mana_unit_is_payable_for_reason(
+                        unit,
+                        payment_source,
+                        reason,
+                    )
+                {
+                    indices.push(idx);
+                    restricted_to_remove -= 1;
+                    if restricted_to_remove == 0 {
+                        break;
+                    }
+                }
+            }
+        }
+        indices.sort_unstable();
+        indices.dedup();
+        indices
+    }
+
     /// Check if a player can pay a mana cost for a specific reason.
     pub fn can_pay_mana_cost_with_reason(
         &self,
@@ -6765,6 +7008,7 @@ impl GameState {
         } else {
             player.mana_pool.clone()
         };
+        self.remove_unpayable_restricted_mana_from_pool(&mut preview_pool, payer, source, reason);
         let (can_pay, life_to_pay) = preview_pool
             .try_pay_tracking_life_with_mana_spend_policy_and_black_life(
                 cost,
@@ -6841,27 +7085,51 @@ impl GameState {
             }
             return true;
         }
-        let (paid, life_to_pay) = {
-            let Some(player) = self.player_mut(payer) else {
+        let (paid, life_to_pay, payment_pool, spent_restricted) = {
+            let Some(before_pool) = self.player(payer).map(|player| player.mana_pool.clone()) else {
                 return false;
             };
-            player
-                .mana_pool
-                .try_pay_tracking_life_with_mana_spend_policy_and_black_life(
-                    cost,
-                    x_value,
-                    &mana_spend_policy,
-                    allow_black_life,
-                )
+            let mut payment_pool = before_pool.clone();
+            let removed_unpayable = self.remove_unpayable_restricted_mana_from_pool(
+                &mut payment_pool,
+                payer,
+                source,
+                reason,
+            );
+            let result = payment_pool.try_pay_tracking_life_with_mana_spend_policy_and_black_life(
+                cost,
+                x_value,
+                &mana_spend_policy,
+                allow_black_life,
+            );
+            for symbol in removed_unpayable {
+                payment_pool.add(symbol, 1);
+            }
+            let spent_restricted = if result.0 {
+                let spent_restricted = self.restricted_mana_indices_spent(
+                    payer,
+                    &before_pool,
+                    &payment_pool,
+                    source,
+                    reason,
+                );
+                spent_restricted
+            } else {
+                Vec::new()
+            };
+            (result.0, result.1, payment_pool, spent_restricted)
         };
         if !paid {
             return false;
         }
         if !self.can_pay_life_with_reason(payer, life_to_pay, reason) {
-            if let (Some(original_pool), Some(player)) = (original_pool, self.player_mut(payer)) {
-                player.mana_pool = original_pool;
-            }
             return false;
+        }
+        if let Some(player) = self.player_mut(payer) {
+            player.mana_pool = payment_pool;
+            for idx in spent_restricted.into_iter().rev() {
+                player.restricted_mana.remove(idx);
+            }
         }
         if life_to_pay > 0 && !self.pay_life(payer, life_to_pay) {
             if let (Some(original_pool), Some(player)) = (original_pool, self.player_mut(payer)) {

--- a/crates/ironsmith-runtime/src/game_state.rs
+++ b/crates/ironsmith-runtime/src/game_state.rs
@@ -6627,6 +6627,25 @@ impl GameState {
         object.card_types.contains(&crate::types::CardType::Land)
     }
 
+    pub(crate) fn object_is_room_unlock_payment_source(&self, object_id: ObjectId) -> bool {
+        let Some(object) = self.object(object_id) else {
+            return false;
+        };
+        object.zone == Zone::Battlefield
+            && self.current_has_subtype(object_id, crate::types::Subtype::Room)
+    }
+
+    pub(crate) fn activation_payment_reason(
+        &self,
+        source: ObjectId,
+    ) -> crate::costs::PaymentReason {
+        if self.object_is_room_unlock_payment_source(source) {
+            crate::costs::PaymentReason::UnlockDoor
+        } else {
+            crate::costs::PaymentReason::ActivateAbility
+        }
+    }
+
     fn required_sacrifice_count_for_cost(&self, cost: &crate::costs::Cost) -> usize {
         if cost.is_sacrifice_self() {
             return 1;
@@ -6892,6 +6911,10 @@ impl GameState {
                             self.object(source_id)
                                 .is_some_and(|source_obj| source_obj.zone == Zone::Battlefield)
                                 && self.is_face_down(source_id)
+                        }))
+                    || (reason == crate::costs::PaymentReason::UnlockDoor
+                        && payment_source.is_some_and(|source_id| {
+                            self.object_is_room_unlock_payment_source(source_id)
                         }))
             }
             crate::ability::ManaUsageRestriction::ActivateAbility => {

--- a/crates/ironsmith-runtime/src/game_state.rs
+++ b/crates/ironsmith-runtime/src/game_state.rs
@@ -2151,6 +2151,9 @@ pub struct GameState {
     /// Face-down permanents created via manifest.
     pub manifested: HashSet<ObjectId>,
 
+    /// Split Room permanents whose linked locked door has been unlocked.
+    pub fully_unlocked_rooms: HashSet<ObjectId>,
+
     /// Number of times each battlefield permanent has transformed.
     ///
     /// Used to enforce CR 701.27f for abilities that try to transform their source.
@@ -2309,6 +2312,7 @@ impl GameState {
             flipped: HashSet::new(),
             face_down: HashSet::new(),
             manifested: HashSet::new(),
+            fully_unlocked_rooms: HashSet::new(),
             transform_count: HashMap::new(),
             face_down_exile_viewers: HashMap::new(),
             phased_out: HashSet::new(),
@@ -6628,11 +6632,27 @@ impl GameState {
     }
 
     pub(crate) fn object_is_room_unlock_payment_source(&self, object_id: ObjectId) -> bool {
+        self.room_has_locked_door(object_id)
+    }
+
+    pub(crate) fn room_has_locked_door(&self, object_id: ObjectId) -> bool {
         let Some(object) = self.object(object_id) else {
             return false;
         };
         object.zone == Zone::Battlefield
             && self.current_has_subtype(object_id, crate::types::Subtype::Room)
+            && object.linked_face_layout == LinkedFaceLayout::Split
+            && !self.fully_unlocked_rooms.contains(&object_id)
+            && self
+                .linked_face_definition_by_name_or_id(
+                    object.other_face_name.as_deref(),
+                    object.other_face,
+                )
+                .is_some_and(|def| def.card.subtypes.contains(&crate::types::Subtype::Room))
+    }
+
+    pub(crate) fn mark_room_fully_unlocked(&mut self, object_id: ObjectId) {
+        self.fully_unlocked_rooms.insert(object_id);
     }
 
     fn required_sacrifice_count_for_cost(&self, cost: &crate::costs::Cost) -> usize {
@@ -9248,6 +9268,7 @@ impl GameState {
         self.flipped.remove(&id);
         self.face_down.remove(&id);
         self.manifested.remove(&id);
+        self.fully_unlocked_rooms.remove(&id);
         self.transform_count.remove(&id);
         self.phased_out.remove(&id);
         self.imprinted_cards.remove(&id);

--- a/crates/ironsmith-runtime/src/game_state.rs
+++ b/crates/ironsmith-runtime/src/game_state.rs
@@ -6635,17 +6635,6 @@ impl GameState {
             && self.current_has_subtype(object_id, crate::types::Subtype::Room)
     }
 
-    pub(crate) fn activation_payment_reason(
-        &self,
-        source: ObjectId,
-    ) -> crate::costs::PaymentReason {
-        if self.object_is_room_unlock_payment_source(source) {
-            crate::costs::PaymentReason::UnlockDoor
-        } else {
-            crate::costs::PaymentReason::ActivateAbility
-        }
-    }
-
     fn required_sacrifice_count_for_cost(&self, cost: &crate::costs::Cost) -> usize {
         if cost.is_sacrifice_self() {
             return 1;
@@ -6842,7 +6831,7 @@ impl GameState {
         filter.matches(source_obj, &filter_ctx, self)
     }
 
-    fn restricted_mana_unit_is_payable_for_reason(
+    pub(crate) fn restricted_mana_unit_is_payable_for_reason(
         &self,
         unit: &crate::ability::RestrictedManaUnit,
         payment_source: Option<ObjectId>,

--- a/crates/ironsmith-runtime/src/special_actions.rs
+++ b/crates/ironsmith-runtime/src/special_actions.rs
@@ -140,6 +140,27 @@ pub fn turn_face_up_cost_display(
     Some(adjusted_turn_face_up_cost(game, controller, permanent_id, &spec).display())
 }
 
+pub fn room_unlock_cost_display(game: &GameState, room_id: ObjectId) -> Option<String> {
+    let room = game.object(room_id)?;
+    let controller = game.controller_of(room);
+    adjusted_room_unlock_cost(game, controller, room_id)
+        .ok()
+        .map(|cost| cost.display())
+}
+
+fn room_locked_door_definition(
+    game: &GameState,
+    room_id: ObjectId,
+) -> Option<crate::cards::CardDefinition> {
+    let room = game.object(room_id)?;
+    game.linked_face_definition_by_name_or_id(room.other_face_name.as_deref(), room.other_face)
+}
+
+fn room_unlock_cost(game: &GameState, room_id: ObjectId) -> Option<crate::cost::TotalCost> {
+    let locked_door = room_locked_door_definition(game, room_id)?;
+    locked_door.card.mana_cost.map(crate::cost::TotalCost::mana)
+}
+
 fn turn_face_up_spec(
     game: &GameState,
     object: &crate::object::Object,
@@ -386,6 +407,9 @@ pub enum SpecialAction {
         permanent_id: ObjectId,
         ability_index: usize,
     },
+
+    /// Unlock the locked linked face of a split Room permanent.
+    UnlockRoomDoor { room_id: ObjectId },
 }
 
 /// Errors that can occur when attempting to perform a special action.
@@ -505,6 +529,7 @@ pub fn can_perform(
             permanent_id,
             ability_index,
         } => can_activate_mana_ability(game, player, *permanent_id, *ability_index, decision_maker),
+        SpecialAction::UnlockRoomDoor { room_id } => can_unlock_room_door(game, player, *room_id),
     }
 }
 
@@ -531,6 +556,7 @@ pub fn can_perform_check(
             permanent_id,
             ability_index,
         } => can_activate_mana_ability_check(game, player, *permanent_id, *ability_index),
+        SpecialAction::UnlockRoomDoor { room_id } => can_unlock_room_door(game, player, *room_id),
     }
 }
 
@@ -565,6 +591,9 @@ pub fn perform(
             ability_index,
             &mut *decision_maker,
         ),
+        SpecialAction::UnlockRoomDoor { room_id } => {
+            perform_unlock_room_door(game, player, room_id, &mut *decision_maker)
+        }
     }
 }
 
@@ -818,6 +847,111 @@ fn perform_turn_face_up(
         ),
     );
 
+    Ok(())
+}
+
+// === Unlock Room Door ===
+
+fn validate_unlock_room_door_common(
+    game: &GameState,
+    player: PlayerId,
+    room_id: ObjectId,
+) -> Result<(), ActionError> {
+    has_sorcery_speed_special_action_timing(game, player)?;
+
+    let room = game.object(room_id).ok_or(ActionError::ObjectNotFound)?;
+    if room.zone != Zone::Battlefield {
+        return Err(ActionError::WrongZone {
+            expected: Zone::Battlefield,
+            actual: room.zone,
+        });
+    }
+    if game.controller_of(room) != player {
+        return Err(ActionError::InvalidTarget);
+    }
+    if !game.room_has_locked_door(room_id) {
+        return Err(ActionError::NoSuchAbility);
+    }
+    Ok(())
+}
+
+fn adjusted_room_unlock_cost(
+    game: &GameState,
+    player: PlayerId,
+    room_id: ObjectId,
+) -> Result<crate::cost::TotalCost, ActionError> {
+    let cost = room_unlock_cost(game, room_id).ok_or(ActionError::NoSuchAbility)?;
+    Ok(adjust_total_cost_mana_components_for_reason(
+        game,
+        player,
+        room_id,
+        &cost,
+        crate::costs::PaymentReason::UnlockDoor,
+    ))
+}
+
+fn can_unlock_room_door(
+    game: &GameState,
+    player: PlayerId,
+    room_id: ObjectId,
+) -> Result<(), ActionError> {
+    validate_unlock_room_door_common(game, player, room_id)?;
+    let cost = adjusted_room_unlock_cost(game, player, room_id)?;
+    crate::cost::can_pay_cost_with_reason(
+        game,
+        room_id,
+        player,
+        &cost,
+        crate::costs::PaymentReason::UnlockDoor,
+    )
+    .map_err(cost_error_to_action_error)
+}
+
+fn perform_unlock_room_door(
+    game: &mut GameState,
+    player: PlayerId,
+    room_id: ObjectId,
+    decision_maker: &mut impl crate::decision::DecisionMaker,
+) -> Result<(), ActionError> {
+    validate_unlock_room_door_common(game, player, room_id)?;
+    let locked_door = room_locked_door_definition(game, room_id).ok_or(ActionError::NoSuchAbility)?;
+    let cost = adjusted_room_unlock_cost(game, player, room_id)?;
+    let action_provenance = game.provenance_graph_mut().alloc_root(
+        crate::provenance::ProvenanceNodeKind::EffectExecution {
+            source: room_id,
+            controller: player,
+        },
+    );
+
+    pay_total_cost_with_choice(
+        game,
+        player,
+        room_id,
+        &cost,
+        crate::costs::PaymentReason::UnlockDoor,
+        decision_maker,
+    )
+    .map_err(cost_error_to_action_error)?;
+
+    if let Some(room) = game.object_mut(room_id) {
+        room.apply_fused_split_spell_overlay(&locked_door);
+    }
+    game.mark_room_fully_unlocked(room_id);
+
+    let event_provenance = game
+        .alloc_child_event_provenance(action_provenance, crate::events::EventKind::KeywordAction);
+    game.queue_trigger_event(
+        action_provenance,
+        TriggerEvent::new_with_provenance(
+            KeywordActionEvent::new(
+                crate::events::KeywordActionKind::UnlockDoor,
+                player,
+                room_id,
+                1,
+            ),
+            event_provenance,
+        ),
+    );
     Ok(())
 }
 


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Creeping Peeper
Initial parse error:
```
compiled text dropped required semantic marker: spend-this-mana-only
```

Current worker: i-03b47e017ab85ef6b
Branch: codex/aws-card-fix-creeping-peeper
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260604T121212Z-controller-dev-loop-wave0021
