### PR TITLE
Fix Ironsmith parse failure: Animate Wall

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
@@ -6460,6 +6460,59 @@ pub(crate) fn parse_source_can_attack_as_though_no_defender_as_long_as_line(
     Ok(Some(granted))
 }
 
+pub(crate) fn parse_attached_can_attack_as_though_no_defender_line(
+    tokens: &[OwnedLexToken],
+) -> Result<Option<StaticAbilityAst>, CardTextError> {
+    let normalized = crate::runtime_backend::token_word_refs(tokens)
+        .into_iter()
+        .map(|word| {
+            if ANTHEM_DIDNT_CONTRACTION_WORD_PATTERN.matches_word(word) {
+                "didnt"
+            } else {
+                word
+            }
+        })
+        .collect::<Vec<_>>();
+    if !CAN_ATTACK_AS_NO_DEFENDER_PATTERN.matches_words(&normalized) {
+        return Ok(None);
+    }
+    let Some(can_idx) =
+        anthem_find_prefix_shape_start(&normalized, &CAN_ATTACK_AS_NO_DEFENDER_PREFIX_PATTERN)
+    else {
+        return Ok(None);
+    };
+    if can_idx == 0 {
+        return Ok(None);
+    }
+
+    let subject_words = &normalized[..can_idx];
+    if !matches!(
+        subject_words.first().copied(),
+        Some("enchanted" | "equipped" | "attached")
+    ) {
+        return Ok(None);
+    }
+    let Some(subject_end) = token_index_for_word_index(tokens, can_idx) else {
+        return Err(CardTextError::ParseError(format!(
+            "unable to map attached no-defender subject (clause: '{}')",
+            normalized.join(" ")
+        )));
+    };
+    let subject_tokens = trim_commas(&tokens[..subject_end]);
+    if subject_tokens.is_empty() {
+        return Ok(None);
+    }
+
+    let subject = crate::runtime_backend::token_word_refs(&subject_tokens).join(" ");
+    Ok(Some(StaticAbilityAst::AttachedStaticAbilityGrant {
+        ability: Box::new(StaticAbilityAst::Static(
+            StaticAbility::can_attack_as_though_no_defender(),
+        )),
+        display: format!("{subject} can attack as though it didn't have defender"),
+        condition: None,
+    }))
+}
+
 pub(crate) fn parse_as_long_as_condition_can_attack_as_though_no_defender_line(
     tokens: &[OwnedLexToken],
 ) -> Result<Option<StaticAbilityAst>, CardTextError> {

--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -2526,6 +2526,14 @@ fn static_ability_rule_head_hints(rule_id: &'static str) -> Vec<StaticAbilityLin
             StaticAbilityLineHeadHint::Single("this"),
             StaticAbilityLineHeadHint::Pair("this", "can"),
         ],
+        "parse_attached_can_attack_as_though_no_defender_line" => vec![
+            StaticAbilityLineHeadHint::Single("enchanted"),
+            StaticAbilityLineHeadHint::Pair("enchanted", "creature"),
+            StaticAbilityLineHeadHint::Pair("enchanted", "wall"),
+            StaticAbilityLineHeadHint::Single("equipped"),
+            StaticAbilityLineHeadHint::Pair("equipped", "creature"),
+            StaticAbilityLineHeadHint::Single("attached"),
+        ],
         "parse_no_maximum_hand_size_line" => vec![
             StaticAbilityLineHeadHint::Single("you"),
             StaticAbilityLineHeadHint::Pair("you", "have"),
@@ -2892,6 +2900,9 @@ fn static_ability_ast_line_rules() -> &'static [StaticAbilityLineRuleDef] {
         multi_static_ability_ast_rule!(parse_attached_has_and_loses_keywords_line),
         single_static_ability_ast_rule!(parse_you_control_attached_creature_line),
         single_static_ability_ast_passthrough_rule!(parse_attached_cant_attack_or_block_line),
+        single_static_ability_ast_passthrough_rule!(
+            parse_attached_can_attack_as_though_no_defender_line
+        ),
         single_static_ability_ast_passthrough_rule!(
             parse_attached_prevent_all_damage_dealt_by_attached_line
         ),

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -28439,6 +28439,111 @@ fn parse_enchanted_creature_doesnt_untap_during_controller_untap_step() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn animate_wall_strict_parser_compiled_text_and_model_regression() {
+    assert_oracle_card_parses_strict("Animate Wall");
+
+    let def = parse_oracle_card_definition("Animate Wall");
+
+    let ids: Vec<_> = def
+        .abilities
+        .iter()
+        .filter_map(|ability| match &ability.kind {
+            AbilityKind::Static(static_ability) => Some(static_ability.id()),
+            _ => None,
+        })
+        .collect();
+    assert!(
+        ids.contains(&StaticAbilityId::AttachedAbilityGrant),
+        "Animate Wall should parse as an attached static ability grant, got {ids:?}"
+    );
+    let Some(AuraAttachmentFilter::Object(filter)) = &def.aura_attach_filter else {
+        panic!(
+            "Animate Wall should parse Enchant Wall as an object attachment filter, got {:?}",
+            def.aura_attach_filter
+        );
+    };
+    assert!(
+        filter.subtypes.contains(&Subtype::Wall),
+        "Animate Wall's attachment filter should require Wall subtype, got {filter:?}"
+    );
+
+    let compiled = compiled_text_lines(&def).join("\n");
+    assert!(
+        compiled.contains("Enchant Wall"),
+        "Animate Wall should preserve its Wall enchant restriction, got {compiled}"
+    );
+    assert!(
+        compiled
+            .to_ascii_lowercase()
+            .contains("enchanted wall can attack as though it didn't have defender"),
+        "Animate Wall should preserve the as-though defender attack clause, got {compiled}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn animate_wall_allows_only_enchanted_wall_to_attack_through_defender() {
+    let animate_wall = parse_oracle_card_definition("Animate Wall");
+    let wall = CardDefinitionBuilder::new(CardId::new(), "Test Wall")
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Wall])
+        .power_toughness(PowerToughness::fixed(0, 4))
+        .defender()
+        .build();
+    let non_wall = CardDefinitionBuilder::new(CardId::new(), "Defender Bear")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .defender()
+        .build();
+
+    let alice = PlayerId::from_index(0);
+    let mut game =
+        crate::game_state::GameState::new(vec!["Alice".to_string(), "Bob".to_string()], 20);
+    let wall_id = game.create_object_from_definition(&wall, alice, Zone::Battlefield);
+    let non_wall_id = game.create_object_from_definition(&non_wall, alice, Zone::Battlefield);
+    let aura_id = game.create_object_from_definition(&animate_wall, alice, Zone::Battlefield);
+    game.remove_summoning_sickness(wall_id);
+    game.remove_summoning_sickness(non_wall_id);
+
+    assert!(
+        !crate::rules::combat::can_attack(
+            game.object(wall_id).expect("wall exists before attachment"),
+            &game,
+        ),
+        "a Wall with defender should not attack before Animate Wall is attached"
+    );
+    assert!(
+        !crate::effects::permanents::attachment_can_attach_to_target(
+            &game,
+            aura_id,
+            crate::object::AttachmentTarget::Object(non_wall_id),
+        ),
+        "Animate Wall's enchant restriction should reject non-Wall targets"
+    );
+    assert!(crate::effects::permanents::attach_battlefield_object_to_target(
+        &mut game,
+        aura_id,
+        crate::object::AttachmentTarget::Object(wall_id),
+    ));
+
+    assert!(
+        crate::rules::combat::can_attack(
+            game.object(wall_id).expect("wall exists after attachment"),
+            &game,
+        ),
+        "Animate Wall should let the enchanted Wall attack as though it didn't have defender"
+    );
+    assert!(
+        !crate::rules::combat::can_attack(
+            game.object(non_wall_id).expect("non-Wall defender exists"),
+            &game,
+        ),
+        "Animate Wall should not let an unattached non-Wall defender attack"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_choose_not_to_untap_artifact_line_as_static_ability() {
     let def = CardDefinitionBuilder::new(CardId::new(), "Endoskeleton Untap Variant")
         .card_types(vec![CardType::Artifact])


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Animate Wall
Initial parse error:
```
compiled text dropped required semantic marker: as-though
```

Current worker: i-0d8afcd7122a2343c
Branch: codex/aws-card-fix-animate-wall
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260604T121212Z-controller-dev-loop-wave0021
