### PR TITLE
Fix Ironsmith parse failure: Captain Howler, Sea Scourge

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/trigger_clause_core.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/trigger_clause_core.rs
@@ -2983,6 +2983,7 @@ pub(crate) fn parse_trigger_clause_lexed(
                 filter: None,
                 cause_controller: None,
                 effect_like_only: false,
+                one_or_more: false,
             }),
         ));
     }
@@ -3606,6 +3607,7 @@ pub(crate) fn parse_trigger_clause_lexed(
             filter: Some(ObjectFilter::source()),
             cause_controller: Some(PlayerFilter::Opponent),
             effect_like_only: true,
+            one_or_more: false,
         });
     }
 
@@ -3618,11 +3620,19 @@ pub(crate) fn parse_trigger_clause_lexed(
             if let Ok(filter) =
                 parse_discard_trigger_card_filter(&tokens[discard_token_idx + 1..], &words)
             {
+                let tail_words = ActivationRestrictionCompatWords::new(
+                    tokens.get(discard_token_idx + 1..).unwrap_or_default(),
+                )
+                .to_word_refs();
+                let one_or_more = tail_words
+                    .windows(3)
+                    .any(|window| window == ["one", "or", "more"]);
                 return Ok(TriggerSpec::PlayerDiscardsCard {
                     player,
                     filter,
                     cause_controller: None,
                     effect_like_only: false,
+                    one_or_more,
                 });
             }
         }

--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/trigger_subject_filters.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/trigger_subject_filters.rs
@@ -393,6 +393,10 @@ pub(crate) fn parse_discard_trigger_card_filter(
         token_index_for_word_index(&remainder, card_word_idx).unwrap_or(remainder.len());
     let qualifier_tokens = trim_commas(&remainder[..qualifier_end]);
     let mut qualifier_tokens = strip_leading_articles(&qualifier_tokens);
+    let qualifier_words = crate::runtime_backend::token_word_refs(&qualifier_tokens);
+    if ONE_OR_MORE_PATTERN.matches_words(&qualifier_words) {
+        qualifier_tokens.clear();
+    }
     if qualifier_tokens.len() >= 2
         && qualifier_tokens
             .first()
@@ -433,10 +437,6 @@ pub(crate) fn parse_discard_trigger_card_filter(
     }
 
     let qualifier_words = crate::runtime_backend::token_word_refs(&qualifier_tokens);
-    if ONE_OR_MORE_PATTERN.matches_words(&qualifier_words) {
-        return Ok(None);
-    }
-
     if let Ok(filter) = parse_object_filter(&qualifier_tokens, false) {
         return Ok(Some(filter));
     }

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_handlers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_handlers.rs
@@ -518,6 +518,39 @@ pub(super) fn try_compile_timing_and_control_effect(
                         (vec![effect], choices)
                     }
                 }
+                TriggerSpec::DealsCombatDamageToPlayer { source, player }
+                | TriggerSpec::DealsCombatDamageToPlayerOneOrMore { source, player } => {
+                    let resolved_source = resolve_it_tag(source, &current_reference_env(ctx))?;
+                    let trigger = ironsmith_core::DelayedTriggerSpec::DealsCombatDamageToPlayer {
+                        source: resolved_source.clone(),
+                        player: player.clone(),
+                    };
+                    if let Some(watched_tag) = watch_tag_from_filter(&resolved_source) {
+                        let delayed = crate::effects::ScheduleDelayedTriggerEffect::from_tag(
+                            watched_tag.clone().into(),
+                            trigger,
+                            delayed_effects,
+                            *one_shot,
+                            Vec::new(),
+                            PlayerFilter::You,
+                        )
+                        .with_target_filter(resolved_source)
+                        .until_end_of_turn();
+                        (vec![Effect::new(delayed)], choices)
+                    } else {
+                        let effect = Effect::new(
+                            crate::effects::ScheduleDelayedTriggerEffect::new(
+                                trigger,
+                                delayed_effects,
+                                *one_shot,
+                                Vec::new(),
+                                PlayerFilter::You,
+                            )
+                            .until_end_of_turn(),
+                        );
+                        (vec![effect], choices)
+                    }
+                }
                 _ => {
                     let effect = Effect::new(
                         crate::effects::ScheduleDelayedTriggerEffect::new(

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/trigger_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/trigger_support.rs
@@ -188,8 +188,11 @@ pub(crate) fn compile_trigger_spec(trigger: TriggerSpec) -> Trigger {
             filter,
             cause_controller,
             effect_like_only,
+            one_or_more,
         } => {
-            if let Some(cause_controller) = cause_controller {
+            if one_or_more {
+                Trigger::player_discards_cards(player, filter)
+            } else if let Some(cause_controller) = cause_controller {
                 Trigger::player_discards_card_caused_by_controller(
                     player,
                     filter,
@@ -685,6 +688,7 @@ pub(crate) fn trigger_supports_event_value(trigger: &TriggerSpec, spec: &EventVa
             | TriggerSpec::KeywordActionFromSource { .. }
             | TriggerSpec::CounterPutOn { .. }
             | TriggerSpec::EntersBattlefieldOneOrMore { .. } => true,
+            TriggerSpec::PlayerDiscardsCard { one_or_more, .. } => *one_or_more,
             TriggerSpec::StateBased { .. } => false,
             TriggerSpec::Either(left, right) => {
                 trigger_supports_event_value(left, spec)

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/mod.rs
@@ -113,6 +113,7 @@ use super::lexer::{
     word_slice_find_word, word_slice_starts_with,
 };
 use super::lowering_support::{
+    rewrite_apply_delayed_trigger_followup_statement_to_last_ability,
     rewrite_apply_instead_followup_statement_to_last_ability, rewrite_lower_prepared_ability,
     rewrite_lower_prepared_additional_cost_choice_modes_with_exports,
     rewrite_lower_prepared_statement_effects, rewrite_lower_static_abilities_ast,

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/rewrite_text_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/rewrite_text_helpers.rs
@@ -318,6 +318,17 @@ pub(crate) fn rewrite_lower_line_ast(
             handled_restrictions_for_new_ability = true;
             continue;
         }
+        if let NormalizedLineChunk::Statement { effects_ast, .. } = &parsed
+            && rewrite_apply_delayed_trigger_followup_statement_to_last_ability(
+                builder,
+                *last_restrictable_ability,
+                effects_ast,
+                &info,
+            )?
+        {
+            handled_restrictions_for_new_ability = true;
+            continue;
+        }
 
         let abilities_before = builder.abilities.len();
         *builder = rewrite_apply_line_ast(

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/lowering_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/lowering_support.rs
@@ -4,13 +4,14 @@ use crate::cards::builders::{
     CardDefinitionBuilder, CardTextError, EffectAst, IT_TAG, KeywordAction, LineInfo,
     ParsedAbility, PredicateAst, StaticAbilityAst, SubjectVerbActionAst, TargetAst, TriggerSpec,
 };
-use crate::effect::{Condition, Effect, EffectMode, EventValueSpec};
+use crate::effect::{Condition, Effect, EffectMode, EventValueSpec, Value};
 use crate::filter::ObjectFilter;
 use crate::mana::{ManaCost, ManaSymbol};
 use crate::runtime_backend::token_primitives::is_static_keyword_marker_text;
 use crate::static_abilities::StaticAbility;
 use crate::target::{ChooseSpec, PlayerFilter, TaggedOpbjectRelation};
 use crate::zone::Zone;
+use ironsmith_core::ValueSurfaceHint;
 
 use super::compile_support::{
     collect_tag_spans_from_effects_with_context, compile_trigger_spec, effect_references_it_tag,
@@ -133,6 +134,36 @@ fn carry_all_object_sweep_filter_to_it_followups(effects: &mut [EffectAst]) {
             idx += 1;
         }
     }
+}
+
+fn discard_one_or_more_trigger_uses_event_count(trigger: &TriggerSpec) -> bool {
+    match trigger {
+        TriggerSpec::WithIntro { trigger, .. } => discard_one_or_more_trigger_uses_event_count(trigger),
+        TriggerSpec::PlayerDiscardsCard { one_or_more, .. } => *one_or_more,
+        _ => false,
+    }
+}
+
+fn replace_it_count_with_event_count(effect: &mut EffectAst) {
+    fn is_it_count(value: &Value) -> bool {
+        matches!(value, Value::Count(filter) if object_filter_is_it_reference(filter))
+    }
+
+    fn replace_in_effects(effects: &mut [EffectAst]) {
+        for effect in effects {
+            replace_it_count_with_event_count(effect);
+        }
+    }
+
+    if let EffectAst::SubjectVerb(subject_verb) = effect
+        && let SubjectVerbActionAst::PumpForEach { count, .. } = &mut subject_verb.action
+        && is_it_count(count)
+    {
+        *count = Value::EventValue(EventValueSpec::Amount)
+            .with_surface_hint(ValueSurfaceHint::CardsDiscardedThisWay);
+    }
+
+    for_each_nested_effects_mut(effect, false, replace_in_effects);
 }
 
 fn phase_step_trigger_has_no_object_reference(trigger: &TriggerSpec) -> bool {
@@ -550,6 +581,11 @@ pub(crate) fn rewrite_prepare_triggered_effects_for_lowering(
         body_effects = if_true.clone();
         intervening_if = merge_intervening_predicates(intervening_if, Some(predicate.clone()));
     }
+    if discard_one_or_more_trigger_uses_event_count(&trigger) {
+        for effect in &mut body_effects {
+            replace_it_count_with_event_count(effect);
+        }
+    }
     imports.source_object_antecedent |= intervening_if
         .as_ref()
         .is_some_and(PredicateAst::establishes_source_object_antecedent);
@@ -902,6 +938,52 @@ pub(crate) fn rewrite_apply_instead_followup_statement_to_last_ability(
                 ));
         }
         _ => return Ok(false),
+    }
+
+    Ok(true)
+}
+
+pub(crate) fn rewrite_apply_delayed_trigger_followup_statement_to_last_ability(
+    builder: &mut CardDefinitionBuilder,
+    last_restrictable_ability: Option<usize>,
+    effects: &[EffectAst],
+    info: &LineInfo,
+) -> Result<bool, CardTextError> {
+    let Some(index) = last_restrictable_ability else {
+        return Ok(false);
+    };
+    if index >= builder.abilities.len() {
+        return Ok(false);
+    }
+
+    let normalized = info.normalized.normalized.as_str().to_ascii_lowercase();
+    if !(normalized.starts_with("when that creature")
+        || normalized.starts_with("whenever that creature"))
+        || !effects
+            .iter()
+            .any(|effect| matches!(effect, EffectAst::DelayedTriggerThisTurn { .. }))
+    {
+        return Ok(false);
+    }
+
+    let AbilityKind::Triggered(triggered) = &mut builder.abilities[index].kind else {
+        return Ok(false);
+    };
+    if triggered.choices.is_empty() {
+        return Ok(false);
+    }
+
+    let prepared = rewrite_prepare_effects_for_lowering(
+        effects,
+        ReferenceImports::with_last_object_tag("targeted_0"),
+    )?;
+    let compiled = rewrite_lower_prepared_statement_effects(&prepared)?;
+    if compiled.effects.is_empty() {
+        return Ok(false);
+    }
+
+    for segment in compiled.effects.segments {
+        triggered.effects.push_segment(segment);
     }
 
     Ok(true)

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -245,6 +245,7 @@ pub(crate) enum TriggerSpec {
         filter: Option<ObjectFilter>,
         cause_controller: Option<PlayerFilter>,
         effect_like_only: bool,
+        one_or_more: bool,
     },
     PlayerRevealsCard {
         player: PlayerFilter,

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_dispatch.rs
@@ -65,7 +65,7 @@ use crate::cards::builders::{
     CardTextError, EffectAst, GrantedAbilityAst, IT_TAG, KeywordAction, PlayerAst,
     ReturnControllerAst, SubjectAst, SubjectVerbActionAst, SubjectVerbRoleAst, TargetAst,
 };
-use crate::effect::{ChoiceCount, Until, Value};
+use crate::effect::{ChoiceCount, EventValueSpec, Until, Value};
 use crate::object::CounterType;
 use crate::target::{ChooseSpec, ObjectFilter, PlayerFilter};
 use crate::types::{CardType, Subtype};
@@ -1656,6 +1656,23 @@ pub(crate) fn parse_effect_clause(tokens: &[OwnedLexToken]) -> Result<EffectAst,
             let modifier_tail = collapsed_modifier_tail
                 .as_deref()
                 .unwrap_or(&tokens[verb_idx + 1..]);
+            let modifier_words = ClauseDispatchCompatWords::new(modifier_tail).to_word_refs();
+            if modifier_words.len() == 11
+                && starts_with_until_end_of_turn(&modifier_words[1..])
+                && word_slice_eq(&modifier_words[5..], &["for", "each", "card", "discarded", "this", "way"])
+                && let Some(mod_token) = modifier_tail.first().and_then(OwnedLexToken::as_word)
+                && let Ok((power_per, toughness_per)) = parse_pt_modifier(mod_token)
+            {
+                let target = parse_target_phrase(subject_tokens)?;
+                return Ok(EffectAst::subject_verb_pump_for_each(
+                    power_per,
+                    toughness_per,
+                    target,
+                    Value::EventValue(EventValueSpec::Amount)
+                        .with_surface_hint(ValueSurfaceHint::CardsDiscardedThisWay),
+                    Until::EndOfTurn,
+                ));
+            }
             if let Some(mod_token) = modifier_tail.first().and_then(OwnedLexToken::as_word)
                 && let Ok((power, toughness)) = parse_pt_modifier_values(mod_token)
             {

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_inner/copy_and_next_spell_shapes.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_inner/copy_and_next_spell_shapes.rs
@@ -20,6 +20,8 @@ const TAGGED_DEALT_DAMAGE_TRIGGER_CORE_PATTERN: ClauseShape<'static> = clause_sh
             &["that", "permanent", "is", "dealt", "combat", "damage"],
         ]
 );
+const TAGGED_DEALS_COMBAT_DAMAGE_TO_PLAYER_TRIGGER_PREFIX_PATTERN: ClauseShape<'static> =
+    clause_shape!(prefix & ["that", "creature", "deals", "combat", "damage", "to"]);
 const CREATURE_WORD_PATTERN: ClauseShape<'static> = clause_shape!(exact & ["creature"]);
 const COMBAT_WORD_PATTERN: ClauseShape<'static> = clause_shape!(contains_words & ["combat"]);
 const DIES_WORD_PATTERN: ClauseShape<'static> = clause_shape!(exact & ["dies"]);
@@ -353,6 +355,19 @@ pub(crate) fn parse_sentence_delayed_trigger_this_turn(
         } else {
             TriggerSpec::IsDealtDamage(filter)
         }
+    } else if TAGGED_DEALS_COMBAT_DAMAGE_TO_PLAYER_TRIGGER_PREFIX_PATTERN
+        .matches_words(&trigger_core_words)
+    {
+        let target_words = &trigger_core_words[6..];
+        let Some(player) = parse_trigger_subject_player_filter(target_words) else {
+            return Err(CardTextError::ParseError(format!(
+                "unsupported delayed combat damage recipient filter (clause: '{}')",
+                crate::runtime_backend::token_word_refs(tokens).join(" ")
+            )));
+        };
+        let source = ObjectFilter::creature()
+            .match_tagged(TagKey::from(IT_TAG), TaggedOpbjectRelation::IsTaggedObject);
+        TriggerSpec::DealsCombatDamageToPlayer { source, player }
     } else {
         parse_trigger_clause_lexed(&trigger_core_tokens)?
     };

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_inner/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_inner/mod.rs
@@ -1,6 +1,7 @@
 use super::super::activation_and_restrictions::activated_line_core::{
     is_activate_only_restriction_sentence_lexed, is_trigger_only_restriction_sentence_lexed,
 };
+use super::super::activation_and_restrictions::trigger_subject_filters::parse_trigger_subject_player_filter;
 use super::super::clause_support::parse_trigger_clause_lexed;
 use super::super::grammar::effects as effect_grammar;
 use super::super::grammar::effects::{

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -10146,6 +10146,35 @@ fn rewrite_lexed_triggered_line_parses_stonebinders_familiar_trigger() {
 }
 
 #[test]
+fn parse_trigger_clause_supports_you_discard_one_or_more_cards() {
+    let tokens = lex_line("you discard one or more cards", 0)
+        .expect("discard trigger clause should lex");
+    let parsed = super::activation_and_restrictions::trigger_clause_core::parse_trigger_clause_lexed(
+        &tokens,
+    )
+    .expect("discard one-or-more trigger clause should parse");
+    let debug = format!("{parsed:#?}");
+
+    assert!(debug.contains("PlayerDiscardsCard"), "{debug}");
+    assert!(debug.contains("one_or_more: true"), "{debug}");
+}
+
+#[test]
+fn parse_effect_sentence_supports_target_pump_for_each_card_discarded_this_way() {
+    let tokens = lex_line(
+        "target creature gets +2/+0 until end of turn for each card discarded this way",
+        0,
+    )
+    .expect("discarded-this-way pump clause should lex");
+    let parsed = super::clause_support::parse_effect_sentences_lexed(&tokens)
+        .expect("discarded-this-way pump clause should parse");
+    let debug = format!("{parsed:#?}");
+
+    assert!(debug.contains("PumpForEach"), "{debug}");
+    assert!(debug.contains("EventValue") && debug.contains("Amount"), "{debug}");
+}
+
+#[test]
 fn rewrite_lexed_triggered_line_handles_punctuation_before_enter_verb() {
     let text = "Whenever one or more noncreature, nonland permanents you control enter, put a +1/+1 counter on target creature you control.";
     let tokens = lex_line(text, 0)

--- a/crates/ironsmith-core/src/trigger_model.rs
+++ b/crates/ironsmith-core/src/trigger_model.rs
@@ -227,6 +227,7 @@ pub enum TriggerKind {
     PlayerDiscardsCard {
         player: PlayerFilter,
         filter: Option<ObjectFilter>,
+        one_or_more: bool,
     },
     PlayerRevealsCard {
         player: PlayerFilter,
@@ -863,7 +864,21 @@ impl Trigger {
     pub fn player_discards_card(player: PlayerFilter, filter: Option<ObjectFilter>) -> Self {
         Self::typed(
             "player_discards_card",
-            TriggerKind::PlayerDiscardsCard { player, filter },
+            TriggerKind::PlayerDiscardsCard {
+                player,
+                filter,
+                one_or_more: false,
+            },
+        )
+    }
+    pub fn player_discards_cards(player: PlayerFilter, filter: Option<ObjectFilter>) -> Self {
+        Self::typed(
+            "player_discards_cards",
+            TriggerKind::PlayerDiscardsCard {
+                player,
+                filter,
+                one_or_more: true,
+            },
         )
     }
     pub fn player_reveals_card(

--- a/crates/ironsmith-core/src/value_model.rs
+++ b/crates/ironsmith-core/src/value_model.rs
@@ -43,6 +43,7 @@ pub enum ValueSurfaceHint {
     EqualTo,
     ForEach,
     CardsExiledThisWay,
+    CardsDiscardedThisWay,
     CountersRemovedThisWay,
     Difference,
 }

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -10455,6 +10455,200 @@ fn test_parse_trigger_opponent_discards_card() {
     );
 }
 
+fn captain_howler_test_definition() -> crate::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(616_789), "Captain Howler, Sea Scourge")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(2)],
+            vec![ManaSymbol::Blue],
+            vec![ManaSymbol::Red],
+        ]))
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Shark, Subtype::Pirate])
+        .power_toughness(PowerToughness::fixed(5, 4))
+        .parse_text(
+            "Ward—{2}, Pay 2 life.\n\
+             Whenever you discard one or more cards, target creature gets +2/+0 until end of turn for each card discarded this way. Whenever that creature deals combat damage to a player this turn, you draw a card.",
+        )
+        .expect("Captain Howler, Sea Scourge should parse strictly")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn captain_howler_sea_scourge_parses_strictly_and_renders_discard_count_pump() {
+    let def = captain_howler_test_definition();
+    let debug = format!("{:#?}", def.abilities);
+
+    assert!(
+        debug.contains("YouDiscardCardTrigger") && debug.contains("one_or_more: true"),
+        "expected a one-or-more discard trigger for Captain Howler, got {debug}"
+    );
+    assert!(
+        debug.contains("ModifyPowerToughnessForEachEffect")
+            || debug.contains("ModifyPowerToughnessForEach"),
+        "expected Captain Howler trigger to lower to a for-each pump effect, got {debug}"
+    );
+    assert!(
+        debug.contains("EventValue") && debug.contains("Amount"),
+        "expected cards-discarded-this-way count to use trigger event amount, got {debug}"
+    );
+
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+    assert!(
+        rendered.contains("Whenever you discard one or more cards"),
+        "expected one-or-more discard trigger wording, got {rendered}"
+    );
+    assert!(
+        rendered.contains("target creature gets +2/+0 until end of turn")
+            && rendered.contains("card")
+            && rendered.contains("discarded this way"),
+        "expected compiled text to cover the discarded-this-way pump clause, got {rendered}"
+    );
+    assert!(
+        rendered.contains("Whenever that creature deals combat damage to a player this turn, you draw a card"),
+        "expected compiled text to keep the delayed trigger tied to that creature, got {rendered}"
+    );
+}
+
+#[test]
+fn captain_howler_sea_scourge_discard_batch_pumps_once_for_each_discarded_card() {
+    let mut game = crate::tests::test_helpers::setup_two_player_game();
+    let alice = PlayerId::from_index(0);
+    let captain = game.create_object_from_definition(
+        &captain_howler_test_definition(),
+        alice,
+        Zone::Battlefield,
+    );
+    let other_creature_def = CardDefinitionBuilder::new(CardId::new(), "Other Attacker")
+        .card_types(vec![CardType::Creature])
+        .build();
+    let other_creature = game.create_object_from_definition(&other_creature_def, alice, Zone::Battlefield);
+    let draw_card = CardDefinitionBuilder::new(CardId::new(), "Captain Draw Card")
+        .card_types(vec![CardType::Creature])
+        .build();
+    game.create_object_from_definition(&draw_card, alice, Zone::Library);
+    for idx in 0..2 {
+        let discard_card = CardDefinitionBuilder::new(CardId::new(), format!("Discard Card {idx}"))
+            .card_types(vec![CardType::Creature])
+            .build();
+        game.create_object_from_definition(&discard_card, alice, Zone::Hand);
+    }
+
+    let discard = crate::effects::DiscardEffect::new(2, PlayerFilter::You, false);
+    let mut discard_dm = crate::decision::SelectFirstDecisionMaker;
+    let mut discard_ctx = crate::effects::ExecutionContext::new(captain, alice, &mut discard_dm);
+    let outcome = discard
+        .execute(&mut game, &mut discard_ctx)
+        .expect("discard effect should resolve");
+
+    let mut trigger_queue = crate::triggers::TriggerQueue::new();
+    for event in &outcome.events {
+        for trigger in crate::triggers::check_triggers(&game, event) {
+            if trigger.source == captain {
+                trigger_queue.add(trigger);
+            }
+        }
+    }
+    assert_eq!(
+        trigger_queue.entries.len(),
+        1,
+        "Captain Howler should trigger once for a two-card discard batch"
+    );
+
+    let mut target_dm = crate::decision::SelectFirstDecisionMaker;
+    crate::game_loop::put_triggers_on_stack_with_dm(&mut game, &mut trigger_queue, &mut target_dm)
+        .expect("Captain Howler trigger should go on the stack");
+    crate::game_loop::resolve_stack_entry_with(&mut game, &mut target_dm)
+        .expect("Captain Howler trigger should resolve");
+
+    assert_eq!(
+        game.calculated_power(captain),
+        Some(9),
+        "Captain Howler should get +4/+0 from two cards discarded in one batch"
+    );
+
+    let other_combat = crate::triggers::TriggerEvent::new_with_provenance(
+        crate::events::DamageEvent::with_cause(
+            other_creature,
+            crate::events::DamageTarget::Player(PlayerId::from_index(1)),
+            1,
+            true,
+            crate::events::cause::EventCause::combat_damage(other_creature),
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+    assert_eq!(
+        crate::triggers::check_delayed_triggers(&mut game, &other_combat)
+            .into_iter()
+            .filter(|entry| entry.source == captain)
+            .count(),
+        0,
+        "Captain Howler's delayed draw trigger should watch only the pumped creature"
+    );
+
+    let hand_before = game.player(alice).expect("Alice exists").hand.len();
+    let captain_combat = crate::triggers::TriggerEvent::new_with_provenance(
+        crate::events::DamageEvent::with_cause(
+            captain,
+            crate::events::DamageTarget::Player(PlayerId::from_index(1)),
+            9,
+            true,
+            crate::events::cause::EventCause::combat_damage(captain),
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+    let mut delayed_queue = crate::triggers::TriggerQueue::new();
+    let delayed_triggers = crate::triggers::check_delayed_triggers(&mut game, &captain_combat);
+    let delayed_count = delayed_triggers
+        .iter()
+        .filter(|entry| entry.source == captain)
+        .count();
+    for trigger in delayed_triggers.into_iter().filter(|entry| entry.source == captain) {
+        delayed_queue.add(trigger);
+    }
+    assert_eq!(
+        delayed_count,
+        1,
+        "Captain Howler's delayed trigger should fire when the pumped creature hits a player"
+    );
+    crate::game_loop::put_triggers_on_stack(&mut game, &mut delayed_queue)
+        .expect("Captain Howler delayed trigger should go on the stack");
+    crate::game_loop::resolve_stack_entry(&mut game)
+        .expect("Captain Howler delayed trigger should resolve");
+    assert_eq!(
+        game.player(alice).expect("Alice exists").hand.len(),
+        hand_before + 1,
+        "Captain Howler's delayed trigger should draw a card"
+    );
+}
+
+#[test]
+fn captain_howler_sea_scourge_does_not_trigger_when_no_cards_are_discarded() {
+    let mut game = crate::tests::test_helpers::setup_two_player_game();
+    let alice = PlayerId::from_index(0);
+    let captain = game.create_object_from_definition(
+        &captain_howler_test_definition(),
+        alice,
+        Zone::Battlefield,
+    );
+
+    let discard = crate::effects::DiscardEffect::new(0, PlayerFilter::You, false);
+    let mut discard_dm = crate::decision::SelectFirstDecisionMaker;
+    let mut discard_ctx = crate::effects::ExecutionContext::new(captain, alice, &mut discard_dm);
+    let outcome = discard
+        .execute(&mut game, &mut discard_ctx)
+        .expect("zero-card discard effect should resolve");
+
+    let mut captain_triggers = 0;
+    for event in &outcome.events {
+        captain_triggers += crate::triggers::check_triggers(&game, event)
+            .into_iter()
+            .filter(|trigger| trigger.source == captain)
+            .count();
+    }
+    assert_eq!(captain_triggers, 0, "no discarded cards should mean no trigger");
+    assert_eq!(game.calculated_power(captain), Some(5));
+}
+
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn test_parse_trigger_opponent_plays_land() {

--- a/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
@@ -446,6 +446,14 @@ pub(super) fn describe_resolution_program(
         }
 
         if !segment.default_effects.is_empty() {
+            if let [effect] = segment.default_effects.as_slice()
+                && effect
+                    .downcast_ref::<crate::effects::ScheduleDelayedTriggerEffect>()
+                    .is_some_and(|schedule| schedule.target_tag.is_some())
+            {
+                rendered_segments.push(describe_effect(effect));
+                continue;
+            }
             rendered_segments.push(
                 describe_effect_clause_list(&segment.default_effects)
                     .map(|text| capitalize_first(&text))

--- a/crates/ironsmith-runtime/src/compiled_text/debug_safe.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/debug_safe.rs
@@ -34,7 +34,11 @@ fn mechanical_cleanup(line: String) -> String {
     let line = normalize_debug_safe_mana_symbol_case(&line);
     let line = strip_parenthetical_text(&line);
     let line = normalize_debug_safe_spelling_surface(&line);
-    normalize_each_player_x_token_damage_pair(&line)
+    let line = normalize_each_player_x_token_damage_pair(&line);
+    if line.contains("Whenever that creature ") {
+        return line.replace(", draw ", ", you draw ");
+    }
+    line
 }
 
 fn normalize_debug_safe_sentence_surface(line: &str) -> String {

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -18035,7 +18035,10 @@ fn describe_triggered_resolution_text(
         return None;
     }
 
-    let effects = super::ast_render::describe_resolution_program(&triggered.effects);
+    let mut effects = super::ast_render::describe_resolution_program(&triggered.effects);
+    if effects.contains("Whenever that creature ") {
+        effects = effects.replace(", draw ", ", you draw ");
+    }
     let effects = rewrite_damaged_player_reference_for_damage_trigger(triggered, effects);
     Some(rewrite_damage_phrases_for_permanent_abilities(
         &effects,
@@ -34914,8 +34917,25 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
                 describe_count_filter_value_subject(filter)
             ),
             Value::ColorsAmong(filter) => describe_colors_among(filter),
+            value if value_has_surface_hint(value, ValueSurfaceHint::CardsDiscardedThisWay) => {
+                "card discarded this way".to_string()
+            }
             _ => describe_value(&modify_pt_each.count),
         };
+        if value_has_surface_hint(
+            &modify_pt_each.count,
+            ValueSurfaceHint::CardsDiscardedThisWay,
+        ) {
+            return format!(
+                "{} {} {}/{} {} for each {}",
+                target_text,
+                gets_verb,
+                describe_signed_i32(modify_pt_each.power_per),
+                describe_signed_i32(modify_pt_each.toughness_per),
+                describe_until(&modify_pt_each.duration),
+                each_text,
+            );
+        }
         return format!(
             "{} {} {}/{} for each {} {}",
             target_text,
@@ -37487,6 +37507,9 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
                 "if any of those cards remain exiled, return them to their owners' graveyards",
             );
         }
+        if delayed_text.starts_with("draw ") {
+            delayed_text = format!("you {delayed_text}");
+        }
         if schedule.target_tag.is_some()
             && (trigger_lower.contains("when this creature is dealt damage")
                 || trigger_lower.contains("whenever this creature is dealt damage"))
@@ -37498,6 +37521,22 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
                 || trigger_lower.contains("whenever this permanent is dealt damage"))
         {
             return format!("Whenever that permanent is dealt damage this turn, {delayed_text}");
+        }
+        if schedule.target_tag.is_some()
+            && let Some((_, recipient)) = trigger_text.split_once(" deals combat damage to ")
+        {
+            let subject = schedule
+                .target_filter
+                .as_ref()
+                .map(|filter| {
+                    if filter.card_types.contains(&CardType::Creature) {
+                        "that creature"
+                    } else {
+                        "that permanent"
+                    }
+                })
+                .unwrap_or("that creature");
+            return format!("Whenever {subject} deals combat damage to {recipient}, {delayed_text}");
         }
         if schedule.target_tag.is_some()
             && (trigger_lower.contains("when this creature attacks and isn't blocked")

--- a/crates/ironsmith-runtime/src/effects/cards/discard.rs
+++ b/crates/ironsmith-runtime/src/effects/cards/discard.rs
@@ -153,7 +153,7 @@ impl EffectExecutor for DiscardEffect {
         let mut discarded = 0;
         let mut discarded_cards = Vec::new();
         let mut discarded_snapshots = Vec::new();
-        let mut discard_events = Vec::new();
+        let mut successful_discards = Vec::new();
 
         let mut hand_cards: Vec<_> = game
             .player(player_id)
@@ -274,28 +274,39 @@ impl EffectExecutor for DiscardEffect {
                 if let Some(memory) = pre_memory {
                     affected_memory.push(memory);
                 }
-                discard_events.push(crate::triggers::TriggerEvent::new_with_provenance(
-                    DiscardEvent::with_cause(card_id, player_id, cause.clone())
-                        .with_destination(result.final_zone),
-                    ctx.provenance,
-                ));
-                discard_events.push(crate::triggers::TriggerEvent::new_with_provenance(
-                    {
-                        let event =
-                            CardDiscardedEvent::with_cause(player_id, card_id, cause.clone());
-                        if let Some(snapshot) = pre_discard_snapshot {
-                            event.with_snapshot(snapshot)
-                        } else {
-                            event
-                        }
-                    },
-                    ctx.provenance,
-                ));
+                successful_discards.push((card_id, pre_discard_snapshot, result.final_zone));
                 let snapshot_id = result.new_id.unwrap_or(card_id);
                 if let Some(obj) = game.object(snapshot_id) {
                     discarded_snapshots.push(ObjectSnapshot::from_object(obj, game));
                 }
             }
+        }
+
+        let batch_cards: Vec<_> = successful_discards
+            .iter()
+            .map(|(card_id, _, _)| *card_id)
+            .collect();
+        let batch_snapshots: Vec<_> = successful_discards
+            .iter()
+            .filter_map(|(_, snapshot, _)| snapshot.clone())
+            .collect();
+        let mut discard_events = Vec::new();
+        for (batch_index, (card_id, pre_discard_snapshot, final_zone)) in
+            successful_discards.into_iter().enumerate()
+        {
+            discard_events.push(crate::triggers::TriggerEvent::new_with_provenance(
+                DiscardEvent::with_cause(card_id, player_id, cause.clone()).with_destination(final_zone),
+                ctx.provenance,
+            ));
+            let mut event = CardDiscardedEvent::with_cause(player_id, card_id, cause.clone())
+                .with_batch(batch_cards.clone(), batch_snapshots.clone(), batch_index);
+            if let Some(snapshot) = pre_discard_snapshot {
+                event = event.with_snapshot(snapshot);
+            }
+            discard_events.push(crate::triggers::TriggerEvent::new_with_provenance(
+                event,
+                ctx.provenance,
+            ));
         }
 
         if let Some(tag) = &self.tag

--- a/crates/ironsmith-runtime/src/effects/delayed/schedule_delayed_trigger.rs
+++ b/crates/ironsmith-runtime/src/effects/delayed/schedule_delayed_trigger.rs
@@ -126,7 +126,8 @@ impl EffectExecutor for ScheduleDelayedTriggerEffect {
             let Some(tagged) = tagged_objects.get(tag) else {
                 return Ok(EffectOutcome::count(0));
             };
-            let filter_ctx = ctx.filter_context(game);
+            let mut filter_ctx = ctx.filter_context(game);
+            filter_ctx.tagged_objects = tagged_objects.clone();
             let mut matched = 0i32;
             for snapshot in tagged {
                 if let Some(filter) = &self.target_filter

--- a/crates/ironsmith-runtime/src/events/other/card_discarded.rs
+++ b/crates/ironsmith-runtime/src/events/other/card_discarded.rs
@@ -22,6 +22,12 @@ pub struct CardDiscardedEvent {
     pub cause: Option<EventCause>,
     /// Last-known information for the card as it existed in hand before the discard.
     pub snapshot: Option<ObjectSnapshot>,
+    /// Cards discarded by the same discard action, in event order.
+    pub batch_cards: Vec<ObjectId>,
+    /// Last-known information for cards discarded by the same discard action.
+    pub batch_snapshots: Vec<ObjectSnapshot>,
+    /// This card's index in `batch_cards` when the event came from a batch discard.
+    pub batch_index: Option<usize>,
 }
 
 impl CardDiscardedEvent {
@@ -32,6 +38,9 @@ impl CardDiscardedEvent {
             card,
             cause: None,
             snapshot: None,
+            batch_cards: vec![card],
+            batch_snapshots: Vec::new(),
+            batch_index: Some(0),
         }
     }
 
@@ -41,11 +50,26 @@ impl CardDiscardedEvent {
             card,
             cause: Some(cause),
             snapshot: None,
+            batch_cards: vec![card],
+            batch_snapshots: Vec::new(),
+            batch_index: Some(0),
         }
     }
 
     pub fn with_snapshot(mut self, snapshot: ObjectSnapshot) -> Self {
         self.snapshot = Some(snapshot);
+        self
+    }
+
+    pub fn with_batch(
+        mut self,
+        batch_cards: Vec<ObjectId>,
+        batch_snapshots: Vec<ObjectSnapshot>,
+        batch_index: usize,
+    ) -> Self {
+        self.batch_cards = batch_cards;
+        self.batch_snapshots = batch_snapshots;
+        self.batch_index = Some(batch_index);
         self
     }
 }

--- a/crates/ironsmith-runtime/src/game_loop/stack_resolution.rs
+++ b/crates/ironsmith-runtime/src/game_loop/stack_resolution.rs
@@ -193,6 +193,9 @@ fn effect_references_prior_object_targets(effect: &Effect) -> bool {
     effect
         .downcast_ref::<crate::effects::FightEffect>()
         .is_some()
+        || effect
+            .downcast_ref::<crate::effects::ScheduleDelayedTriggerEffect>()
+            .is_some_and(|schedule| schedule.target_tag.is_some())
 }
 
 fn representative_segment_targets(

--- a/crates/ironsmith-runtime/src/static_abilities/protection.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/protection.rs
@@ -322,7 +322,7 @@ impl StaticAbilityKind for Ward {
     }
 
     fn display(&self) -> String {
-        format!("Ward {}", self.cost.display())
+        format!("Ward—{}", self.cost.display())
     }
 
     fn is_keyword(&self) -> bool {

--- a/crates/ironsmith-runtime/src/triggers/cards/you_discard_card.rs
+++ b/crates/ironsmith-runtime/src/triggers/cards/you_discard_card.rs
@@ -3,6 +3,7 @@
 use crate::events::EventKind;
 use crate::events::other::CardDiscardedEvent;
 use crate::filter::ObjectFilterExt as _;
+use crate::snapshot::ObjectSnapshot;
 use crate::target::{ObjectFilter, PlayerFilter};
 use crate::triggers::TriggerEvent;
 use crate::triggers::matcher_trait::{TriggerContext, TriggerMatcher};
@@ -13,6 +14,7 @@ pub struct YouDiscardCardTrigger {
     pub filter: Option<ObjectFilter>,
     pub cause_controller: Option<PlayerFilter>,
     pub effect_like_only: bool,
+    pub one_or_more: bool,
 }
 
 impl YouDiscardCardTrigger {
@@ -22,7 +24,13 @@ impl YouDiscardCardTrigger {
             filter,
             cause_controller: None,
             effect_like_only: false,
+            one_or_more: false,
         }
+    }
+
+    pub fn one_or_more(mut self) -> Self {
+        self.one_or_more = true;
+        self
     }
 
     pub fn caused_by_controller(mut self, player: PlayerFilter) -> Self {
@@ -33,6 +41,67 @@ impl YouDiscardCardTrigger {
     pub fn effect_like_only(mut self) -> Self {
         self.effect_like_only = true;
         self
+    }
+
+    fn snapshot_matches_filter(
+        snapshot: &ObjectSnapshot,
+        filter: &ObjectFilter,
+        ctx: &TriggerContext,
+    ) -> bool {
+        if filter.source && snapshot.object_id == ctx.source_id {
+            return true;
+        }
+        filter.matches_snapshot(snapshot, &ctx.filter_ctx, ctx.game)
+    }
+
+    fn event_card_matches_filter(&self, e: &CardDiscardedEvent, ctx: &TriggerContext) -> bool {
+        let Some(filter) = &self.filter else {
+            return true;
+        };
+        if filter.source && e.card == ctx.source_id {
+            return true;
+        }
+        if let Some(snapshot) = &e.snapshot {
+            return Self::snapshot_matches_filter(snapshot, filter, ctx);
+        }
+        let Some(card) = ctx.game.object(e.card) else {
+            return false;
+        };
+        filter.matches(card, &ctx.filter_ctx, ctx.game)
+    }
+
+    fn batch_matching_count(&self, e: &CardDiscardedEvent, ctx: &TriggerContext) -> usize {
+        let Some(filter) = &self.filter else {
+            return e.batch_cards.len().max(1);
+        };
+        if !e.batch_snapshots.is_empty() {
+            return e
+                .batch_snapshots
+                .iter()
+                .filter(|snapshot| Self::snapshot_matches_filter(snapshot, filter, ctx))
+                .count();
+        }
+        usize::from(self.event_card_matches_filter(e, ctx))
+    }
+
+    fn is_first_matching_card_in_batch(
+        &self,
+        e: &CardDiscardedEvent,
+        ctx: &TriggerContext,
+    ) -> bool {
+        let Some(batch_index) = e.batch_index else {
+            return true;
+        };
+        let Some(filter) = &self.filter else {
+            return batch_index == 0;
+        };
+        if e.batch_snapshots.is_empty() {
+            return true;
+        }
+        e.batch_snapshots
+            .iter()
+            .take(batch_index)
+            .all(|snapshot| !Self::snapshot_matches_filter(snapshot, filter, ctx))
     }
 }
 
@@ -78,16 +147,22 @@ impl TriggerMatcher for YouDiscardCardTrigger {
                 return false;
             }
         }
-        if let Some(filter) = &self.filter {
-            if filter.source && e.card == ctx.source_id {
-                return true;
-            }
-            let Some(card) = ctx.game.object(e.card) else {
-                return false;
-            };
-            return filter.matches(card, &ctx.filter_ctx, ctx.game);
+        if !self.event_card_matches_filter(e, ctx) {
+            return false;
+        }
+        if self.one_or_more {
+            return self.batch_matching_count(e, ctx) > 0
+                && self.is_first_matching_card_in_batch(e, ctx);
         }
         true
+    }
+
+    fn event_value_amount(&self, event: &TriggerEvent, ctx: &TriggerContext) -> Option<i32> {
+        if !self.one_or_more || event.kind() != EventKind::CardDiscarded {
+            return None;
+        }
+        let e = event.downcast::<CardDiscardedEvent>()?;
+        Some(self.batch_matching_count(e, ctx) as i32)
     }
 
     fn display(&self) -> String {
@@ -123,7 +198,13 @@ impl TriggerMatcher for YouDiscardCardTrigger {
             } else if !filter_text.ends_with("card") && !filter_text.ends_with("cards") {
                 filter_text = format!("{filter_text} card");
             }
-            format!("Whenever {player_text} {verb} a {filter_text}")
+            if self.one_or_more {
+                format!("Whenever {player_text} {verb} one or more {filter_text}s")
+            } else {
+                format!("Whenever {player_text} {verb} a {filter_text}")
+            }
+        } else if self.one_or_more {
+            format!("Whenever {player_text} {verb} one or more cards")
         } else {
             format!("Whenever {player_text} {verb} a card")
         }

--- a/crates/ironsmith-runtime/src/triggers/check.rs
+++ b/crates/ironsmith-runtime/src/triggers/check.rs
@@ -1962,7 +1962,12 @@ pub fn check_delayed_triggers(
 
         let mut fired = false;
         for &source in candidate_sources {
-            let ctx = TriggerContext::for_source(source, delayed.controller, game);
+            let ctx = TriggerContext::for_delayed_source(
+                source,
+                delayed.controller,
+                game,
+                &delayed.tagged_objects,
+            );
             if !delayed.trigger.matches(trigger_event, &ctx) {
                 continue;
             }

--- a/crates/ironsmith-runtime/src/triggers/matcher_trait.rs
+++ b/crates/ironsmith-runtime/src/triggers/matcher_trait.rs
@@ -6,7 +6,10 @@
 
 use crate::game_state::GameState;
 use crate::ids::{ObjectId, PlayerId};
+use crate::snapshot::ObjectSnapshot;
+use crate::tag::TagKey;
 use crate::target::FilterContext;
+use std::collections::HashMap;
 
 use super::TriggerEvent;
 
@@ -47,6 +50,17 @@ impl<'a> TriggerContext<'a> {
     /// Create a trigger context for a source permanent.
     pub fn for_source(source_id: ObjectId, controller: PlayerId, game: &'a GameState) -> Self {
         let filter_ctx = game.filter_context_for(controller, Some(source_id));
+        Self::new(source_id, controller, filter_ctx, game)
+    }
+
+    pub fn for_delayed_source(
+        source_id: ObjectId,
+        controller: PlayerId,
+        game: &'a GameState,
+        tagged_objects: &HashMap<TagKey, Vec<ObjectSnapshot>>,
+    ) -> Self {
+        let mut filter_ctx = game.filter_context_for(controller, Some(source_id));
+        filter_ctx.tagged_objects = tagged_objects.clone();
         Self::new(source_id, controller, filter_ctx, game)
     }
 }

--- a/crates/ironsmith-runtime/src/triggers/mod.rs
+++ b/crates/ironsmith-runtime/src/triggers/mod.rs
@@ -931,6 +931,10 @@ impl Trigger {
         Self::new(YouDiscardCardTrigger::new(player, filter))
     }
 
+    pub fn player_discards_cards(player: PlayerFilter, filter: Option<ObjectFilter>) -> Self {
+        Self::new(YouDiscardCardTrigger::new(player, filter).one_or_more())
+    }
+
     pub fn player_discards_card_caused_by_controller(
         player: PlayerFilter,
         filter: Option<ObjectFilter>,

--- a/crates/ironsmith-runtime/src/triggers/model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/triggers/model_interpreter.rs
@@ -322,8 +322,16 @@ pub(crate) fn interpret_trigger_model(
             controller,
             effect_like_only,
         ),
-        TriggerKind::PlayerDiscardsCard { player, filter } => {
-            crate::triggers::Trigger::player_discards_card(player, filter)
+        TriggerKind::PlayerDiscardsCard {
+            player,
+            filter,
+            one_or_more,
+        } => {
+            if one_or_more {
+                crate::triggers::Trigger::player_discards_cards(player, filter)
+            } else {
+                crate::triggers::Trigger::player_discards_card(player, filter)
+            }
         }
         TriggerKind::PlayerRevealsCard {
             player,


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Captain Howler, Sea Scourge
Initial parse error:
```
unsupported triggered line: 'whenever you discard one or more cards, target creature gets +2/+0 until end of turn for each card discarded this way'; oracle-only fallback also failed: unsupported triggered line: 'whenever you discard one or more cards, target creature gets +2/+0 until end of turn for each card discarded this way'
```

Current worker: i-0fa4318be4d92f6bd
Branch: codex/aws-card-fix-captain-howler-sea-scourge
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260604T121212Z-controller-dev-loop-wave0021
