### PR TITLE
Fix Ironsmith parse failure: Ratonhnhaké꞉ton

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
@@ -589,6 +589,19 @@ const SOURCE_ATTACKED_THIS_TURN_CONDITION_PATTERN: ClauseShape<'static> = clause
             &["that", "creature", "attacked", "this", "turn"],
         ]
 );
+const SOURCE_HAS_NOT_DEALT_DAMAGE_YET_CONDITION_PATTERN: ClauseShape<'static> = clause_shape!(
+    exact_any
+        & [
+            &["it", "hasnt", "dealt", "damage", "yet"],
+            &["it", "hasn't", "dealt", "damage", "yet"],
+            &["this", "hasnt", "dealt", "damage", "yet"],
+            &["this", "hasn't", "dealt", "damage", "yet"],
+            &["this", "creature", "hasnt", "dealt", "damage", "yet"],
+            &["this", "creature", "hasn't", "dealt", "damage", "yet"],
+            &["this", "permanent", "hasnt", "dealt", "damage", "yet"],
+            &["this", "permanent", "hasn't", "dealt", "damage", "yet"],
+        ]
+);
 const YOU_ATTACKED_THIS_TURN_CONDITION_PATTERN: ClauseShape<'static> =
     clause_shape!(exact & ["you", "attacked", "this", "turn"]);
 const SOURCE_ENTERED_THIS_TURN_CONDITION_PATTERN: ClauseShape<'static> = clause_shape!(
@@ -2894,6 +2907,11 @@ pub(crate) fn parse_static_condition_clause(
     }
     if SOURCE_ATTACKED_THIS_TURN_CONDITION_PATTERN.matches_words(&clause_words) {
         return Ok(crate::ConditionExpr::SourceAttackedThisTurn);
+    }
+    if SOURCE_HAS_NOT_DEALT_DAMAGE_YET_CONDITION_PATTERN.matches_words(&clause_words) {
+        return Ok(crate::ConditionExpr::Not(Box::new(
+            crate::ConditionExpr::SourceDealtDamage,
+        )));
     }
     if YOU_ATTACKED_THIS_TURN_CONDITION_PATTERN.matches_words(&clause_words) {
         return Ok(crate::ConditionExpr::AttackedThisTurn);

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
@@ -3686,6 +3686,7 @@ fn parse_battlefield_change_this_turn_predicate(words: &[&str]) -> Option<Predic
 fn parse_combat_damage_this_turn_predicate(words: &[&str]) -> Option<PredicateAst> {
     let tokens = crate::runtime_backend::lexer::synthetic_word_tokens(words);
     parse_source_dealt_combat_damage_this_turn_shape(&tokens)
+        .or_else(|| parse_source_dealt_damage_shape(&tokens))
         .or_else(|| parse_player_dealt_combat_damage_by_subtype_this_turn_shape(&tokens))
 }
 
@@ -3795,6 +3796,34 @@ fn parse_source_dealt_combat_damage_this_turn_shape(
         return None;
     }
     Some(PredicateAst::SourceDealtCombatDamageToPlayerThisTurn)
+}
+
+fn parse_source_dealt_damage_shape(tokens: &[OwnedLexToken]) -> Option<PredicateAst> {
+    let clause = LexedClause::new(tokens);
+    let action_phrase = &["dealt", "damage"];
+    let atoms = [
+        LexPattern::subject("subject", LexCaptureKind::UntilPhrase(action_phrase)),
+        LexPattern::action("action", LexCaptureKind::WordCount(action_phrase.len())),
+        LexPattern::modifier("tail", LexCaptureKind::Rest),
+    ];
+    let matched = LexPattern::new(&atoms).match_clause(clause)?;
+    let subject_clause = matched.capture_clause_by_role(LexCaptureRole::Subject, clause)?;
+    if !clause_matches_any_phrase(
+        subject_clause,
+        &[
+            &["it"],
+            &["this"],
+            &["this", "creature"],
+            &["this", "permanent"],
+        ],
+    ) {
+        return None;
+    }
+    let tail_clause = matched.capture_clause("tail", clause)?;
+    if !tail_clause.tokens().is_empty() {
+        return None;
+    }
+    Some(PredicateAst::SourceDealtDamage)
 }
 
 fn parse_player_dealt_combat_damage_by_subtype_this_turn_shape(

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
@@ -619,6 +619,7 @@ pub(crate) fn compile_condition_from_predicate_ast(
             display: Some(display.clone()),
         },
         PredicateAst::SourcePowerAtLeast(count) => Condition::SourcePowerAtLeast(*count),
+        PredicateAst::SourceDealtDamage => Condition::SourceDealtDamage,
         PredicateAst::SourceDealtCombatDamageToPlayerThisTurn => {
             Condition::SourceDealtCombatDamageToPlayerThisTurn
         }

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
@@ -5,6 +5,7 @@ type EffectCompileHandler = fn(
     &EffectAst,
     &mut EffectLoweringContext,
 ) -> Result<Option<EffectCompileOutcome>, CardTextError>;
+const ATTACH_CREATED_TOKEN_TAG: &str = "__created_token__";
 
 #[derive(Clone, Copy)]
 struct EffectCompileHandlerDef {
@@ -1143,8 +1144,19 @@ fn compile_subject_verb_effect(
         SubjectVerbActionAst::Attach { object, target } => {
             let (objects, object_choices) =
                 resolve_attach_object_spec(object, &current_reference_env(ctx))?;
-            let (target, target_choices) =
-                resolve_target_spec_with_choices(target, &current_reference_env(ctx))?;
+            let (target, target_choices) = if matches!(
+                target,
+                TargetAst::Tagged(tag, _) if tag.as_str() == ATTACH_CREATED_TOKEN_TAG
+            ) {
+                let tag = ctx.last_created_token_tag.clone().ok_or_else(|| {
+                    CardTextError::ParseError(
+                        "missing created token antecedent for attach target".to_string(),
+                    )
+                })?;
+                (ChooseSpec::Tagged(TagKey::from(tag)), Vec::new())
+            } else {
+                resolve_target_spec_with_choices(target, &current_reference_env(ctx))?
+            };
             let mut choices = Vec::new();
             for choice in object_choices {
                 push_choice(&mut choices, choice);
@@ -3765,6 +3777,7 @@ fn compile_subject_verb_effect(
                 let tag = ctx.next_tag("created");
                 effect = effect.tag(tag.clone());
                 ctx.last_object_tag = Some(tag.clone());
+                ctx.last_created_token_tag = Some(tag.clone());
                 created_tag = Some(tag);
             }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -591,6 +591,7 @@ pub(crate) enum PredicateAst {
         display: String,
     },
     SourcePowerAtLeast(u32),
+    SourceDealtDamage,
     SourceDealtCombatDamageToPlayerThisTurn,
     PlayerWasDealtCombatDamageByCreatureSubtypeThisTurn {
         player: PlayerAst,

--- a/crates/ironsmith-compiler/src/runtime_backend/model/shared_types.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/shared_types.rs
@@ -42,6 +42,7 @@ pub(crate) struct LoweringFrame {
     pub(crate) last_effect_id: Option<EffectId>,
     pub(crate) last_library_search_effect_id: Option<EffectId>,
     pub(crate) last_object_tag: Option<String>,
+    pub(crate) last_created_token_tag: Option<String>,
     pub(crate) last_it_choice_is_set: bool,
     pub(crate) last_revealed_tag: Option<String>,
     pub(crate) last_exiled_collection_tag: Option<String>,
@@ -164,6 +165,7 @@ impl EffectLoweringContext {
         self.last_effect_id = frame.last_effect_id;
         self.last_library_search_effect_id = frame.last_library_search_effect_id;
         self.last_object_tag = frame.last_object_tag;
+        self.last_created_token_tag = frame.last_created_token_tag;
         self.last_it_choice_is_set = frame.last_it_choice_is_set;
         self.last_exiled_collection_tag = frame.last_exiled_collection_tag;
         self.last_player_filter = frame.last_player_filter;

--- a/crates/ironsmith-compiler/src/runtime_backend/references/reference_model.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/references/reference_model.rs
@@ -17,6 +17,7 @@ pub(crate) struct ReferenceFrame {
     pub(crate) last_effect_id: Option<EffectId>,
     pub(crate) last_library_search_effect_id: Option<EffectId>,
     pub(crate) last_object_tag: Option<String>,
+    pub(crate) last_created_token_tag: Option<String>,
     pub(crate) last_it_choice_is_set: bool,
     pub(crate) last_player_filter: Option<PlayerFilter>,
     pub(crate) source_object_antecedent: bool,
@@ -34,6 +35,7 @@ impl ReferenceFrame {
             last_effect_id: frame.last_effect_id,
             last_library_search_effect_id: frame.last_library_search_effect_id,
             last_object_tag: frame.last_object_tag.clone(),
+            last_created_token_tag: frame.last_created_token_tag.clone(),
             last_it_choice_is_set: frame.last_it_choice_is_set,
             last_player_filter: frame.last_player_filter.clone(),
             source_object_antecedent: frame.source_object_antecedent,
@@ -51,6 +53,7 @@ impl ReferenceFrame {
             last_effect_id: self.last_effect_id,
             last_library_search_effect_id: self.last_library_search_effect_id,
             last_object_tag: self.last_object_tag.clone(),
+            last_created_token_tag: self.last_created_token_tag.clone(),
             last_it_choice_is_set: self.last_it_choice_is_set,
             last_revealed_tag: None,
             last_exiled_collection_tag: None,
@@ -95,6 +98,7 @@ impl<T: Clone + PartialEq> RefState<T> {
 #[derive(Debug, Clone, PartialEq, Default)]
 pub(crate) struct ReferenceImports {
     pub(crate) last_object_tag: Option<TagKey>,
+    pub(crate) last_created_token_tag: Option<TagKey>,
     pub(crate) last_it_choice_is_set: bool,
     pub(crate) last_player_filter: Option<PlayerFilter>,
     pub(crate) source_object_antecedent: bool,
@@ -105,6 +109,7 @@ pub(crate) struct ReferenceImports {
 impl ReferenceImports {
     pub(crate) fn is_empty(&self) -> bool {
         self.last_object_tag.is_none()
+            && self.last_created_token_tag.is_none()
             && !self.last_it_choice_is_set
             && self.last_player_filter.is_none()
             && !self.source_object_antecedent
@@ -115,6 +120,7 @@ impl ReferenceImports {
     pub(crate) fn with_last_object_tag(tag: impl Into<TagKey>) -> Self {
         Self {
             last_object_tag: Some(tag.into()),
+            last_created_token_tag: None,
             last_it_choice_is_set: false,
             ..Default::default()
         }
@@ -123,6 +129,7 @@ impl ReferenceImports {
     pub(crate) fn from_frame(frame: &ReferenceFrame) -> Self {
         Self {
             last_object_tag: frame.last_object_tag.as_ref().map(TagKey::from),
+            last_created_token_tag: frame.last_created_token_tag.as_ref().map(TagKey::from),
             last_it_choice_is_set: frame.last_it_choice_is_set,
             last_player_filter: frame.last_player_filter.clone(),
             source_object_antecedent: frame.source_object_antecedent,
@@ -139,6 +146,7 @@ impl ReferenceImports {
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct ReferenceEnv {
     pub(crate) last_object_tag: RefState<TagKey>,
+    pub(crate) last_created_token_tag: RefState<TagKey>,
     pub(crate) last_it_choice_is_set: bool,
     pub(crate) last_player_filter: RefState<PlayerFilter>,
     pub(crate) source_object_antecedent: bool,
@@ -153,6 +161,7 @@ impl Default for ReferenceEnv {
     fn default() -> Self {
         Self {
             last_object_tag: RefState::Unknown,
+            last_created_token_tag: RefState::Unknown,
             last_it_choice_is_set: false,
             last_player_filter: RefState::Unknown,
             source_object_antecedent: false,
@@ -175,6 +184,7 @@ impl ReferenceEnv {
     ) -> Self {
         Self {
             last_object_tag: RefState::from_option(imports.last_object_tag.clone()),
+            last_created_token_tag: RefState::from_option(imports.last_created_token_tag.clone()),
             last_it_choice_is_set: imports.last_it_choice_is_set,
             last_player_filter: RefState::from_option(imports.last_player_filter.clone()),
             source_object_antecedent: imports.source_object_antecedent,
@@ -194,6 +204,9 @@ impl ReferenceEnv {
         Self {
             last_object_tag: RefState::from_option(
                 frame.last_object_tag.as_ref().map(TagKey::from),
+            ),
+            last_created_token_tag: RefState::from_option(
+                frame.last_created_token_tag.as_ref().map(TagKey::from),
             ),
             last_it_choice_is_set: frame.last_it_choice_is_set,
             last_player_filter: RefState::from_option(frame.last_player_filter.clone()),
@@ -222,6 +235,11 @@ impl ReferenceEnv {
             last_library_search_effect_id: self.last_library_search_effect_id.clone().into_option(),
             last_object_tag: self
                 .last_object_tag
+                .clone()
+                .into_option()
+                .map(|tag| tag.as_str().to_string()),
+            last_created_token_tag: self
+                .last_created_token_tag
                 .clone()
                 .into_option()
                 .map(|tag| tag.as_str().to_string()),
@@ -275,6 +293,7 @@ impl ReferenceEnv {
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct ReferenceExports {
     pub(crate) last_object_tag: RefState<TagKey>,
+    pub(crate) last_created_token_tag: RefState<TagKey>,
     pub(crate) last_it_choice_is_set: bool,
     pub(crate) last_player_filter: RefState<PlayerFilter>,
     pub(crate) source_object_antecedent: bool,
@@ -287,6 +306,7 @@ impl Default for ReferenceExports {
     fn default() -> Self {
         Self {
             last_object_tag: RefState::Unknown,
+            last_created_token_tag: RefState::Unknown,
             last_it_choice_is_set: false,
             last_player_filter: RefState::Unknown,
             source_object_antecedent: false,
@@ -301,6 +321,7 @@ impl ReferenceExports {
     pub(crate) fn from_env(env: &ReferenceEnv) -> Self {
         Self {
             last_object_tag: env.last_object_tag.clone(),
+            last_created_token_tag: env.last_created_token_tag.clone(),
             last_it_choice_is_set: env.last_it_choice_is_set,
             last_player_filter: env.last_player_filter.clone(),
             source_object_antecedent: env.source_object_antecedent,
@@ -313,6 +334,10 @@ impl ReferenceExports {
     pub(crate) fn join(left: &Self, right: &Self) -> Self {
         Self {
             last_object_tag: RefState::join(&left.last_object_tag, &right.last_object_tag),
+            last_created_token_tag: RefState::join(
+                &left.last_created_token_tag,
+                &right.last_created_token_tag,
+            ),
             last_it_choice_is_set: left.last_it_choice_is_set && right.last_it_choice_is_set,
             last_player_filter: RefState::join(&left.last_player_filter, &right.last_player_filter),
             source_object_antecedent: left.source_object_antecedent
@@ -329,6 +354,7 @@ impl ReferenceExports {
     pub(crate) fn to_imports(&self) -> ReferenceImports {
         ReferenceImports {
             last_object_tag: self.last_object_tag.clone().into_option(),
+            last_created_token_tag: self.last_created_token_tag.clone().into_option(),
             last_it_choice_is_set: self.last_it_choice_is_set,
             last_player_filter: self.last_player_filter.clone().into_option(),
             source_object_antecedent: self.source_object_antecedent,

--- a/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
@@ -405,7 +405,9 @@ fn advance_reference_frame_for_effect(
                 }
                 SubjectVerbActionAst::Populate { .. } => {
                     if frame.auto_tag_object_targets {
-                        frame.last_object_tag = Some(next_reference_tag(id_gen, "created"));
+                        let tag = next_reference_tag(id_gen, "created");
+                        frame.last_object_tag = Some(tag.clone());
+                        frame.last_created_token_tag = Some(tag);
                     }
                 }
                 SubjectVerbActionAst::Amass { .. } => {
@@ -958,7 +960,9 @@ fn advance_reference_frame_for_effect(
                 | SubjectVerbActionAst::CreateTokenCopyFromSource { player, .. } => {
                     track_effect_player(*player, frame, true, true)?;
                     if frame.auto_tag_object_targets {
-                        frame.last_object_tag = Some(next_reference_tag(id_gen, "created"));
+                        let tag = next_reference_tag(id_gen, "created");
+                        frame.last_object_tag = Some(tag.clone());
+                        frame.last_created_token_tag = Some(tag);
                     }
                 }
                 SubjectVerbActionAst::CreateTokenWithMods {
@@ -972,7 +976,9 @@ fn advance_reference_frame_for_effect(
                         || attached_to.is_some()
                         || dynamic_power_toughness.is_some()
                     {
-                        frame.last_object_tag = Some(next_reference_tag(id_gen, "created"));
+                        let tag = next_reference_tag(id_gen, "created");
+                        frame.last_object_tag = Some(tag.clone());
+                        frame.last_created_token_tag = Some(tag);
                     }
                     if frame.auto_tag_object_targets && attached_to.is_some() {
                         frame.last_object_tag = Some(next_reference_tag(id_gen, "attachment_target"));
@@ -1888,6 +1894,10 @@ fn advance_reference_env_for_effect(
                 last_object_tag: RefState::join(
                     &true_sequence.final_env.last_object_tag,
                     &false_sequence.final_env.last_object_tag,
+                ),
+                last_created_token_tag: RefState::join(
+                    &true_sequence.final_env.last_created_token_tag,
+                    &false_sequence.final_env.last_created_token_tag,
                 ),
                 last_it_choice_is_set: true_sequence.final_env.last_it_choice_is_set
                     && false_sequence.final_env.last_it_choice_is_set,

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/combat_verbs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/verb_handlers/combat_verbs.rs
@@ -9,7 +9,10 @@ const ATTACH_TAGGED_ARTIFACT_PATTERN: ClauseShape<'static> =
 const ATTACH_TAGGED_ENCHANTMENT_PATTERN: ClauseShape<'static> =
     clause_shape!(exact & ["that", "enchantment"]);
 const ATTACH_IT_TO_TOKEN_PATTERN: ClauseShape<'static> = clause_shape!(exact & ["it"]);
-const ATTACH_TOKEN_TARGET_PATTERN: ClauseShape<'static> = clause_shape!(exact & ["the", "token"]);
+const ATTACH_THE_TOKEN_TARGET_PATTERN: ClauseShape<'static> = clause_shape!(exact & ["the", "token"]);
+const ATTACH_TOKEN_TARGET_PATTERN: ClauseShape<'static> =
+    clause_shape!(exact_any & [&["the", "token"], &["that", "token"]]);
+pub(crate) const ATTACH_CREATED_TOKEN_TAG: &str = "__created_token__";
 const DAMAGE_EACH_OPPONENT_HAND_SIZE_PATTERN: ClauseShape<'static> = clause_shape!(
     prefix &["damage", "to", "each", "opponent", "equal", "to"];
     contains_words &["number", "cards", "hand"]
@@ -253,7 +256,7 @@ pub(crate) fn parse_attach(tokens: &[OwnedLexToken]) -> Result<EffectAst, CardTe
     let object = parse_attach_object_phrase(&object_tokens)?;
     let target_words = crate::runtime_backend::token_word_refs(&target_tokens);
     if ATTACH_IT_TO_TOKEN_PATTERN.matches_words(&object_words)
-        && ATTACH_TOKEN_TARGET_PATTERN.matches_words(&target_words)
+        && ATTACH_THE_TOKEN_TARGET_PATTERN.matches_words(&target_words)
     {
         return Ok(EffectAst::subject_verb_attach(
             TargetAst::Tagged(TagKey::from("triggering"), span_from_tokens(&object_tokens)),
@@ -262,6 +265,11 @@ pub(crate) fn parse_attach(tokens: &[OwnedLexToken]) -> Result<EffectAst, CardTe
     }
     let target = if ATTACH_TAGGED_OBJECT_PATTERN.matches_words(&target_words) {
         TargetAst::Tagged(TagKey::from(IT_TAG), span_from_tokens(&target_tokens))
+    } else if ATTACH_TOKEN_TARGET_PATTERN.matches_words(&target_words) {
+        TargetAst::Tagged(
+            TagKey::from(ATTACH_CREATED_TOKEN_TAG),
+            span_from_tokens(&target_tokens),
+        )
     } else {
         parse_target_phrase(&target_tokens)?
     };

--- a/crates/ironsmith-core/src/value_model.rs
+++ b/crates/ironsmith-core/src/value_model.rs
@@ -815,6 +815,7 @@ pub enum Condition {
     },
     SourceHasCountersAtLeast(u32),
     SourcePowerAtLeast(u32),
+    SourceDealtDamage,
     SourceDealtCombatDamageToPlayerThisTurn,
     PlayerWasDealtCombatDamageByCreatureSubtypeThisTurn {
         player: PlayerFilter,

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -302,6 +302,195 @@ fn rayne_academy_chancellor_targeting_trigger_draws_conditionally_at_runtime() {
 }
 
 #[test]
+fn ratonhnhake_ton_strict_parser_and_compiled_text_regression() {
+    assert_oracle_card_parses_strict("Ratonhnhaké꞉ton");
+
+    let def = parse_oracle_card_definition("Ratonhnhaké꞉ton");
+    let rendered = compiled_text_lines(&def).join("\n");
+    let abilities_debug = format!("{:#?}", def.abilities);
+
+    assert!(
+        rendered.contains(
+            "As long as Ratonhnhaké꞉ton hasn't dealt damage yet, Ratonhnhaké꞉ton has hexproof and can't be blocked."
+        ),
+        "expected Ratonhnhake ton's damage-yet static condition to render as one conditional keyword line, got {rendered}"
+    );
+    assert!(
+        rendered.contains(
+            "return target Equipment card from your graveyard to the battlefield, then attach it to that token"
+        ),
+        "expected Ratonhnhake ton's reflexive Equipment return to attach to the created token, got {rendered}"
+    );
+    assert!(
+        abilities_debug.contains("Not(SourceDealtDamage)")
+            && abilities_debug.contains("ReflexiveTriggerEffect")
+            && abilities_debug.contains("created_0")
+            && abilities_debug.contains("returned_1"),
+        "expected Ratonhnhake ton to structurally track source damage and created/returned object tags, got {abilities_debug}"
+    );
+}
+
+#[test]
+fn ratonhnhake_ton_loses_hexproof_and_unblockable_after_dealing_damage() {
+    let def = parse_oracle_card_definition("Ratonhnhaké꞉ton");
+    let mut game = crate::tests::test_helpers::setup_two_player_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let raton = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let bob_source = CardDefinitionBuilder::new(CardId::new(), "Bob Targeting Source")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .build();
+    let bob_source = game.create_object_from_definition(&bob_source, bob, Zone::Battlefield);
+    let damage_target = CardDefinitionBuilder::new(CardId::new(), "Damage Target")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .build();
+    let damage_target = game.create_object_from_definition(&damage_target, bob, Zone::Battlefield);
+
+    game.update_cant_effects();
+    assert!(
+        !game.can_be_blocked(raton),
+        "Ratonhnhake ton should be unblockable before it has dealt damage"
+    );
+    assert!(
+        !crate::targeting::can_target_object(&game, raton, bob_source, bob).is_legal(),
+        "Ratonhnhake ton should have hexproof from opponents before it has dealt damage"
+    );
+
+    let damage_event = crate::triggers::TriggerEvent::new_with_provenance(
+        crate::events::DamageEvent::with_cause(
+            raton,
+            crate::events::DamageTarget::Object(damage_target),
+            1,
+            false,
+            crate::events::cause::EventCause::effect(),
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+    game.record_turn_history_event(&damage_event);
+    game.update_cant_effects();
+
+    assert!(
+        game.can_be_blocked(raton),
+        "Ratonhnhake ton should be blockable after it has dealt any damage"
+    );
+    assert!(
+        crate::targeting::can_target_object(&game, raton, bob_source, bob).is_legal(),
+        "Ratonhnhake ton should lose hexproof from opponents after it has dealt damage"
+    );
+
+    game.turn_store.turn_history.clear_for_new_turn();
+    game.update_cant_effects();
+    assert!(
+        game.can_be_blocked(raton)
+            && crate::targeting::can_target_object(&game, raton, bob_source, bob).is_legal(),
+        "the damage-yet condition should remain false after turn history clears"
+    );
+
+    let exiled_raton = game
+        .move_object_by_effect(raton, Zone::Exile)
+        .expect("Ratonhnhake ton should move to exile");
+    let returned_raton = game
+        .move_object_by_effect(exiled_raton, Zone::Battlefield)
+        .expect("Ratonhnhake ton should return as a new object");
+    game.update_cant_effects();
+    assert!(
+        !game.can_be_blocked(returned_raton)
+            && !crate::targeting::can_target_object(&game, returned_raton, bob_source, bob)
+                .is_legal(),
+        "a new Ratonhnhake ton object should not inherit the old object's damage history"
+    );
+}
+
+#[test]
+fn ratonhnhake_ton_combat_damage_trigger_returns_and_attaches_equipment_to_token() {
+    struct ChooseEquipment {
+        equipment: ObjectId,
+    }
+    impl crate::decision::DecisionMaker for ChooseEquipment {
+        fn decide_targets(
+            &mut self,
+            _game: &crate::game_state::GameState,
+            ctx: &crate::decisions::context::TargetsContext,
+        ) -> Vec<crate::game_state::Target> {
+            ctx.requirements
+                .iter()
+                .filter_map(|requirement| {
+                    requirement.legal_targets.iter().find_map(|target| match target {
+                        crate::game_state::Target::Object(object) if *object == self.equipment => {
+                            Some(*target)
+                        }
+                        _ => None,
+                    })
+                })
+                .collect()
+        }
+    }
+
+    let def = parse_oracle_card_definition("Ratonhnhaké꞉ton");
+    let mut game = crate::tests::test_helpers::setup_two_player_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let raton = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let equipment_def = CardDefinitionBuilder::new(CardId::new(), "Hidden Blade")
+        .card_types(vec![CardType::Artifact])
+        .subtypes(vec![Subtype::Equipment])
+        .build();
+    let equipment = game.create_object_from_definition(&equipment_def, alice, Zone::Graveyard);
+    let equipment_stable = game.object(equipment).expect("Equipment should exist").stable_id;
+
+    let damage_event = crate::triggers::TriggerEvent::new_with_provenance(
+        crate::events::DamageEvent::with_cause(
+            raton,
+            crate::events::DamageTarget::Player(bob),
+            3,
+            true,
+            crate::events::cause::EventCause::combat_damage(raton),
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+    let mut trigger_queue = crate::triggers::TriggerQueue::new();
+    for trigger in crate::triggers::check_triggers(&game, &damage_event) {
+        trigger_queue.add(trigger);
+    }
+    assert_eq!(
+        trigger_queue.entries.len(),
+        1,
+        "Ratonhnhake ton should trigger once"
+    );
+
+    let mut dm = ChooseEquipment { equipment };
+    crate::game_loop::put_triggers_on_stack_with_dm(&mut game, &mut trigger_queue, &mut dm)
+        .expect("Ratonhnhake ton trigger should go on the stack");
+    game.turn.priority_player = Some(game.turn.active_player);
+    crate::game_loop::run_priority_loop_with(&mut game, &mut trigger_queue, &mut dm)
+        .expect("Ratonhnhake ton trigger and reflexive trigger should resolve");
+
+    let assassin = game
+        .objects_in_zone(Zone::Battlefield)
+        .into_iter()
+        .find(|object_id| {
+            game.object(*object_id).is_some_and(|object| {
+                object.name == "Assassin" && game.controller_of(object) == alice
+            })
+        })
+        .expect("Ratonhnhake ton should create an Assassin token");
+    let returned_equipment = game
+        .find_object_by_stable_id(equipment_stable)
+        .expect("Equipment should still exist after returning");
+    let equipment_object = game
+        .object(returned_equipment)
+        .expect("returned Equipment should exist");
+    assert_eq!(equipment_object.zone, Zone::Battlefield);
+    assert_eq!(
+        equipment_object.attached_to,
+        Some(crate::object::AttachmentTarget::Object(assassin)),
+        "returned Equipment should attach to the Assassin token, not to itself"
+    );
+}
+
+#[test]
 fn rampaging_aetherhood_strict_parser_and_compiled_text_regression() {
     let def = parse_oracle_card_definition("Rampaging Aetherhood");
     let ability_debug = format!("{:#?}", def.abilities);

--- a/crates/ironsmith-runtime/src/compiled_text/debug_safe.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/debug_safe.rs
@@ -18,10 +18,44 @@ impl DebugSafeLine {
 }
 
 pub(super) fn normalize_debug_safe_surface(lines: Vec<RawRenderedLine>) -> Vec<DebugSafeLine> {
-    lines
+    let lines = lines
         .into_iter()
         .filter_map(DebugSafeLine::from_raw)
-        .collect()
+        .collect::<Vec<_>>();
+    merge_matching_conditional_keyword_and_unblockable(lines)
+}
+
+fn merge_matching_conditional_keyword_and_unblockable(
+    lines: Vec<DebugSafeLine>,
+) -> Vec<DebugSafeLine> {
+    let mut merged = Vec::new();
+    let mut iter = lines.into_iter().peekable();
+    while let Some(line) = iter.next() {
+        if let Some(next) = iter.peek()
+            && let Some(combined) = conditional_keyword_unblockable_line(&line.0, &next.0)
+        {
+            merged.push(DebugSafeLine(combined));
+            iter.next();
+            continue;
+        }
+        merged.push(line);
+    }
+    merged
+}
+
+fn conditional_keyword_unblockable_line(first: &str, second: &str) -> Option<String> {
+    let (keyword_prefix, condition) = first.strip_suffix('.')?.split_once(" as long as ")?;
+    let keyword = keyword_prefix.strip_prefix("This creature has ")?;
+    let unblockable_condition = second
+        .strip_suffix('.')?
+        .strip_prefix("This creature can't be blocked as long as ")?;
+    if condition != unblockable_condition {
+        return None;
+    }
+    Some(format!(
+        "As long as {condition}, this creature has {} and can't be blocked.",
+        keyword.to_ascii_lowercase()
+    ))
 }
 
 fn mechanical_cleanup(line: String) -> String {
@@ -127,6 +161,10 @@ fn normalize_debug_safe_spelling_surface(line: &str) -> String {
         .replace("enter the battlefield", "enter")
         .replace("Enters the battlefield", "Enters")
         .replace("Enter the battlefield", "Enter")
+        .replace(
+            "to the battlefield. Attach it to that token",
+            "to the battlefield, then attach it to that token",
+        )
         .replace(" in the battlefield", " on the battlefield")
         .replace(" In the battlefield", " On the battlefield")
         .replace("Cascade and Cascade", "Cascade, cascade")

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -12793,6 +12793,7 @@ pub(super) fn describe_condition(condition: &Condition) -> String {
             counter.description()
         ),
         Condition::SourceAttackedThisTurn => "this creature attacked this turn".to_string(),
+        Condition::SourceDealtDamage => "this creature has dealt damage".to_string(),
         Condition::SourceDealtCombatDamageToPlayerThisTurn => {
             "it dealt combat damage to a player this turn".to_string()
         }

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -770,6 +770,12 @@ fn normalize_compile_effect_list_surface(line: &str) -> String {
     {
         return "Each opponent chooses a creature card in their graveyard. Put those cards onto the battlefield under your control".to_string();
     }
+    if lower.contains(" to the battlefield. attach it to that token") {
+        return line.replace(
+            " to the battlefield. Attach it to that token",
+            " to the battlefield, then attach it to that token",
+        );
+    }
     line.to_string()
 }
 
@@ -5656,6 +5662,10 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
         }
         return format!("{}. {compact_tail}", prefix.trim_end_matches('.'));
     }
+    let raw_effects = effects.iter().collect::<Vec<_>>();
+    if let Some(compact) = describe_put_onto_battlefield_attached(&raw_effects) {
+        return compact;
+    }
     if let [for_players_effect, look_effect, grant_effect] = effects
         && let Some(for_players) =
             for_players_effect.downcast_ref::<crate::effects::ForPlayersEffect>()
@@ -5676,7 +5686,6 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
         return compact;
     }
 
-    let raw_effects = effects.iter().collect::<Vec<_>>();
     if let Some(compact) = describe_discard_reveal_hand_choose_discard_chosen(&raw_effects) {
         return compact;
     }
@@ -6402,13 +6411,16 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
         };
 
         let tagged_move = move_effect.downcast_ref::<crate::effects::TaggedEffect>()?;
-        let move_to_zone = tagged_move
+        let moves_to_battlefield = tagged_move
             .effect
-            .downcast_ref::<crate::effects::MoveToZoneEffect>()?;
+            .downcast_ref::<crate::effects::MoveToZoneEffect>()
+            .is_some_and(|move_to_zone| move_to_zone.zone == Zone::Battlefield)
+            || tagged_move
+                .effect
+                .downcast_ref::<crate::effects::ReturnFromGraveyardToBattlefieldEffect>()
+                .is_some_and(|return_to_battlefield| !return_to_battlefield.tapped);
         let attach = attach_effect.downcast_ref::<crate::effects::AttachObjectsEffect>()?;
-        if move_to_zone.zone != Zone::Battlefield
-            || !choose_spec_references_exact_tag(&attach.objects, &tagged_move.tag)
-        {
+        if !moves_to_battlefield || !choose_spec_references_exact_tag(&attach.objects, &tagged_move.tag) {
             return None;
         }
 
@@ -6420,14 +6432,17 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
             return None;
         }
 
-        Some(format!(
-            "{move_text} attached to {}",
-            describe_choose_spec(&attach.target)
-        ))
-    }
-
-    if let Some(compact) = describe_put_onto_battlefield_attached(&raw_effects) {
-        return compact;
+        let target_text = match &attach.target {
+            ChooseSpec::Tagged(tag) if tag.as_str().starts_with("created_") => "that token".to_string(),
+            _ => describe_choose_spec(&attach.target),
+        };
+        if move_text.to_ascii_lowercase().contains("onto the battlefield") {
+            Some(format!("{move_text} attached to {target_text}"))
+        } else if move_text.to_ascii_lowercase().contains("to the battlefield") {
+            Some(format!("{move_text}, then attach it to {target_text}"))
+        } else {
+            None
+        }
     }
 
     fn describe_exile_then_incubate_count(effects: &[&Effect]) -> Option<String> {
@@ -29546,7 +29561,13 @@ pub(super) fn describe_with_id_then_reflexive_trigger(
     }
 
     let setup = describe_effect(&with_id.effect);
-    let triggered = lowercase_first(&describe_effect_list(&reflexive.effects));
+    let mut triggered = lowercase_first(&describe_effect_list(&reflexive.effects));
+    if triggered.contains(" to the battlefield. attach it to that token") {
+        triggered = triggered.replace(
+            " to the battlefield. attach it to that token",
+            " to the battlefield, then attach it to that token",
+        );
+    }
     let condition = if let Some(may) = with_id.effect.downcast_ref::<crate::effects::MayEffect>() {
         let who = may
             .decider
@@ -31502,6 +31523,11 @@ fn choose_spec_references_exact_tag(spec: &ChooseSpec, tag: &TagKey) -> bool {
         ChooseSpec::Tagged(candidate) => candidate == tag,
         ChooseSpec::Object(filter) | ChooseSpec::All(filter) => {
             filter == &ObjectFilter::tagged(tag.clone())
+                || filter.tagged_constraints.iter().any(|constraint| {
+                    constraint.tag == *tag
+                        && constraint.relation
+                            == crate::filter::TaggedOpbjectRelation::IsTaggedObject
+                })
         }
         ChooseSpec::Target(inner) | ChooseSpec::WithCount(inner, _) => {
             choose_spec_references_exact_tag(inner, tag)
@@ -34260,6 +34286,11 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
             && matches!(&attach.target, ChooseSpec::Tagged(tag) if tag.as_str().starts_with("created_"))
         {
             return "Attach it to the token".to_string();
+        }
+        if matches!(&attach.target, ChooseSpec::Tagged(tag) if tag.as_str().starts_with("created_"))
+            && matches!(&attach.objects, ChooseSpec::All(filter) | ChooseSpec::Object(filter) if filter.tagged_constraints.iter().any(|constraint| constraint.tag.as_str().starts_with("returned_") && constraint.relation == crate::filter::TaggedOpbjectRelation::IsTaggedObject))
+        {
+            return "Attach it to that token".to_string();
         }
         return format!(
             "Attach {} to {}",

--- a/crates/ironsmith-runtime/src/condition_eval.rs
+++ b/crates/ironsmith-runtime/src/condition_eval.rs
@@ -1108,6 +1108,7 @@ fn evaluate_condition_shared_core(
                 .or_else(|| game.object(ctx.source).and_then(|obj| obj.power()))
                 .is_some_and(|power| power >= *min_power as i32),
         ),
+        Condition::SourceDealtDamage => Some(game.source_dealt_damage(ctx.source)),
         Condition::SourceDealtCombatDamageToPlayerThisTurn => {
             Some(game.source_dealt_combat_damage_to_player_this_turn(ctx.source))
         }
@@ -1249,6 +1250,7 @@ fn assert_condition_variant_coverage(condition: &Condition) {
         Condition::SourceHasCounterAtLeast { .. } => {}
         Condition::SourceHasCountersAtLeast(..) => {}
         Condition::SourcePowerAtLeast(..) => {}
+        Condition::SourceDealtDamage => {}
         Condition::SourceDealtCombatDamageToPlayerThisTurn => {}
         Condition::PlayerWasDealtCombatDamageByCreatureSubtypeThisTurn { .. } => {}
         Condition::SourceAttackedOrBlockedThisTurn => {}
@@ -2154,6 +2156,7 @@ pub fn evaluate_condition_external(
         | Condition::SpellsWereCastLastTurnOrMore(_)
         | Condition::SourceHasNoCounter(_)
         | Condition::SourceHasCounterAtLeast { .. }
+        | Condition::SourceDealtDamage
         | Condition::SourceIsInZone(_)
         | Condition::ManaSpentToCastThisSpellAtLeast { .. }
         | Condition::SameColorManaSpentToCastThisSpellAtLeast(_)
@@ -2820,6 +2823,7 @@ fn evaluate_condition_simple(
         | Condition::CountParity { .. }
         | Condition::OwnsCardExiledWithCounter(_)
         | Condition::SourceAttackedThisTurn
+        | Condition::SourceDealtDamage
         | Condition::SourceDealtCombatDamageToPlayerThisTurn
         | Condition::SourceCameUnderYourControlThisTurn
         | Condition::SourceAttackedOrBlockedThisTurn
@@ -3985,6 +3989,7 @@ fn evaluate_condition(
             })
         })),
         Condition::SourceAttackedThisTurn => Ok(game.creature_attacked_this_turn(ctx.source)),
+        Condition::SourceDealtDamage => Ok(game.source_dealt_damage(ctx.source)),
         Condition::SourceDealtCombatDamageToPlayerThisTurn => {
             Ok(game.source_dealt_combat_damage_to_player_this_turn(ctx.source))
         }

--- a/crates/ironsmith-runtime/src/game_state.rs
+++ b/crates/ironsmith-runtime/src/game_state.rs
@@ -2091,6 +2091,9 @@ pub struct GameState {
     /// Used for "one or more ... deal combat damage to a player" trigger matching.
     pub combat_damage_player_batch_hits: Vec<(ObjectId, PlayerId)>,
 
+    /// Object instances that have dealt damage this game.
+    pub sources_dealt_damage: HashSet<ObjectId>,
+
     /// Players whose inherent speed trigger has already fired this turn.
     pub speed_increase_triggered_this_turn: HashSet<PlayerId>,
 
@@ -2290,6 +2293,7 @@ impl GameState {
             soulbond_pairs: HashMap::new(),
             ninjutsu_attack_targets: HashMap::new(),
             combat_damage_player_batch_hits: Vec::new(),
+            sources_dealt_damage: HashSet::new(),
             speed_increase_triggered_this_turn: HashSet::new(),
             draft_noted_highest_numbers: HashMap::new(),
             noted_life_totals: HashMap::new(),
@@ -8518,6 +8522,10 @@ impl GameState {
             .source_dealt_damage_to_player_this_turn(source, stable_id, player)
     }
 
+    pub fn source_dealt_damage(&self, source: ObjectId) -> bool {
+        self.sources_dealt_damage.contains(&source)
+    }
+
     /// Clear damage from an object.
     pub fn clear_damage(&mut self, id: ObjectId) {
         self.damage_marked.remove(&id);
@@ -9530,6 +9538,18 @@ impl GameState {
 
     pub(crate) fn record_turn_history_event(&mut self, event: &crate::triggers::TriggerEvent) {
         let (object_snapshot, source_snapshot) = self.projected_turn_event_snapshots(event);
+        if let Some(damage) = event.downcast::<crate::events::DamageEvent>()
+            && damage.amount > 0
+        {
+            if let Some(source_id) = source_snapshot
+                .as_ref()
+                .or(object_snapshot.as_ref())
+                .map(|snapshot| snapshot.object_id)
+                .or_else(|| self.object(damage.source).map(|obj| obj.id))
+            {
+                self.sources_dealt_damage.insert(source_id);
+            }
+        }
         self.turn_store
             .turn_history
             .record_event(event, object_snapshot, source_snapshot);

--- a/crates/ironsmith-runtime/src/static_abilities/continuous.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/continuous.rs
@@ -1029,6 +1029,9 @@ pub(super) fn describe_static_condition(condition: &crate::ConditionExpr) -> Str
         crate::ConditionExpr::SourceAttackedThisTurn => {
             "as long as this creature attacked this turn".to_string()
         }
+        crate::ConditionExpr::SourceDealtDamage => {
+            "as long as this creature has dealt damage".to_string()
+        }
         crate::ConditionExpr::OpponentLostLifeThisTurn => {
             "as long as an opponent lost life this turn".to_string()
         }
@@ -1050,6 +1053,11 @@ pub(super) fn describe_static_condition(condition: &crate::ConditionExpr) -> Str
             if matches!(inner.as_ref(), crate::ConditionExpr::SourceAttackedThisTurn) =>
         {
             "as long as this creature didn't attack this turn".to_string()
+        }
+        crate::ConditionExpr::Not(inner)
+            if matches!(inner.as_ref(), crate::ConditionExpr::SourceDealtDamage) =>
+        {
+            "as long as this creature hasn't dealt damage yet".to_string()
         }
         crate::ConditionExpr::Not(inner) => {
             if let crate::ConditionExpr::PlayerCastSpellsThisTurnOrMore { player, count: 1 } =


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Ratonhnhaké꞉ton
Initial parse error:
```
unsupported static condition clause (clause: 'this hasnt dealt damage yet'); oracle-only fallback also failed: unsupported static condition clause (clause: 'this hasnt dealt damage yet')
```

Current worker: i-0e4047ee9e7b86933
Branch: codex/aws-card-fix-ratonhnhak-ton
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260604T121212Z-controller-dev-loop-wave0022
