### PR TITLE
Fix Ironsmith parse failure: Tangle Wire

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
@@ -1416,6 +1416,40 @@ pub(crate) fn parse_for_each_count_value_words(words: &[&str]) -> Option<(Value,
             filter_end,
         ));
     }
+    if let Some(counter_idx) = find_index(count_words, |word| {
+        COUNTER_OR_COUNTERS_WORD_PATTERN.matches_word(word)
+    }) && count_words
+        .get(counter_idx + 1)
+        .is_some_and(|word| ON_WORD_PATTERN.matches_word(word))
+    {
+        let counter_tokens = crate::runtime_backend::lexer::synthetic_word_tokens(count_words);
+        if let Some(counter_type) = parse_counter_type_from_tokens(&counter_tokens) {
+            let reference = &count_words[counter_idx + 2..];
+            if SOURCE_COUNTER_REFERENCE_PATTERN.matches_words(reference) {
+                if let Some(surface) = this_source_surface_for_words(reference) {
+                    return Some((
+                        Value::CountersOn(
+                            Box::new(source_choose_spec_for_surface(surface)),
+                            Some(counter_type),
+                        ),
+                        filter_end,
+                    ));
+                }
+                return Some((Value::CountersOnSource(counter_type), filter_end));
+            }
+            if TAGGED_COUNTER_REFERENCE_PATTERN.matches_words(reference) {
+                return Some((
+                    Value::CountersOn(
+                        Box::new(ChooseSpec::Tagged(TagKey::from(
+                            crate::cards::builders::IT_TAG,
+                        ))),
+                        Some(counter_type),
+                    ),
+                    filter_end,
+                ));
+            }
+        }
+    }
 
     let filter_tokens =
         crate::runtime_backend::lexer::synthetic_word_tokens(&words[idx..filter_end]);
@@ -2355,6 +2389,7 @@ pub(crate) fn parse_counter_type_word(word: &str) -> Option<CounterType> {
         "blood" => Some(CounterType::Blood),
         "ice" => Some(CounterType::Ice),
         "finality" => Some(CounterType::Finality),
+        "fade" => Some(CounterType::Fade),
         "time" => Some(CounterType::Time),
         "brain" => Some(CounterType::Brain),
         "burden" => Some(CounterType::Named(intern_counter_name("burden"))),
@@ -3868,6 +3903,67 @@ mod tests {
         assert_eq!(used_words, words.len());
         assert_eq!(value, Value::MaxCardsDrawnThisTurn(PlayerFilter::You));
     }
+
+    #[test]
+    fn parse_for_each_count_value_words_handles_fade_counters_on_source() {
+        let words = ["for", "each", "fade", "counter", "on", "this", "artifact"];
+
+        let (value, used_words) =
+            parse_for_each_count_value_words(&words).expect("fade counter count should parse");
+
+        assert_eq!(used_words, words.len());
+        let Value::CountersOn(spec, Some(CounterType::Fade)) = value else {
+            panic!("expected source fade counter count, got {value:?}");
+        };
+        assert_eq!(describe_choose_spec_for_test(&spec), "this artifact");
+    }
+
+    #[test]
+    fn parse_target_phrase_handles_dynamic_count_for_each_source_counter() {
+        let tokens = lex_line(
+            "an untapped artifact, creature, or land they control for each fade counter on this artifact",
+            0,
+        )
+        .unwrap();
+
+        let target = parse_target_phrase(&tokens).expect("dynamic counted target should parse");
+
+        let TargetAst::WithCountValue(inner, count, value) = target else {
+            panic!("expected dynamic-count target, got {target:?}");
+        };
+        assert!(count.is_dynamic_x());
+        let Value::CountersOn(spec, Some(CounterType::Fade)) = value else {
+            panic!("expected source fade counter count, got {value:?}");
+        };
+        assert_eq!(describe_choose_spec_for_test(&spec), "this artifact");
+        let TargetAst::Object(filter, _, _) = inner.as_ref() else {
+            panic!("expected object target, got {inner:?}");
+        };
+        assert!(filter.untapped, "expected untapped filter, got {filter:?}");
+        assert!(
+            filter.controller.is_some(),
+            "expected controller filter, got {filter:?}"
+        );
+        assert!(filter.card_types.contains(&CardType::Artifact));
+        assert!(filter.card_types.contains(&CardType::Creature));
+        assert!(filter.card_types.contains(&CardType::Land));
+    }
+
+    fn describe_choose_spec_for_test(spec: &ChooseSpec) -> String {
+        match spec {
+            ChooseSpec::SurfaceHinted { hints, .. } => hints
+                .iter()
+                .find_map(|hint| match hint {
+                    ChooseSpecSurfaceHint::SourceReference(SourceReferenceSurface::FullName(text))
+                    | ChooseSpecSurfaceHint::SourceReference(SourceReferenceSurface::ShortName(text))
+                    | ChooseSpecSurfaceHint::SourceReference(
+                        SourceReferenceSurface::ThisPermanentType(text),
+                    ) => Some(text.clone()),
+                })
+                .unwrap_or_else(|| format!("{spec:?}")),
+            _ => format!("{spec:?}"),
+        }
+    }
 }
 
 pub(crate) fn wrap_target_count(target: TargetAst, target_count: Option<ChoiceCount>) -> TargetAst {
@@ -4793,6 +4889,30 @@ fn parse_target_phrase_inner(tokens: &[OwnedLexToken]) -> Result<TargetAst, Card
             "unsupported creature-token/player/planeswalker target phrase (clause: '{}')",
             remaining_words.join(" ")
         )));
+    }
+
+    let remaining_word_view = UtilWordView::new(remaining);
+    let remaining_words_with_articles = remaining_word_view.to_word_refs();
+    if target_count.is_none_or(|count| count.is_single())
+        && let Some(for_each_word_idx) = remaining_words_with_articles
+            .windows(2)
+            .position(|window| window == ["for", "each"])
+        && for_each_word_idx > 0
+        && let Some((count_value, used_words)) =
+            parse_for_each_count_value_words(&remaining_words_with_articles[for_each_word_idx..])
+        && for_each_word_idx + used_words == remaining_words_with_articles.len()
+        && let Some(for_each_token_idx) =
+            remaining_word_view.token_index_for_word_index(for_each_word_idx)
+    {
+        let object_tokens = trim_commas(&remaining[..for_each_token_idx]);
+        if !object_tokens.is_empty() {
+            let filter = parse_object_filter(&object_tokens, other)?;
+            return Ok(TargetAst::WithCountValue(
+                Box::new(TargetAst::Object(filter, target_span, None)),
+                ChoiceCount::dynamic_x(),
+                count_value,
+            ));
+        }
     }
 
     let mut filter = parse_object_filter(remaining, other)?;

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -6416,6 +6416,44 @@ fn test_builder_fading_creates_counter_upkeep_and_sacrifice_triggers() {
 }
 
 #[test]
+fn parse_tangle_wire_strictly_and_renders_fade_counter_tap_clause() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(3_694), "Tangle Wire")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(3)]]))
+        .card_types(vec![CardType::Artifact])
+        .parse_text(concat!(
+            "Fading 4 (This artifact enters with four fade counters on it. ",
+            "At the beginning of your upkeep, remove a fade counter from it. ",
+            "If you can't, sacrifice it.)\n",
+            "At the beginning of each player's upkeep, that player taps an untapped artifact, ",
+            "creature, or land they control for each fade counter on this artifact."
+        ))
+        .expect("Tangle Wire should parse strictly");
+
+    let rendered = unprocessed_compiled_lines(&def).join("\n");
+    assert!(
+        rendered.contains("Fading 4"),
+        "expected fading keyword line, got {rendered}"
+    );
+    assert!(
+        rendered.contains(concat!(
+            "At the beginning of each player's upkeep, that player taps an untapped artifact, ",
+            "creature, or land they control for each fade counter on this artifact"
+        )),
+        "expected exact Tangle Wire dynamic tap clause, got {rendered}"
+    );
+
+    let debug = format!("{:#?}", def.abilities);
+    assert!(
+        debug.contains("WithCountValue")
+            && debug.contains("Fade")
+            && debug.contains("ThisPermanentType")
+            && debug.contains("this artifact")
+            && debug.contains("BeginningOfUpkeepTrigger"),
+        "expected Tangle Wire to lower to an upkeep tap choice counted by fade counters on this artifact, got {debug}"
+    );
+}
+
+#[test]
 fn test_builder_vanishing_creates_counter_upkeep_and_sacrifice_triggers() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Vanishing Test")
         .card_types(vec![CardType::Creature])

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -31805,6 +31805,68 @@ fn prevent_next_time_tagged_source_text(filter: &ObjectFilter) -> Option<String>
     }
 }
 
+fn singularize_plural_object_phrase(phrase: &str) -> String {
+    phrase
+        .split_whitespace()
+        .map(|word| {
+            let (core, suffix) = word
+                .strip_suffix(',')
+                .map(|core| (core, ","))
+                .unwrap_or((word, ""));
+            if matches!(core, "and" | "or") {
+                return word.to_string();
+            }
+            let singular = if let Some(stem) = core.strip_suffix("ies") {
+                format!("{stem}y")
+            } else if let Some(stem) = core.strip_suffix('s') {
+                if core.ends_with("ss") {
+                    core.to_string()
+                } else {
+                    stem.to_string()
+                }
+            } else {
+                core.to_string()
+            };
+            format!("{singular}{suffix}")
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn describe_dynamic_count_tap(tap: &crate::effects::TapEffect) -> Option<String> {
+    let ChooseSpec::WithCountValue(inner, count, count_value) = &tap.target else {
+        return None;
+    };
+    if !count.is_dynamic_x() || count.is_up_to_dynamic_x() || count.is_random() {
+        return None;
+    }
+    let (counter_type, source_text) = match count_value {
+        Value::CountersOnSource(counter_type) => (*counter_type, "this permanent".to_string()),
+        Value::CountersOn(spec, Some(counter_type)) => (*counter_type, describe_choose_spec(spec)),
+        _ => return None,
+    };
+    let ChooseSpec::Object(filter) = inner.base() else {
+        return None;
+    };
+
+    let description = filter.description();
+    let (prefix, object_phrase, control_tail) = if filter.controller == Some(PlayerFilter::Active) {
+        let stripped = description
+            .strip_prefix("the active player's ")
+            .or_else(|| description.strip_prefix("active player's "))
+            .unwrap_or_else(|| strip_leading_article(&description));
+        ("That player taps", stripped, " they control")
+    } else {
+        ("Tap", strip_leading_article(&description), "")
+    };
+    let object_phrase = singularize_plural_object_phrase(object_phrase);
+    Some(format!(
+        "{prefix} {}{control_tail} for each {} counter on {source_text}",
+        with_indefinite_article(&object_phrase),
+        describe_counter_type(counter_type)
+    ))
+}
+
 pub(super) fn describe_effect_impl(effect: &Effect) -> String {
     if effect
         .downcast_ref::<crate::effects::TagTriggeringSourceEffect>()
@@ -34210,6 +34272,9 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
         );
     }
     if let Some(tap) = effect.downcast_ref::<crate::effects::TapEffect>() {
+        if let Some(text) = describe_dynamic_count_tap(tap) {
+            return text;
+        }
         return format!("Tap {}", describe_choose_spec(&tap.target));
     }
     if let Some(untap) = effect.downcast_ref::<crate::effects::UntapEffect>() {

--- a/crates/ironsmith-runtime/src/effects/helpers.rs
+++ b/crates/ironsmith-runtime/src/effects/helpers.rs
@@ -2725,14 +2725,29 @@ pub fn resolve_objects_for_effect_with_choice_description(
         }
 
         let count = spec.count();
+        let resolved_dynamic_count = if count.is_dynamic_x() {
+            if let Some(count_value) = spec.count_value() {
+                Some(resolve_value(game, count_value, ctx)?.max(0) as usize)
+            } else {
+                None
+            }
+        } else {
+            None
+        };
         let mut candidates = candidate_object_ids_for_filter(game, filter, ctx);
         if candidates.is_empty() {
+            if resolved_dynamic_count.is_some() {
+                return Ok(Vec::new());
+            }
             return Err(ExecutionError::InvalidTarget);
+        }
+        if resolved_dynamic_count == Some(0) {
+            return Ok(Vec::new());
         }
 
         let (min, max) = if count.is_dynamic_x() {
-            let x = if let Some(count_value) = spec.count_value() {
-                resolve_value(game, count_value, ctx)?.max(0) as usize
+            let x = if let Some(x) = resolved_dynamic_count {
+                x
             } else {
                 ctx.x_value.ok_or_else(|| {
                     ExecutionError::UnresolvableValue("X value not set".to_string())
@@ -2740,6 +2755,9 @@ pub fn resolve_objects_for_effect_with_choice_description(
             };
             if count.is_up_to_dynamic_x() {
                 (0, x.min(candidates.len()))
+            } else if spec.count_value().is_some() {
+                let bounded = x.min(candidates.len());
+                (bounded, bounded)
             } else if x > candidates.len() {
                 return Err(ExecutionError::InvalidTarget);
             } else {
@@ -3061,15 +3079,30 @@ pub fn resolve_objects_from_spec(
                     .map(|(id, _)| id)
                     .collect();
 
+                let resolved_dynamic_count = if count.is_dynamic_x() {
+                    if let Some(count_value) = spec.count_value() {
+                        Some(resolve_value(game, count_value, ctx)?.max(0) as usize)
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                };
+
                 if objects.is_empty() {
+                    if resolved_dynamic_count.is_some() {
+                        return Ok(objects);
+                    }
                     return Err(ExecutionError::InvalidTarget);
                 }
 
                 let max = if count.is_dynamic_x() {
-                    ctx.x_value
-                        .map(|x| x as usize)
-                        .or(count.max)
-                        .unwrap_or(objects.len())
+                    resolved_dynamic_count.unwrap_or_else(|| {
+                        ctx.x_value
+                            .map(|x| x as usize)
+                            .or(count.max)
+                            .unwrap_or(objects.len())
+                    })
                 } else {
                     count.max.unwrap_or(objects.len())
                 };

--- a/crates/ironsmith-runtime/src/effects/permanents/tap.rs
+++ b/crates/ironsmith-runtime/src/effects/permanents/tap.rs
@@ -135,10 +135,12 @@ impl CostExecutableEffect for TapEffect {
 mod tests {
     use super::*;
     use crate::card::{CardBuilder, PowerToughness};
+    use crate::effect::{ChoiceCount, Value};
     use crate::effects::ResolvedTarget;
     use crate::ids::{CardId, ObjectId, PlayerId};
     use crate::mana::{ManaCost, ManaSymbol};
-    use crate::object::Object;
+    use crate::object::{CounterType, Object};
+    use crate::target::{ChooseSpecSurfaceHint, SourceReferenceSurface};
     use crate::test_prelude::*;
     use crate::types::CardType;
     use crate::zone::Zone;
@@ -164,6 +166,38 @@ mod tests {
         let obj = Object::from_card(id, &card, controller, Zone::Battlefield);
         game.add_object(obj);
         id
+    }
+
+    fn create_permanent(
+        game: &mut GameState,
+        name: &str,
+        controller: PlayerId,
+        card_types: Vec<CardType>,
+    ) -> ObjectId {
+        let id = game.new_object_id();
+        let card = CardBuilder::new(CardId::from_raw(id.0 as u32), name)
+            .card_types(card_types)
+            .build();
+        let obj = Object::from_card(id, &card, controller, Zone::Battlefield);
+        game.add_object(obj);
+        id
+    }
+
+    fn tangle_wire_dynamic_tap_effect() -> TapEffect {
+        let mut filter = ObjectFilter::default().in_zone(Zone::Battlefield);
+        filter.controller = Some(PlayerFilter::Active);
+        filter.card_types = vec![CardType::Artifact, CardType::Creature, CardType::Land];
+        filter.untapped = true;
+
+        let source = ChooseSpec::Source.with_surface_hint(
+            ChooseSpecSurfaceHint::SourceReference(SourceReferenceSurface::ThisPermanentType(
+                "this artifact".to_string(),
+            )),
+        );
+        TapEffect::with_spec(ChooseSpec::Object(filter).with_count_value(
+            ChoiceCount::dynamic_x(),
+            Value::CountersOn(Box::new(source), Some(CounterType::Fade)),
+        ))
     }
 
     // === Targeted tap tests ===
@@ -367,6 +401,102 @@ mod tests {
         let effect = TapEffect::all(ObjectFilter::creature());
         // All effects don't have a target spec
         assert!(effect.get_target_spec().is_none());
+    }
+
+    #[test]
+    fn tangle_wire_taps_active_players_untapped_permanents_for_each_fade_counter() {
+        let mut game = setup_game();
+        let alice = PlayerId::from_index(0);
+        let bob = PlayerId::from_index(1);
+        game.turn.active_player = bob;
+
+        let tangle_wire =
+            create_permanent(&mut game, "Tangle Wire", alice, vec![CardType::Artifact]);
+        game.add_counters(tangle_wire, CounterType::Fade, 2);
+        let alice_artifact =
+            create_permanent(&mut game, "Alice Relic", alice, vec![CardType::Artifact]);
+        let bob_artifact =
+            create_permanent(&mut game, "Bob Relic", bob, vec![CardType::Artifact]);
+        let bob_creature = create_creature(&mut game, "Bob Bear", bob);
+        let bob_land = create_permanent(&mut game, "Bob Land", bob, vec![CardType::Land]);
+
+        let effect = tangle_wire_dynamic_tap_effect();
+        let mut ctx = ExecutionContext::new_default(tangle_wire, alice);
+        let result = effect.execute(&mut game, &mut ctx).unwrap();
+
+        assert_eq!(result.value, crate::effect::OutcomeValue::Count(2));
+        let bob_tapped = [bob_artifact, bob_creature, bob_land]
+            .into_iter()
+            .filter(|id| game.is_tapped(*id))
+            .count();
+        assert_eq!(bob_tapped, 2, "exactly two Bob permanents should be tapped");
+        assert!(
+            !game.is_tapped(alice_artifact),
+            "Tangle Wire should not tap the non-active player's permanent"
+        );
+    }
+
+    #[test]
+    fn tangle_wire_taps_no_permanents_when_it_has_no_fade_counters() {
+        let mut game = setup_game();
+        let alice = PlayerId::from_index(0);
+        let bob = PlayerId::from_index(1);
+        game.turn.active_player = bob;
+
+        let tangle_wire =
+            create_permanent(&mut game, "Tangle Wire", alice, vec![CardType::Artifact]);
+        let bob_artifact =
+            create_permanent(&mut game, "Bob Relic", bob, vec![CardType::Artifact]);
+        let bob_creature = create_creature(&mut game, "Bob Bear", bob);
+
+        let effect = tangle_wire_dynamic_tap_effect();
+        let mut ctx = ExecutionContext::new_default(tangle_wire, alice);
+        let result = effect.execute(&mut game, &mut ctx).unwrap();
+
+        assert_eq!(result.value, crate::effect::OutcomeValue::Count(0));
+        assert!(!game.is_tapped(bob_artifact));
+        assert!(!game.is_tapped(bob_creature));
+    }
+
+    #[test]
+    fn tangle_wire_with_no_fade_counters_allows_no_eligible_permanents() {
+        let mut game = setup_game();
+        let alice = PlayerId::from_index(0);
+        let bob = PlayerId::from_index(1);
+        game.turn.active_player = bob;
+
+        let tangle_wire =
+            create_permanent(&mut game, "Tangle Wire", alice, vec![CardType::Artifact]);
+
+        let effect = tangle_wire_dynamic_tap_effect();
+        let mut ctx = ExecutionContext::new_default(tangle_wire, alice);
+        let result = effect.execute(&mut game, &mut ctx).unwrap();
+
+        assert_eq!(result.value, crate::effect::OutcomeValue::Count(0));
+    }
+
+    #[test]
+    fn tangle_wire_taps_available_permanents_when_fade_counters_exceed_choices() {
+        let mut game = setup_game();
+        let alice = PlayerId::from_index(0);
+        let bob = PlayerId::from_index(1);
+        game.turn.active_player = bob;
+
+        let tangle_wire =
+            create_permanent(&mut game, "Tangle Wire", alice, vec![CardType::Artifact]);
+        game.add_counters(tangle_wire, CounterType::Fade, 3);
+        let alice_artifact =
+            create_permanent(&mut game, "Alice Relic", alice, vec![CardType::Artifact]);
+        let bob_artifact =
+            create_permanent(&mut game, "Bob Relic", bob, vec![CardType::Artifact]);
+
+        let effect = tangle_wire_dynamic_tap_effect();
+        let mut ctx = ExecutionContext::new_default(tangle_wire, alice);
+        let result = effect.execute(&mut game, &mut ctx).unwrap();
+
+        assert_eq!(result.value, crate::effect::OutcomeValue::Count(1));
+        assert!(game.is_tapped(bob_artifact));
+        assert!(!game.is_tapped(alice_artifact));
     }
 
     #[test]

--- a/crates/ironsmith-runtime/src/game_loop/stack_resolution.rs
+++ b/crates/ironsmith-runtime/src/game_loop/stack_resolution.rs
@@ -1636,6 +1636,7 @@ mod tests {
     use crate::cards::builders::CardDefinitionBuilder;
     use crate::events::phase::BeginningOfUpkeepEvent;
     use crate::ids::CardId;
+    use crate::object::CounterType;
     use crate::static_abilities::StaticAbility;
     use crate::types::CardType;
 
@@ -1749,6 +1750,22 @@ mod tests {
         parse_spell_definition(name, vec![CardType::Instant], oracle_text)
     }
 
+    fn tangle_wire_definition() -> crate::cards::CardDefinition {
+        CardDefinitionBuilder::new(CardId::from_raw(3_694), "Tangle Wire")
+            .mana_cost(crate::mana::ManaCost::from_pips(vec![vec![
+                crate::mana::ManaSymbol::Generic(3),
+            ]]))
+            .card_types(vec![CardType::Artifact])
+            .parse_text(concat!(
+                "Fading 4 (This artifact enters with four fade counters on it. ",
+                "At the beginning of your upkeep, remove a fade counter from it. ",
+                "If you can't, sacrifice it.)\n",
+                "At the beginning of each player's upkeep, that player taps an untapped artifact, ",
+                "creature, or land they control for each fade counter on this artifact."
+            ))
+            .expect("Tangle Wire should parse for runtime test")
+    }
+
     fn create_creature(
         game: &mut GameState,
         name: &str,
@@ -1759,6 +1776,13 @@ mod tests {
         let card = CardBuilder::new(CardId::new(), name)
             .card_types(vec![CardType::Creature])
             .power_toughness(PowerToughness::fixed(power, toughness))
+            .build();
+        game.create_object_from_card(&card, controller, Zone::Battlefield)
+    }
+
+    fn create_artifact(game: &mut GameState, name: &str, controller: PlayerId) -> ObjectId {
+        let card = CardBuilder::new(CardId::new(), name)
+            .card_types(vec![CardType::Artifact])
             .build();
         game.create_object_from_card(&card, controller, Zone::Battlefield)
     }
@@ -1836,6 +1860,83 @@ mod tests {
             game.effect_store.delayed_triggers.len(),
             1,
             "upkeep copy should not install another Epic delayed trigger"
+        );
+    }
+
+    #[test]
+    fn tangle_wire_upkeep_trigger_has_active_player_choose_their_permanent() {
+        struct TangleWireDecisionMaker {
+            expected_player: PlayerId,
+            selected: ObjectId,
+            saw_object_choice: bool,
+        }
+
+        impl crate::decision::DecisionMaker for TangleWireDecisionMaker {
+            fn decide_objects(
+                &mut self,
+                _game: &GameState,
+                ctx: &crate::decisions::context::SelectObjectsContext,
+            ) -> Vec<ObjectId> {
+                assert_eq!(
+                    ctx.player, self.expected_player,
+                    "Tangle Wire's active upkeep player should choose what they tap"
+                );
+                assert!(
+                    ctx.candidates.iter().any(|candidate| candidate.id == self.selected),
+                    "expected selected permanent to be eligible: {:?}",
+                    ctx.candidates
+                );
+                self.saw_object_choice = true;
+                vec![self.selected]
+            }
+        }
+
+        let mut game = crate::tests::test_helpers::setup_two_player_game();
+        let alice = PlayerId::from_index(0);
+        let bob = PlayerId::from_index(1);
+        game.turn.active_player = bob;
+        game.turn.phase = crate::game_state::Phase::Beginning;
+        game.turn.step = Some(crate::game_state::Step::Upkeep);
+
+        let tangle_wire = game.create_object_from_definition(
+            &tangle_wire_definition(),
+            alice,
+            Zone::Battlefield,
+        );
+        game.add_counters(tangle_wire, CounterType::Fade, 1)
+            .expect("Tangle Wire should accept fade counters");
+        let alice_artifact = create_artifact(&mut game, "Alice Relic", alice);
+        let bob_default_artifact = create_artifact(&mut game, "Bob Relic", bob);
+        let bob_selected_artifact = create_artifact(&mut game, "Bob Choice", bob);
+
+        let upkeep_event = crate::triggers::generate_step_trigger_events(&game)
+            .expect("Bob's upkeep should generate a trigger event");
+        let mut trigger_queue = TriggerQueue::new();
+        for trigger in crate::triggers::check_triggers(&game, &upkeep_event) {
+            trigger_queue.add(trigger);
+        }
+        put_triggers_on_stack(&mut game, &mut trigger_queue)
+            .expect("Tangle Wire trigger should go on the stack");
+
+        let mut dm = TangleWireDecisionMaker {
+            expected_player: bob,
+            selected: bob_selected_artifact,
+            saw_object_choice: false,
+        };
+        resolve_stack_entry_with(&mut game, &mut dm).expect("Tangle Wire trigger should resolve");
+
+        assert!(
+            dm.saw_object_choice,
+            "Tangle Wire should ask the active player to choose a permanent"
+        );
+        assert!(game.is_tapped(bob_selected_artifact));
+        assert!(
+            !game.is_tapped(bob_default_artifact),
+            "the test chooses a non-default eligible permanent"
+        );
+        assert!(
+            !game.is_tapped(alice_artifact),
+            "Tangle Wire should not tap the controller's permanent during Bob's upkeep"
         );
     }
 


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Tangle Wire
Initial parse error:
```
object filter has unconsumed 'for each' clause 'for each fade counter on this artifact' (full input: 'untapped artifact creature or land they control for each fade counter on this artifact'); oracle-only fallback also failed: object filter has unconsumed 'for each' clause 'for each fade counter on this artifact' (full input: 'untapped artifact creature or land they control for each fade counter on this artifact')
```

Current worker: i-0a92d7fc744cda5dc
Branch: codex/aws-card-fix-tangle-wire
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260604T121212Z-controller-dev-loop-wave0023
