### PR TITLE
Fix Ironsmith parse failure: Rampaging Cyclops

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/anthem_grant_lines.rs
@@ -461,6 +461,15 @@ const ANTHEM_FOR_EACH_PREFIX_PATTERN: ClauseShape<'static> =
     clause_shape!(prefix & ["for", "each"]);
 const ANTHEM_AFFECTED_ATTACKED_THIS_TURN_PATTERN: ClauseShape<'static> =
     clause_shape!(exact & ["time", "it", "has", "attacked", "this", "turn"]);
+const CREATURES_ARE_BLOCKING_SOURCE_TAIL_PATTERN: ClauseShape<'static> = clause_shape!(
+    exact_any
+        & [
+            &["creature", "is", "blocking", "it"],
+            &["creature", "is", "blocking", "this", "creature"],
+            &["creatures", "are", "blocking", "it"],
+            &["creatures", "are", "blocking", "this", "creature"],
+        ]
+);
 const ANTHEM_AFFECTED_COLORS_PATTERN: ClauseShape<'static> = clause_shape!(
     exact_any
         & [
@@ -2956,6 +2965,16 @@ pub(crate) fn parse_static_condition_clause(
     if let Some(condition) = parse_cards_drawn_this_turn_static_condition(&tokens) {
         return Ok(condition);
     }
+    if let Ok((comparison, used)) = parse_static_quantity_prefix(&tokens, true) {
+        let tail_words = &clause_words[used..];
+        if CREATURES_ARE_BLOCKING_SOURCE_TAIL_PATTERN.matches_words(tail_words) {
+            return Ok(crate::ConditionExpr::CountComparison {
+                count: AnthemCountExpression::BlockingSource,
+                comparison,
+                display: Some(clause_words.join(" ")),
+            });
+        }
+    }
     if YOUR_LIFE_HALF_STARTING_CONDITION_PATTERN.matches_words(&clause_words) {
         return Ok(
             crate::ConditionExpr::PlayerLifeAtMostHalfStartingLifeTotal {
@@ -3443,6 +3462,10 @@ pub(crate) fn parse_anthem_for_each_expression(
             ))
         })?;
         return Ok(AnthemCountExpression::CreatureTypesAmong(filter));
+    }
+
+    if CREATURES_ARE_BLOCKING_SOURCE_TAIL_PATTERN.matches_words(&rest_words) {
+        return Ok(AnthemCountExpression::BlockingSource);
     }
 
     if let Some(attached_idx) = anthem_token_offset(rest, |token| {

--- a/crates/ironsmith-core/src/anthem_model.rs
+++ b/crates/ironsmith-core/src/anthem_model.rs
@@ -12,6 +12,7 @@ pub enum AnthemCountExpression {
     CountersAmong(ObjectFilter, CounterType),
     BasicLandTypesAmong(ObjectFilter),
     CreatureTypesAmong(ObjectFilter),
+    BlockingSource,
     CommanderCastCount(PlayerFilter),
     PlayerSpeed(PlayerFilter),
     UnspentMana {

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -17681,6 +17681,31 @@ fn test_parse_cant_be_blocked_by_more_than_one_creature() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn rampaging_cyclops_parses_blocker_count_static_condition() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Rampaging Cyclops")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(4, 4))
+        .parse_text(
+            "This creature gets -2/-0 as long as two or more creatures are blocking it.",
+        )
+        .expect("Rampaging Cyclops should parse strictly");
+
+    let rendered = unprocessed_compiled_lines(&def).join("\n");
+    assert_eq!(
+        rendered,
+        "This creature gets -2/-0 as long as two or more creatures are blocking it.",
+        "expected Rampaging Cyclops compiled text to preserve its blocker-count condition"
+    );
+
+    let debug = format!("{:?}", def.abilities);
+    assert!(
+        debug.contains("CountComparison") && debug.contains("BlockingSource"),
+        "expected Rampaging Cyclops to lower to a structural blocking-source count condition, got {debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn test_parse_each_creature_cant_be_blocked_by_more_than_one_creature() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Familiar Ground Probe")
         .card_types(vec![CardType::Enchantment])

--- a/crates/ironsmith-runtime/src/game_loop/combat_decisions.rs
+++ b/crates/ironsmith-runtime/src/game_loop/combat_decisions.rs
@@ -589,6 +589,7 @@ pub fn apply_blocker_declarations(
 
     // Block triggers can depend on the complete set of blockers declared together.
     game.combat = Some(combat.clone());
+    game.mark_continuous_state_dirty();
 
     // Emit block triggers (per declaration).
     for (blocker, attacker) in &pairs {

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -21707,6 +21707,87 @@ fn test_marhault_elsdragon_rampage_buffs_for_blockers_beyond_first() {
     );
 }
 
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn rampaging_cyclops_loses_power_only_when_two_or_more_creatures_block_it() {
+    let mut game = setup_game();
+    let mut trigger_queue = TriggerQueue::new();
+    let mut combat = CombatState::default();
+
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let rampaging_cyclops_def =
+        CardDefinitionBuilder::new(CardId::from_raw(1), "Rampaging Cyclops")
+            .card_types(vec![CardType::Creature])
+            .power_toughness(PowerToughness::fixed(4, 4))
+            .parse_text(
+                "This creature gets -2/-0 as long as two or more creatures are blocking it.",
+            )
+            .expect("Rampaging Cyclops should parse for runtime test");
+    let cyclops =
+        game.create_object_from_definition(&rampaging_cyclops_def, alice, Zone::Battlefield);
+    let blocker_1 = create_creature(&mut game, "Blocker 1", bob, 1, 1);
+    let blocker_2 = create_creature(&mut game, "Blocker 2", bob, 1, 1);
+
+    combat.attackers.push(crate::combat_state::AttackerInfo {
+        creature: cyclops,
+        target: AttackTarget::Player(bob),
+    });
+
+    apply_blocker_declarations(
+        &mut game,
+        &mut combat,
+        &mut trigger_queue,
+        &[BlockerDeclaration {
+            blocker: blocker_1,
+            blocking: cyclops,
+        }],
+        bob,
+    )
+    .expect("one blocker should be a legal block");
+    game.refresh_continuous_state();
+    assert_eq!(
+        game.calculated_power(cyclops),
+        Some(4),
+        "Rampaging Cyclops should keep 4 power with only one blocker"
+    );
+    assert_eq!(
+        game.calculated_toughness(cyclops),
+        Some(4),
+        "Rampaging Cyclops toughness should not change"
+    );
+
+    apply_blocker_declarations(
+        &mut game,
+        &mut combat,
+        &mut trigger_queue,
+        &[
+            BlockerDeclaration {
+                blocker: blocker_1,
+                blocking: cyclops,
+            },
+            BlockerDeclaration {
+                blocker: blocker_2,
+                blocking: cyclops,
+            },
+        ],
+        bob,
+    )
+    .expect("two blockers should be a legal block");
+    game.refresh_continuous_state();
+    assert_eq!(
+        game.calculated_power(cyclops),
+        Some(2),
+        "Rampaging Cyclops should get -2/-0 with two blockers"
+    );
+    assert_eq!(
+        game.calculated_toughness(cyclops),
+        Some(4),
+        "Rampaging Cyclops toughness should still not change"
+    );
+}
+
 fn create_creature(
     game: &mut GameState,
     name: &str,

--- a/crates/ironsmith-runtime/src/game_state.rs
+++ b/crates/ironsmith-runtime/src/game_state.rs
@@ -2393,7 +2393,7 @@ impl GameState {
         }
     }
 
-    fn mark_continuous_state_dirty(&self) {
+    pub(crate) fn mark_continuous_state_dirty(&self) {
         self.runtime_cache.continuous_state_dirty.set(true);
         self.runtime_cache
             .calculated_characteristics_cache

--- a/crates/ironsmith-runtime/src/static_abilities/continuous.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/continuous.rs
@@ -696,6 +696,7 @@ fn describe_anthem_count_expression(expr: &AnthemCountExpression) -> String {
         AnthemCountExpression::CreatureTypesAmong(filter) => {
             format!("creature type among {}", pluralized_subject_text(filter))
         }
+        AnthemCountExpression::BlockingSource => "creature blocking it".to_string(),
         AnthemCountExpression::CommanderCastCount(player) => match player {
             crate::target::PlayerFilter::You => {
                 "times you've cast your commander from the command zone this game".to_string()
@@ -799,6 +800,7 @@ fn describe_anthem_for_each_count_expression(expr: &AnthemCountExpression) -> Op
             "creature type among {}",
             pluralized_subject_text(filter)
         )),
+        AnthemCountExpression::BlockingSource => Some("creature blocking it".to_string()),
         AnthemCountExpression::CommanderCastCount(player) => Some(match player {
             crate::target::PlayerFilter::You => {
                 "time you've cast your commander from the command zone this game".to_string()
@@ -832,6 +834,7 @@ fn describe_anthem_where_x_count_expression(expr: &AnthemCountExpression) -> Str
                 pluralized_subject_text(filter)
             )
         }
+        AnthemCountExpression::BlockingSource => "the number of creatures blocking it".to_string(),
         _ => format!("the number of {}", describe_anthem_count_expression(expr)),
     }
 }
@@ -1650,6 +1653,12 @@ pub(crate) fn resolve_anthem_count_expression(
             }
             seen.len() as i32
         }
+        AnthemCountExpression::BlockingSource => game
+            .combat
+            .as_ref()
+            .and_then(|combat| combat.blockers.get(&source))
+            .map(|blockers| blockers.len() as i32)
+            .unwrap_or(0),
         AnthemCountExpression::CommanderCastCount(player_filter) => game
             .players
             .iter()


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Rampaging Cyclops
Initial parse error:
```
unsupported static condition clause (clause: 'two or more creatures are blocking it'); oracle-only fallback also failed: unsupported static condition clause (clause: 'two or more creatures are blocking it')
```

Current worker: i-0732ce9d28f0cf9f4
Branch: codex/aws-card-fix-rampaging-cyclops
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260604T121212Z-controller-dev-loop-wave0024
