### PR TITLE
Fix Ironsmith parse failure: Black Cat, Cunning Thief

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/permission_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/permission_helpers.rs
@@ -260,6 +260,7 @@ const PERMISSION_LIFETIME_PREFIXES: &[&[&str]] = &[
     &[
         "for", "as", "long", "as", "those", "cards", "remain", "exiled",
     ],
+    &["for", "as", "long", "as", "they", "remain", "exiled"],
     &[
         "for", "as", "long", "as", "you", "control", "this", "creature",
     ],
@@ -422,7 +423,12 @@ fn parse_tagged_cast_or_play_target_inner<'a>(
                 tag: TagKey::from(IT_TAG),
                 as_copy: false,
             }),
-            grammar::phrase(&["those", "cards"]).value(TaggedPermissionTarget {
+            alt((
+                grammar::phrase(&["those", "cards"]),
+                grammar::phrase(&["the", "exiled", "cards"]),
+                grammar::phrase(&["exiled", "cards"]),
+            ))
+            .value(TaggedPermissionTarget {
                 tag: TagKey::from(IT_TAG),
                 as_copy: false,
             }),

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_flow_search_handlers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_flow_search_handlers.rs
@@ -51,6 +51,27 @@ fn binary_pile_choice_labels(
     })
 }
 
+fn compiled_effects_are_play_permissions(effects: &[Effect]) -> bool {
+    let mut saw_play_grant = false;
+    for effect in effects {
+        if effect
+            .downcast_ref::<crate::effects::GrantPlayTaggedEffect>()
+            .is_some()
+        {
+            saw_play_grant = true;
+            continue;
+        }
+        if effect
+            .downcast_ref::<crate::effects::GrantTaggedSpellFreeCastUntilEndOfTurnEffect>()
+            .is_some()
+        {
+            continue;
+        }
+        return false;
+    }
+    saw_play_grant
+}
+
 fn try_compile_for_each_object_become_copy_of_prior_choice(
     filter: &ObjectFilter,
     effects: &[EffectAst],
@@ -128,6 +149,9 @@ pub(super) fn try_compile_flow_and_iteration_effect(
                     "empty compiled may-effect branch is unsupported".to_string(),
                 ));
             }
+            if compiled_effects_are_play_permissions(&inner_effects) {
+                return Ok(Some((inner_effects, inner_choices)));
+            }
             let effect = Effect::may(inner_effects);
             (vec![effect], inner_choices)
         }
@@ -158,9 +182,12 @@ pub(super) fn try_compile_flow_and_iteration_effect(
                     "empty compiled may-by-player effect branch is unsupported".to_string(),
                 ));
             }
-            let effect = Effect::may_player(player_filter, inner_effects);
             let mut choices = inner_choices;
             choices.extend(subject.into_choices());
+            if compiled_effects_are_play_permissions(&inner_effects) {
+                return Ok(Some((inner_effects, choices)));
+            }
+            let effect = Effect::may_player(player_filter, inner_effects);
             (vec![effect], choices)
         }
         EffectAst::RepeatThisProcessMay => (

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_visibility_object_handlers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_visibility_object_handlers.rs
@@ -219,13 +219,17 @@ pub(super) fn try_compile_object_zone_and_exchange_effect(
                     false,
                 )
             } else if chooses_tagged_pool {
+                let choice_zones = resolved_filter
+                    .zone
+                    .map(|zone| vec![zone])
+                    .unwrap_or_else(scoped_collection_zones);
                 compile_choose_objects_across_zones_with_subject(
                     subject,
                     resolved_filter,
                     *count,
                     count_value.clone(),
                     tag.clone(),
-                    scoped_collection_zones(),
+                    choice_zones,
                     None,
                     false,
                 )

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_dispatch.rs
@@ -699,6 +699,63 @@ fn clause_may_contain_cast_or_play_permission(tokens: &[OwnedLexToken]) -> bool 
         })
 }
 
+fn parse_play_exiled_cards_for_as_long_as_exiled_clause(
+    tokens: &[OwnedLexToken],
+) -> Option<EffectAst> {
+    let trimmed = trim_commas(tokens);
+    let words = TokenWordView::new(&trimmed).word_refs();
+    let matches = words
+        == [
+            "play", "the", "exiled", "cards", "for", "as", "long", "as", "they", "remain",
+            "exiled",
+        ]
+        || words
+            == [
+                "play", "exiled", "cards", "for", "as", "long", "as", "they", "remain",
+                "exiled",
+            ];
+    matches.then(|| {
+        EffectAst::subject_verb_grant_play_tagged_for_as_long_as_exiled(
+            TagKey::from(IT_TAG),
+            PlayerAst::You,
+            true,
+            false,
+            false,
+            None,
+        )
+    })
+}
+
+fn parse_mana_any_type_cast_tagged_this_way_clause(tokens: &[OwnedLexToken]) -> Option<EffectAst> {
+    let trimmed = trim_commas(tokens);
+    let words = TokenWordView::new(&trimmed).word_refs();
+    let matches = words
+        == [
+            "mana", "of", "any", "type", "can", "be", "spent", "to", "cast", "spells",
+            "this", "way",
+        ]
+        || words
+            == [
+                "mana", "of", "any", "type", "can", "be", "spent", "to", "cast", "them",
+                "this", "way",
+            ]
+        || words
+            == [
+                "mana", "of", "any", "type", "can", "be", "spent", "to", "cast", "that",
+                "spell", "this", "way",
+            ];
+    matches.then(|| {
+        EffectAst::subject_verb_grant_play_tagged_for_as_long_as_exiled(
+            TagKey::from(IT_TAG),
+            PlayerAst::You,
+            false,
+            false,
+            true,
+            None,
+        )
+    })
+}
+
 fn parse_for_each_prevent_damage_clause(
     tokens: &[OwnedLexToken],
 ) -> Result<Option<EffectAst>, CardTextError> {
@@ -974,6 +1031,10 @@ pub(crate) fn parse_effect_clause(tokens: &[OwnedLexToken]) -> Result<EffectAst,
             return Ok(build_may_cast_tagged_effect(&spec));
         }
 
+        if let Some(effect) = parse_play_exiled_cards_for_as_long_as_exiled_clause(tokens) {
+            return Ok(effect);
+        }
+
         if let Some(effect) = parse_cast_or_play_tagged_clause(tokens)? {
             return Ok(effect);
         }
@@ -985,6 +1046,10 @@ pub(crate) fn parse_effect_clause(tokens: &[OwnedLexToken]) -> Result<EffectAst,
         if let Some(effect) = parse_cast_single_spell_from_among_hand_cards_clause(tokens) {
             return Ok(effect);
         }
+    }
+
+    if let Some(effect) = parse_mana_any_type_cast_tagged_this_way_clause(tokens) {
+        return Ok(effect);
     }
 
     if let Some(player) = parse_leading_player_may(tokens) {

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_inner/generic_subject_verb_programs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_inner/generic_subject_verb_programs.rs
@@ -706,6 +706,25 @@ fn has_where_x_value_binding(tokens: &[OwnedLexToken]) -> bool {
 pub(crate) fn parse_top_level_subject_verb_recognition(
     tokens: &[OwnedLexToken],
 ) -> Result<Option<(&'static str, Vec<EffectAst>)>, CardTextError> {
+    if let Some(effect) = parse_generic_play_exiled_cards_for_as_long_as_exiled(tokens) {
+        return Ok(Some((
+            "subject-verb verb=Play subject=implicit recognizer=exiled-cards-play-permission",
+            vec![effect],
+        )));
+    }
+    if let Some(effect) = super::super::permission_helpers::parse_cast_or_play_tagged_clause(tokens)?
+    {
+        return Ok(Some((
+            "subject-verb verb=Play subject=implicit recognizer=tagged-play-permission",
+            vec![effect],
+        )));
+    }
+    if let Some(effect) = parse_generic_mana_any_type_cast_tagged_this_way(tokens) {
+        return Ok(Some((
+            "subject-verb verb=Cast subject=implicit recognizer=tagged-any-mana-permission",
+            vec![effect],
+        )));
+    }
     if let Some(effects) = parse_source_gets_unblockable_subject_verb(tokens)? {
         return Ok(Some((
             "subject-verb verb=Get subject=source recognizer=source-pump-unblockable",
@@ -746,6 +765,10 @@ pub(crate) fn parse_top_level_subject_verb_recognition(
     {
         Some(GenericTopLevelProgram::PreventDamageAndPutCounters { effect })
     } else if let Some(effects) =
+        parse_generic_top_cards_exile_counted_face_down_rest_bottom_subject_verb(tokens)?
+    {
+        Some(GenericTopLevelProgram::LookedCardsCountedRemainder { effects })
+    } else if let Some(effects) =
         parse_generic_top_cards_put_counted_into_hand_rest_graveyard_subject_verb(tokens)
     {
         Some(GenericTopLevelProgram::LookedCardsCountedRemainder { effects })
@@ -779,6 +802,63 @@ pub(crate) fn parse_top_level_subject_verb_recognition(
         let route = program.route();
         (route, program.lower())
     }))
+}
+
+fn parse_generic_play_exiled_cards_for_as_long_as_exiled(
+    tokens: &[OwnedLexToken],
+) -> Option<EffectAst> {
+    let trimmed = trim_commas(tokens);
+    let words = TokenWordView::new(&trimmed).word_refs();
+    let matches = words
+        == [
+            "play", "the", "exiled", "cards", "for", "as", "long", "as", "they", "remain",
+            "exiled",
+        ]
+        || words
+            == [
+                "play", "exiled", "cards", "for", "as", "long", "as", "they", "remain",
+                "exiled",
+            ];
+    matches.then(|| {
+        EffectAst::subject_verb_grant_play_tagged_for_as_long_as_exiled(
+            TagKey::from(IT_TAG),
+            PlayerAst::You,
+            true,
+            false,
+            false,
+            None,
+        )
+    })
+}
+
+fn parse_generic_mana_any_type_cast_tagged_this_way(tokens: &[OwnedLexToken]) -> Option<EffectAst> {
+    let trimmed = trim_commas(tokens);
+    let words = TokenWordView::new(&trimmed).word_refs();
+    let matches = words
+        == [
+            "mana", "of", "any", "type", "can", "be", "spent", "to", "cast", "spells",
+            "this", "way",
+        ]
+        || words
+            == [
+                "mana", "of", "any", "type", "can", "be", "spent", "to", "cast", "them",
+                "this", "way",
+            ]
+        || words
+            == [
+                "mana", "of", "any", "type", "can", "be", "spent", "to", "cast", "that",
+                "spell", "this", "way",
+            ];
+    matches.then(|| {
+        EffectAst::subject_verb_grant_play_tagged_for_as_long_as_exiled(
+            TagKey::from(IT_TAG),
+            PlayerAst::You,
+            false,
+            false,
+            true,
+            None,
+        )
+    })
 }
 
 fn parse_source_gets_unblockable_subject_verb(
@@ -1038,6 +1118,92 @@ fn put_counted_top_cards_owner(owner_clause: LexedClause<'_>, default: PlayerAst
     } else {
         None
     }
+}
+
+fn generic_words_contain_phrase(words: &[&str], phrase: &[&str]) -> bool {
+    !phrase.is_empty()
+        && words
+            .windows(phrase.len())
+            .any(|window| window == phrase)
+}
+
+fn parse_generic_top_cards_exile_counted_face_down_rest_bottom_subject_verb(
+    tokens: &[OwnedLexToken],
+) -> Result<Option<Vec<EffectAst>>, CardTextError> {
+    let sentence_tokens = trim_commas(tokens);
+    let sentence_clause = LexedClause::new(&sentence_tokens).trimmed();
+    let Some(exile_word_idx) = sentence_clause.find_word("exile") else {
+        return Ok(None);
+    };
+    let Some(exile_token_idx) = sentence_clause.token_index_for_word_index(exile_word_idx) else {
+        return Ok(None);
+    };
+
+    let look_clause = sentence_clause.before(exile_token_idx).trimmed();
+    let exile_clause = sentence_clause.from(exile_token_idx).trimmed();
+    let look_effect = super::verb_handlers::parse_look(look_clause.tokens(), None)?;
+    let EffectAst::SubjectVerb(SubjectVerbEffectAst {
+        subject: SubjectVerbSubjectAst { player, .. },
+        action: SubjectVerbActionAst::LookAtTopCards { count, .. },
+    }) = look_effect
+    else {
+        return Ok(None);
+    };
+
+    let exile_tokens = trim_commas(exile_clause.tokens());
+    let exile_clause = LexedClause::new(&exile_tokens).trimmed();
+    let Some(count_start) = exile_clause.token_index_for_word_index(1) else {
+        return Ok(None);
+    };
+    let count_tokens = trim_commas(&exile_clause.tokens()[count_start..]);
+    let Some((exile_count, used)) =
+        crate::runtime_backend::util::parse_choice_count_token_prefix_consumed(&count_tokens)
+    else {
+        return Ok(None);
+    };
+    let tail_tokens = trim_commas(&count_tokens[used..]);
+    let tail_words = crate::runtime_backend::util::non_article_token_word_refs(&tail_tokens);
+    let references_looked = tail_words.starts_with(&["of", "them", "face", "down"])
+        || tail_words.starts_with(&["them", "face", "down"])
+        || tail_words.starts_with(&["of", "those", "cards", "face", "down"])
+        || tail_words.starts_with(&["those", "cards", "face", "down"]);
+    let bottoms_rest = generic_words_contain_phrase(&tail_words, &["put", "rest", "on", "bottom"])
+        || generic_words_contain_phrase(&tail_words, &["put", "rest", "onto", "bottom"])
+        || generic_words_contain_phrase(&tail_words, &["put", "the", "rest", "on", "bottom"])
+        || generic_words_contain_phrase(&tail_words, &["put", "the", "rest", "onto", "bottom"]);
+    if !references_looked || !bottoms_rest || !tail_words.iter().any(|word| *word == "library") {
+        return Ok(None);
+    }
+    let bottom_order = if generic_words_contain_phrase(&tail_words, &["random", "order"]) {
+        crate::cards::builders::LibraryBottomOrderAst::Random
+    } else if generic_words_contain_phrase(&tail_words, &["any", "order"]) {
+        crate::cards::builders::LibraryBottomOrderAst::ChooserChooses
+    } else {
+        return Ok(None);
+    };
+
+    let looked_tag = crate::runtime_backend::util::helper_tag_for_tokens(tokens, "looked");
+    let exiled_tag = TagKey::from(IT_TAG);
+    let mut choice_filter = ObjectFilter::tagged(looked_tag.clone());
+    choice_filter.zone = Some(Zone::Library);
+
+    Ok(Some(vec![
+        EffectAst::subject_verb_look_at_top_cards(player, count, looked_tag.clone()),
+        EffectAst::ChooseObjects {
+            filter: choice_filter,
+            count: exile_count,
+            count_value: None,
+            player: PlayerAst::You,
+            tag: exiled_tag.clone(),
+        },
+        EffectAst::subject_verb_exile(TargetAst::Tagged(exiled_tag.clone(), None), true),
+        EffectAst::subject_verb_put_tagged_remainder_on_bottom_of_library(
+            looked_tag,
+            Some(exiled_tag),
+            bottom_order,
+            PlayerAst::You,
+        ),
+    ]))
 }
 
 pub(crate) fn parse_generic_top_cards_put_counted_into_hand_rest_graveyard_subject_verb(

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_inner/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_inner/mod.rs
@@ -48,8 +48,8 @@ use super::{
 #[allow(unused_imports)]
 use crate::cards::builders::{
     CardTextError, EffectAst, ExtraTurnAnchorAst, GrantedAbilityAst, IT_TAG, KeywordAction,
-    LineAst, PlayerAst, SubjectAst, SubjectVerbActionAst, SubjectVerbEffectAst, SubjectVerbRoleAst,
-    TagKey, TargetAst, TextSpan, TriggerSpec, Verb,
+    LineAst, PlayerAst, SubjectAst, SubjectVerbActionAst, SubjectVerbEffectAst,
+    SubjectVerbRoleAst, SubjectVerbSubjectAst, TagKey, TargetAst, TextSpan, TriggerSpec, Verb,
 };
 use crate::effect::{ChoiceCount, EventValueSpec, Until, Value};
 use crate::object::CounterType;

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sequence_rules/generic_subject_verb_sequences/pairs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sequence_rules/generic_subject_verb_sequences/pairs.rs
@@ -23,7 +23,7 @@ use crate::runtime_backend::permission_helpers::parse_cast_or_play_tagged_clause
 use crate::runtime_backend::token_primitives::{
     find_index, parse_leading_may_action_lexed, word_view_has_any_prefix,
 };
-use crate::runtime_backend::util::trim_commas;
+use crate::runtime_backend::util::{parse_choice_count_token_prefix_consumed, trim_commas};
 use crate::runtime_backend::util::{
     helper_tag_for_tokens, is_article, non_article_token_word_refs, non_article_word_refs,
     parse_subject, strip_leading_token_word_once_any, word_refs_except,
@@ -526,11 +526,137 @@ const PUT_OTHER_LOOKED_CARDS_INTO_GRAVEYARD_PATTERN: ClauseShape<'static> = clau
         ]]
 );
 
+const COUNTED_EXILE_LOOKED_FACE_DOWN_REST_BOTTOM_PATTERN: ClauseShape<'static> = clause_shape!(
+    prefix_any
+        & [
+            &["of", "them", "face", "down"],
+            &["of", "those", "cards", "face", "down"],
+            &["them", "face", "down"],
+            &["those", "cards", "face", "down"],
+        ];
+    contains_words &["library"]
+);
+
+fn words_contain_phrase(words: &[&str], phrase: &[&str]) -> bool {
+    !phrase.is_empty()
+        && words
+            .windows(phrase.len())
+            .any(|window| window == phrase)
+}
+
+fn parse_counted_looked_exile_face_down_rest_bottom(
+    tokens: &[OwnedLexToken],
+) -> Option<(ChoiceCount, LibraryBottomOrderAst)> {
+    let clause = LexedClause::new(tokens).trimmed();
+    if clause.word_refs().first().copied() != Some("exile") {
+        return None;
+    }
+
+    let count_start = clause.token_index_for_word_index(1)?;
+    let count_tokens = trim_commas(&clause.tokens()[count_start..]);
+    let (count, used) = parse_choice_count_token_prefix_consumed(&count_tokens)?;
+    let tail_tokens = trim_commas(&count_tokens[used..]);
+    let tail_words = non_article_token_word_refs(&tail_tokens);
+    if !COUNTED_EXILE_LOOKED_FACE_DOWN_REST_BOTTOM_PATTERN.matches_words(&tail_words) {
+        return None;
+    }
+    let bottoms_rest = words_contain_phrase(&tail_words, &["put", "rest", "on", "bottom"])
+        || words_contain_phrase(&tail_words, &["put", "rest", "onto", "bottom"])
+        || words_contain_phrase(&tail_words, &["put", "the", "rest", "on", "bottom"])
+        || words_contain_phrase(&tail_words, &["put", "the", "rest", "onto", "bottom"]);
+    if !bottoms_rest {
+        return None;
+    }
+
+    let order = parse_consult_remainder_order(&LexedClause::new(&tail_tokens).word_refs())?;
+    Some((count, order))
+}
+
 pub(crate) fn parse_look_at_top_then_exile_face_down_then_play_while_exiled(
     sentences: &[SentenceInput],
     sentence_idx: usize,
 ) -> Result<Option<Vec<EffectAst>>, CardTextError> {
     let first_clause = LexedClause::new(sentences[sentence_idx].lowered()).trimmed();
+
+    if let Some(exile_word_idx) = first_clause.find_word("exile") {
+        let Some(exile_token_idx) = first_clause.token_index_for_word_index(exile_word_idx) else {
+            return Ok(None);
+        };
+        let look_clause = first_clause.before(exile_token_idx).trimmed();
+        let exile_clause = first_clause.from(exile_token_idx).trimmed();
+
+        if let Some((exile_count, bottom_order)) =
+            parse_counted_looked_exile_face_down_rest_bottom(exile_clause.tokens())
+        {
+            let Ok(look_effects) = effect_sentences::parse_effect_sentence_lexed(look_clause.tokens())
+            else {
+                return Ok(None);
+            };
+            let [look_effect] = look_effects.as_slice() else {
+                return Ok(None);
+            };
+            let Some((library_owner, count)) = look_at_top_cards_parts(look_effect) else {
+                return Ok(None);
+            };
+
+            let Some(permission_effect) =
+                parse_cast_or_play_tagged_clause(sentences[sentence_idx + 1].lowered())?
+            else {
+                return Ok(None);
+            };
+            let EffectAst::SubjectVerb(SubjectVerbEffectAst {
+                action:
+                    SubjectVerbActionAst::GrantPlayTaggedForAsLongAsExiled {
+                        player: permission_player,
+                        allow_land,
+                        without_paying_mana_cost,
+                        allow_any_color_for_cast,
+                        filter,
+                        ..
+                    },
+                ..
+            }) = permission_effect
+            else {
+                return Ok(None);
+            };
+
+            let looked_tag = helper_tag_for_tokens(sentences[sentence_idx].lowered(), "looked");
+            let exiled_tag = helper_tag_for_tokens(exile_clause.tokens(), "exiled");
+            let mut choice_filter = ObjectFilter::tagged(looked_tag.clone());
+            choice_filter.zone = Some(Zone::Library);
+
+            return Ok(Some(vec![
+                EffectAst::subject_verb_look_at_top_cards(
+                    library_owner,
+                    count,
+                    looked_tag.clone(),
+                ),
+                EffectAst::ChooseObjects {
+                    filter: choice_filter,
+                    count: exile_count,
+                    count_value: None,
+                    player: PlayerAst::You,
+                    tag: exiled_tag.clone(),
+                },
+                EffectAst::subject_verb_exile(TargetAst::Tagged(exiled_tag.clone(), None), true),
+                EffectAst::subject_verb_put_tagged_remainder_on_bottom_of_library(
+                    looked_tag,
+                    Some(exiled_tag.clone()),
+                    bottom_order,
+                    PlayerAst::You,
+                ),
+                EffectAst::subject_verb_grant_play_tagged_for_as_long_as_exiled(
+                    exiled_tag,
+                    permission_player,
+                    allow_land,
+                    without_paying_mana_cost,
+                    allow_any_color_for_cast,
+                    filter,
+                ),
+            ]));
+        }
+    }
+
     let Some(then_idx) = first_clause.find_phrase_start(&["then", "exile"]) else {
         return Ok(None);
     };

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sequence_rules/generic_subject_verb_sequences/quads.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sequence_rules/generic_subject_verb_sequences/quads.rs
@@ -15,6 +15,7 @@ use crate::runtime_backend::effect_sentences::SentenceInput;
 use crate::runtime_backend::effect_sentences::clause_pattern_helpers::{ClauseShape, clause_shape};
 use crate::runtime_backend::front_end::lexer::{LexedClause, OwnedLexToken};
 use crate::runtime_backend::object_filters::parse_object_filter_lexed;
+use crate::runtime_backend::permission_helpers::parse_cast_or_play_tagged_clause;
 use crate::runtime_backend::util::{
     helper_tag_for_tokens, non_article_token_word_refs, parse_choice_count_token_prefix_consumed,
     trim_commas,
@@ -137,6 +138,16 @@ const EXILE_ONE_LOOKED_CARD_FACE_DOWN_REST_BOTTOM_PATTERN: ClauseShape<'static> 
     contains_phrases & [&["put", "rest"], &["bottom", "of", "your", "library"]]
 );
 
+const EXILE_COUNTED_LOOKED_CARDS_FACE_DOWN_PATTERN: ClauseShape<'static> = clause_shape!(
+    prefix_any
+        & [
+            &["of", "them", "face", "down"],
+            &["of", "those", "cards", "face", "down"],
+            &["them", "face", "down"],
+            &["those", "cards", "face", "down"],
+        ]
+);
+
 const CAST_EXILED_CARD_FREE_PREFIX_PATTERN: ClauseShape<'static> = clause_shape!(
     exact
         & [
@@ -203,6 +214,48 @@ fn exiles_one_looked_card_face_down_and_bottoms_rest(tokens: &[OwnedLexToken]) -
     let trimmed = trim_commas(tokens);
     let words = non_article_token_word_refs(&trimmed);
     EXILE_ONE_LOOKED_CARD_FACE_DOWN_REST_BOTTOM_PATTERN.matches_words(&words)
+}
+
+fn words_contain_phrase(words: &[&str], phrase: &[&str]) -> bool {
+    !phrase.is_empty()
+        && words
+            .windows(phrase.len())
+            .any(|window| window == phrase)
+}
+
+fn parse_counted_looked_cards_exile_face_down(
+    tokens: &[OwnedLexToken],
+) -> Option<(ChoiceCount, bool)> {
+    let trimmed = trim_commas(tokens);
+    let clause = LexedClause::new(&trimmed).trimmed();
+    if clause.word_refs().first().copied() != Some("exile") {
+        return None;
+    }
+
+    let count_start = clause.token_index_for_word_index(1)?;
+    let count_tokens = trim_commas(&clause.tokens()[count_start..]);
+    let (count, used) = parse_choice_count_token_prefix_consumed(&count_tokens)?;
+    let tail_tokens = trim_commas(&count_tokens[used..]);
+    let tail_words = non_article_token_word_refs(&tail_tokens);
+    if !EXILE_COUNTED_LOOKED_CARDS_FACE_DOWN_PATTERN.matches_words(&tail_words) {
+        return None;
+    }
+    let includes_remainder = words_contain_phrase(&tail_words, &["put", "rest"])
+        || words_contain_phrase(&tail_words, &["put", "the", "rest"]);
+    Some((count, includes_remainder))
+}
+
+fn puts_looked_remainder_on_bottom(tokens: &[OwnedLexToken]) -> Option<LibraryBottomOrderAst> {
+    let trimmed = trim_commas(tokens);
+    let words = non_article_token_word_refs(&trimmed);
+    let puts_rest = words_contain_phrase(&words, &["put", "rest", "on", "bottom"])
+        || words_contain_phrase(&words, &["put", "rest", "onto", "bottom"])
+        || words_contain_phrase(&words, &["put", "the", "rest", "on", "bottom"])
+        || words_contain_phrase(&words, &["put", "the", "rest", "onto", "bottom"]);
+    if !puts_rest || !words.iter().any(|word| *word == "library") {
+        return None;
+    }
+    effect_sentences::parse_consult_remainder_order(&LexedClause::new(&trimmed).word_refs())
 }
 
 fn parse_exiled_card_cast_filter(
@@ -510,6 +563,124 @@ pub(crate) fn parse_look_at_top_exile_one_rest_bottom_cast_else_hand(
                 None,
             )],
         },
+    ]))
+}
+
+pub(crate) fn parse_look_at_top_exile_counted_rest_bottom_play_while_exiled(
+    sentences: &[SentenceInput],
+    sentence_idx: usize,
+) -> Result<Option<Vec<EffectAst>>, CardTextError> {
+    let first_clause = LexedClause::new(sentences[sentence_idx].lowered()).trimmed();
+    let (look_tokens, exile_count, bottom_order) =
+        if let Some(exile_word_idx) = first_clause.find_word("exile") {
+            let Some(exile_token_idx) = first_clause.token_index_for_word_index(exile_word_idx)
+            else {
+                return Ok(None);
+            };
+            let look_clause = first_clause.before(exile_token_idx).trimmed();
+            let exile_clause = first_clause.from(exile_token_idx).trimmed();
+            let Some((count, includes_remainder)) =
+                parse_counted_looked_cards_exile_face_down(exile_clause.tokens())
+            else {
+                return Ok(None);
+            };
+            let order = if includes_remainder {
+                puts_looked_remainder_on_bottom(exile_clause.tokens())
+            } else {
+                puts_looked_remainder_on_bottom(sentences[sentence_idx + 2].lowered())
+            };
+            let Some(order) = order else {
+                return Ok(None);
+            };
+            (look_clause.tokens(), count, order)
+        } else {
+            let Some((count, includes_remainder)) =
+                parse_counted_looked_cards_exile_face_down(sentences[sentence_idx + 1].lowered())
+            else {
+                return Ok(None);
+            };
+            let order = if includes_remainder {
+                puts_looked_remainder_on_bottom(sentences[sentence_idx + 1].lowered())
+            } else {
+                puts_looked_remainder_on_bottom(sentences[sentence_idx + 2].lowered())
+            };
+            let Some(order) = order else {
+                return Ok(None);
+            };
+            (first_clause.tokens(), count, order)
+        };
+
+    let Ok(look_effects) = effect_sentences::parse_effect_sentence_lexed(look_tokens) else {
+        return Ok(None);
+    };
+    let [look_effect] = look_effects.as_slice() else {
+        return Ok(None);
+    };
+    let Some(library_owner) = look_at_top_cards_player(look_effect) else {
+        return Ok(None);
+    };
+    let EffectAst::SubjectVerb(SubjectVerbEffectAst {
+        action: SubjectVerbActionAst::LookAtTopCards { count, .. },
+        ..
+    }) = look_effect
+    else {
+        return Ok(None);
+    };
+
+    let Some(permission_effect) =
+        parse_cast_or_play_tagged_clause(sentences[sentence_idx + 3].lowered())?
+    else {
+        return Ok(None);
+    };
+    let EffectAst::SubjectVerb(SubjectVerbEffectAst {
+        action:
+            SubjectVerbActionAst::GrantPlayTaggedForAsLongAsExiled {
+                player: permission_player,
+                allow_land,
+                without_paying_mana_cost,
+                allow_any_color_for_cast,
+                filter,
+                ..
+            },
+        ..
+    }) = permission_effect
+    else {
+        return Ok(None);
+    };
+
+    let looked_tag = helper_tag_for_tokens(sentences[sentence_idx].lowered(), "looked");
+    let exiled_tag = helper_tag_for_tokens(sentences[sentence_idx + 1].lowered(), "exiled");
+    let mut choice_filter = ObjectFilter::tagged(looked_tag.clone());
+    choice_filter.zone = Some(Zone::Library);
+
+    Ok(Some(vec![
+        EffectAst::subject_verb_look_at_top_cards(
+            library_owner,
+            count.clone(),
+            looked_tag.clone(),
+        ),
+        EffectAst::ChooseObjects {
+            filter: choice_filter,
+            count: exile_count,
+            count_value: None,
+            player: PlayerAst::You,
+            tag: exiled_tag.clone(),
+        },
+        EffectAst::subject_verb_exile(TargetAst::Tagged(exiled_tag.clone(), None), true),
+        EffectAst::subject_verb_put_tagged_remainder_on_bottom_of_library(
+            looked_tag,
+            Some(exiled_tag.clone()),
+            bottom_order,
+            PlayerAst::You,
+        ),
+        EffectAst::subject_verb_grant_play_tagged_for_as_long_as_exiled(
+            exiled_tag,
+            permission_player,
+            allow_land,
+            without_paying_mana_cost,
+            allow_any_color_for_cast,
+            filter,
+        ),
     ]))
 }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sequence_rules/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/sequence_rules/mod.rs
@@ -187,6 +187,14 @@ fn for_each_tagged_copy_window(sentences: &[SentenceInput], sentence_idx: usize)
 
 const SUBJECT_VERB_SEQUENCE_RULES: &[SequenceRuleDef] = &[
     SequenceRuleDef {
+        name: "look-at-top-exile-counted-rest-bottom-play-while-exiled",
+        feature_tag: Some("looked-cards-exile-play-while-exiled"),
+        priority: 432,
+        consumed_sentences: 4,
+        predicate: first_word_look,
+        parser: generic_subject_verb_sequences::quads::parse_look_at_top_exile_counted_rest_bottom_play_while_exiled,
+    },
+    SequenceRuleDef {
         name: "search-reveal-named-match-battlefield-else-hand-then-shuffle",
         feature_tag: Some("search-named-card-branch"),
         priority: 431,

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -32799,6 +32799,49 @@ fn parse_the_mana_rig_tracks_trigger_and_xxx_tap_activation_shape() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_black_cat_cunning_thief_oracle_text_strictly() {
+    let oracle = "When Black Cat enters, look at the top nine cards of target opponent's library, exile two of them face down, then put the rest on the bottom of their library in a random order. You may play the exiled cards for as long as they remain exiled. Mana of any type can be spent to cast spells this way.";
+    let def = CardDefinitionBuilder::new(CardId::new(), "Black Cat, Cunning Thief")
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Human, Subtype::Rogue, Subtype::Villain])
+        .parse_text(oracle)
+        .expect("Black Cat, Cunning Thief should parse strictly");
+
+    assert_eq!(
+        unprocessed_compiled_lines(&def).join(" "),
+        "When Black Cat enters, look at the top nine cards of target opponent's library, exile two of them face down, then put the rest on the bottom of their library in a random order. You may play the exiled cards for as long as they remain exiled. Mana of any type can be spent to cast spells this way."
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn parse_black_cat_cunning_thief_tracks_targets_and_exiled_card_grants() {
+    let oracle = "When Black Cat enters, look at the top nine cards of target opponent's library, exile two of them face down, then put the rest on the bottom of their library in a random order. You may play the exiled cards for as long as they remain exiled. Mana of any type can be spent to cast spells this way.";
+    let def = CardDefinitionBuilder::new(CardId::new(), "Black Cat, Cunning Thief")
+        .card_types(vec![CardType::Creature])
+        .parse_text(oracle)
+        .expect("Black Cat, Cunning Thief should parse strictly");
+
+    let debug = format!("{:#?}", def.abilities);
+    assert!(
+        debug.contains("Target(")
+            && debug.contains("Opponent")
+            && debug.contains("ChooseObjectsEffect")
+            && debug.contains("count: ChoiceCount")
+            && debug.contains("min: 2")
+            && debug.contains("max: Some")
+            && debug.contains("ExileEffect")
+            && debug.contains("face_down: true")
+            && debug.contains("PutTaggedRemainderOnLibraryBottomEffect")
+            && debug.contains("GrantPlayTaggedEffect")
+            && debug.contains("allow_land: true")
+            && debug.contains("allow_any_color_for_cast: true"),
+        "expected Black Cat target, two-card face-down exile, remainder, and any-mana grants, got {debug}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_token_with_banding_keyword_modifier() {
     let result = CardDefinitionBuilder::new(CardId::new(), "Errand of Duty Variant")
         .parse_text("Create a 1/1 white Knight creature token with banding.");

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -15593,6 +15593,80 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
             idx += 3;
             continue;
         }
+        if idx + 4 < filtered.len()
+            && let Some(look_at_top) =
+                filtered[idx].downcast_ref::<crate::effects::LookAtTopCardsEffect>()
+            && let Some(choose) =
+                filtered[idx + 1].downcast_ref::<crate::effects::ChooseObjectsEffect>()
+            && let Some(exile) = filtered[idx + 2].downcast_ref::<crate::effects::ExileEffect>()
+            && let Some(rest) = filtered[idx + 3]
+                .downcast_ref::<crate::effects::PutTaggedRemainderOnLibraryBottomEffect>()
+            && let Some(grant) =
+                filtered[idx + 4].downcast_ref::<crate::effects::GrantPlayTaggedEffect>()
+            && let Some(compact) =
+                describe_look_at_top_choose_exile_face_down_rest_bottom_then_play_while_exiled(
+                    look_at_top,
+                    choose,
+                    exile,
+                    rest,
+                    grant,
+                )
+        {
+            parts.push(compact);
+            idx += 5;
+            continue;
+        }
+        if idx + 5 < filtered.len()
+            && let Some(look_at_top) =
+                filtered[idx].downcast_ref::<crate::effects::LookAtTopCardsEffect>()
+            && let Some(choose) =
+                filtered[idx + 1].downcast_ref::<crate::effects::ChooseObjectsEffect>()
+            && let Some(exile) = filtered[idx + 2].downcast_ref::<crate::effects::ExileEffect>()
+            && let Some(rest) = filtered[idx + 3]
+                .downcast_ref::<crate::effects::PutTaggedRemainderOnLibraryBottomEffect>()
+            && let Some(play_grant) =
+                filtered[idx + 4].downcast_ref::<crate::effects::GrantPlayTaggedEffect>()
+            && let Some(any_mana_grant) =
+                filtered[idx + 5].downcast_ref::<crate::effects::GrantPlayTaggedEffect>()
+            && let Some(compact) =
+                describe_look_at_top_choose_exile_rest_bottom_play_grants_and_any_mana_while_exiled(
+                    look_at_top,
+                    choose,
+                    exile,
+                    rest,
+                    play_grant,
+                    any_mana_grant,
+                )
+        {
+            parts.push(compact);
+            idx += 6;
+            continue;
+        }
+        if idx + 5 < filtered.len()
+            && let Some(look_at_top) =
+                filtered[idx].downcast_ref::<crate::effects::LookAtTopCardsEffect>()
+            && let Some(choose) =
+                filtered[idx + 1].downcast_ref::<crate::effects::ChooseObjectsEffect>()
+            && let Some(exile) = filtered[idx + 2].downcast_ref::<crate::effects::ExileEffect>()
+            && let Some(rest) = filtered[idx + 3]
+                .downcast_ref::<crate::effects::PutTaggedRemainderOnLibraryBottomEffect>()
+            && let Some(may_play) = filtered[idx + 4].downcast_ref::<crate::effects::MayEffect>()
+            && let Some(any_mana_grant) =
+                filtered[idx + 5].downcast_ref::<crate::effects::GrantPlayTaggedEffect>()
+            && let Some(compact) =
+                describe_look_at_top_choose_exile_rest_bottom_play_and_any_mana_while_exiled(
+                    look_at_top,
+                    choose,
+                    exile,
+                    rest,
+                    may_play,
+                    any_mana_grant,
+                )
+        {
+            parts.push(compact);
+            idx += 6;
+            continue;
+        }
         if idx + 7 < filtered.len()
             && let Some(look_at_top) =
                 filtered[idx].downcast_ref::<crate::effects::LookAtTopCardsEffect>()
@@ -18552,6 +18626,16 @@ fn normalize_redundant_short_name_etb_surface(
             .filter(|start| *start == 0 || line[..*start].ends_with(": "))
             .map(|start| (start, prefix.len()))
     }) else {
+        for generic_subject in [subject, "this creature", "this permanent", "this artifact"] {
+            let generic_prefix = format!("When {generic_subject} enters,");
+            if let Some(start) = line
+                .find(generic_prefix.as_str())
+                .filter(|start| *start == 0 || line[..*start].ends_with(": "))
+            {
+                let rest = &line[start + generic_prefix.len()..];
+                return format!("{}When {surface} enters,{rest}", &line[..start]);
+            }
+        }
         return line;
     };
     let rest = &line[start + prefix_len..];
@@ -18568,7 +18652,7 @@ fn normalize_redundant_short_name_etb_surface(
     {
         return line;
     }
-    format!("{}When {subject} enters,{rest}", &line[..start])
+    format!("{}When {surface} enters,{rest}", &line[..start])
 }
 
 fn normalize_spellcast_trigger_mana_value_surface(
@@ -26039,6 +26123,149 @@ pub(super) fn describe_look_at_top_exile_face_down_then_play_while_exiled(
 
     Some(format!(
         "{look_clause}, then exile {object_ref} face down. For as long as {duration_ref} remains exiled, {player} may {verb} {object_ref}{mana_suffix}"
+    ))
+}
+
+fn describe_look_at_top_choose_exile_face_down_rest_bottom_then_play_while_exiled(
+    look_at_top: &crate::effects::LookAtTopCardsEffect,
+    choose: &crate::effects::ChooseObjectsEffect,
+    exile: &crate::effects::ExileEffect,
+    rest: &crate::effects::PutTaggedRemainderOnLibraryBottomEffect,
+    grant: &crate::effects::GrantPlayTaggedEffect,
+) -> Option<String> {
+    if look_at_top.reveal
+        || choose.chooser != PlayerFilter::You
+        || choose_primary_zone(choose) != Some(Zone::Library)
+        || !choose.filter.tagged_constraints.iter().any(|constraint| {
+            constraint.relation == crate::filter::TaggedOpbjectRelation::IsTaggedObject
+                && constraint.tag == look_at_top.tag
+        })
+        || !matches!(exile.spec.base(), ChooseSpec::Tagged(tag) if tag == &choose.tag)
+        || !exile.face_down
+        || rest.tag != look_at_top.tag
+        || rest.keep_tagged.as_ref() != Some(&choose.tag)
+        || rest.order != crate::effects::consult_helpers::LibraryBottomOrder::Random
+        || grant.tag != choose.tag
+        || grant.duration != crate::effects::GrantPlayTaggedDuration::ForAsLongAsExiled
+    {
+        return None;
+    }
+
+    let chosen_ref = if choose.count.is_single() {
+        "one of them".to_string()
+    } else if choose.count.min == 0 {
+        let max = choose.count.max?;
+        let count_text = small_number_word(max as u32).unwrap_or_else(|| max.to_string());
+        format!("up to {count_text} of them")
+    } else if choose.count.max == Some(choose.count.min) {
+        let count_text = small_number_word(choose.count.min as u32)
+            .unwrap_or_else(|| choose.count.min.to_string());
+        format!("{count_text} of them")
+    } else {
+        return None;
+    };
+
+    let owner = describe_possessive_player_filter(&look_at_top.player);
+    let (count_text, noun, singular_count) = describe_look_count_and_noun(&look_at_top.count);
+    if singular_count {
+        return None;
+    }
+    let player = describe_player_filter(&grant.player);
+    let verb = if grant.allow_land { "play" } else { "cast" };
+    let mana_sentence = if grant.allow_any_color_for_cast {
+        ". Mana of any type can be spent to cast them"
+    } else {
+        ""
+    };
+
+    Some(format!(
+        "Look at the top {count_text} {noun} of {owner} library, exile {chosen_ref} face down, then put the rest on the bottom of {owner} library in a random order. {player} may {verb} the exiled cards for as long as they remain exiled{mana_sentence}"
+    ))
+}
+
+fn describe_look_at_top_choose_exile_rest_bottom_play_and_any_mana_while_exiled(
+    look_at_top: &crate::effects::LookAtTopCardsEffect,
+    choose: &crate::effects::ChooseObjectsEffect,
+    exile: &crate::effects::ExileEffect,
+    rest: &crate::effects::PutTaggedRemainderOnLibraryBottomEffect,
+    may_play: &crate::effects::MayEffect,
+    any_mana_grant: &crate::effects::GrantPlayTaggedEffect,
+) -> Option<String> {
+    let [play_effect] = may_play.effects.as_slice() else {
+        return None;
+    };
+    let play_grant = play_effect.downcast_ref::<crate::effects::GrantPlayTaggedEffect>()?;
+    describe_look_at_top_choose_exile_rest_bottom_play_grants_and_any_mana_while_exiled(
+        look_at_top,
+        choose,
+        exile,
+        rest,
+        play_grant,
+        any_mana_grant,
+    )
+}
+
+fn describe_look_at_top_choose_exile_rest_bottom_play_grants_and_any_mana_while_exiled(
+    look_at_top: &crate::effects::LookAtTopCardsEffect,
+    choose: &crate::effects::ChooseObjectsEffect,
+    exile: &crate::effects::ExileEffect,
+    rest: &crate::effects::PutTaggedRemainderOnLibraryBottomEffect,
+    play_grant: &crate::effects::GrantPlayTaggedEffect,
+    any_mana_grant: &crate::effects::GrantPlayTaggedEffect,
+) -> Option<String> {
+    let exiled_tag = rest.keep_tagged.as_ref()?;
+    if look_at_top.reveal
+        || choose.chooser != PlayerFilter::You
+        || choose_primary_zone(choose) != Some(Zone::Library)
+        || !choose.filter.tagged_constraints.iter().any(|constraint| {
+            constraint.relation == crate::filter::TaggedOpbjectRelation::IsTaggedObject
+                && constraint.tag == look_at_top.tag
+        })
+        || !matches!(exile.spec.base(), ChooseSpec::Tagged(tag) if tag == &choose.tag)
+        || !exile.face_down
+        || rest.tag != look_at_top.tag
+        || rest.order != crate::effects::consult_helpers::LibraryBottomOrder::Random
+        || play_grant.tag != *exiled_tag
+        || any_mana_grant.tag != *exiled_tag
+        || play_grant.duration != crate::effects::GrantPlayTaggedDuration::ForAsLongAsExiled
+        || any_mana_grant.duration != crate::effects::GrantPlayTaggedDuration::ForAsLongAsExiled
+        || !play_grant.allow_land
+        || play_grant.allow_any_color_for_cast
+        || any_mana_grant.allow_land
+        || !any_mana_grant.allow_any_color_for_cast
+    {
+        return None;
+    }
+
+    let chosen_ref = if choose.count.is_single() {
+        "one of them".to_string()
+    } else if choose.count.min == 0 {
+        let max = choose.count.max?;
+        let count_text = small_number_word(max as u32).unwrap_or_else(|| max.to_string());
+        format!("up to {count_text} of them")
+    } else if choose.count.max == Some(choose.count.min) {
+        let count_text = small_number_word(choose.count.min as u32)
+            .unwrap_or_else(|| choose.count.min.to_string());
+        format!("{count_text} of them")
+    } else {
+        return None;
+    };
+    let owner = describe_possessive_player_filter(&look_at_top.player);
+    let remainder_owner = if matches!(
+        look_at_top.player,
+        PlayerFilter::Target(_) | PlayerFilter::DamagedPlayer | PlayerFilter::ChosenPlayer
+    ) {
+        "their".to_string()
+    } else {
+        owner.clone()
+    };
+    let (count_text, noun, singular_count) = describe_look_count_and_noun(&look_at_top.count);
+    if singular_count {
+        return None;
+    }
+
+    Some(format!(
+        "Look at the top {count_text} {noun} of {owner} library, exile {chosen_ref} face down, then put the rest on the bottom of {remainder_owner} library in a random order. You may play the exiled cards for as long as they remain exiled. Mana of any type can be spent to cast spells this way"
     ))
 }
 

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -31163,6 +31163,195 @@ fn test_fallen_shinobi_trigger_exiles_top_two_cards_and_grants_play_permission()
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn black_cat_cunning_thief_definition() -> crate::cards::CardDefinition {
+    let oracle = "When Black Cat enters, look at the top nine cards of target opponent's library, \
+        exile two of them face down, then put the rest on the bottom of their library in a random \
+        order. You may play the exiled cards for as long as they remain exiled. Mana of any type \
+        can be spent to cast spells this way.";
+
+    CardDefinitionBuilder::new(CardId::from_raw(90_468), "Black Cat, Cunning Thief")
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Human, Subtype::Rogue, Subtype::Villain])
+        .power_toughness(PowerToughness::fixed(2, 3))
+        .parse_text(oracle)
+        .expect("Black Cat, Cunning Thief should parse for runtime tests")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+struct ChooseBlackCatCardsDecisionMaker {
+    selected: Vec<ObjectId>,
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+impl DecisionMaker for ChooseBlackCatCardsDecisionMaker {
+    fn decide_objects(
+        &mut self,
+        _game: &GameState,
+        ctx: &crate::decisions::context::SelectObjectsContext,
+    ) -> Vec<ObjectId> {
+        ctx.candidates
+            .iter()
+            .filter(|candidate| candidate.legal && self.selected.contains(&candidate.id))
+            .map(|candidate| candidate.id)
+            .take(ctx.max.unwrap_or(self.selected.len()))
+            .collect()
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn black_cat_library_card(name: &str, card_type: CardType) -> crate::card::Card {
+    CardBuilder::new(CardId::new(), name)
+        .card_types(vec![card_type])
+        .build()
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn black_cat_cunning_thief_exiles_two_looked_cards_face_down_and_bottoms_rest() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let black_cat = black_cat_cunning_thief_definition();
+    let source = game.create_object_from_definition(&black_cat, alice, Zone::Battlefield);
+
+    let alice_card = black_cat_library_card("Alice Untouched", CardType::Sorcery);
+    let alice_card_id = game.create_object_from_card(&alice_card, alice, Zone::Library);
+    let unrelated_exiled_card = black_cat_library_card("Unrelated Exiled", CardType::Instant);
+    let unrelated_exiled_id =
+        game.create_object_from_card(&unrelated_exiled_card, bob, Zone::Exile);
+
+    let mut bob_library = Vec::new();
+    for index in 1..=9 {
+        let card_type = if index == 8 {
+            CardType::Land
+        } else if index == 9 {
+            CardType::Instant
+        } else {
+            CardType::Sorcery
+        };
+        let card = black_cat_library_card(&format!("Bob Card {index}"), card_type);
+        bob_library.push(game.create_object_from_card(&card, bob, Zone::Library));
+    }
+    assert!(game.set_player_library_order_with_audit(
+        bob,
+        bob_library.clone(),
+        "Black Cat runtime test setup",
+    ));
+    let selected_permanent = bob_library[7];
+    let selected_spell = bob_library[8];
+    let selected_permanent_stable = game
+        .object(selected_permanent)
+        .expect("selected permanent setup")
+        .stable_id;
+    let selected_spell_stable = game
+        .object(selected_spell)
+        .expect("selected spell setup")
+        .stable_id;
+
+    let triggered = black_cat
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Triggered(triggered) => Some(triggered),
+            _ => None,
+        })
+        .expect("Black Cat should have an enters trigger");
+    let mut dm = ChooseBlackCatCardsDecisionMaker {
+        selected: vec![selected_permanent, selected_spell],
+    };
+    let mut ctx = crate::effects::ExecutionContext::new_default(source, alice)
+        .with_decision_maker(&mut dm)
+        .with_targets(vec![crate::effects::ResolvedTarget::Player(bob)])
+        .with_triggering_event(TriggerEvent::new_with_provenance(
+            EnterBattlefieldEvent::new(source, Zone::Hand),
+            crate::provenance::ProvNodeId::default(),
+        ));
+    crate::game_loop::execute_resolution_program(
+        &mut game,
+        &mut ctx,
+        alice,
+        source,
+        &triggered.effects,
+        None,
+        &[],
+    )
+    .expect("Black Cat enters trigger should resolve");
+
+    let selected_permanent = game
+        .find_object_by_stable_id(selected_permanent_stable)
+        .expect("selected permanent should still exist");
+    let selected_spell = game
+        .find_object_by_stable_id(selected_spell_stable)
+        .expect("selected spell should still exist");
+    for selected in [selected_permanent, selected_spell] {
+        assert_eq!(
+            game.object(selected).expect("selected card exists").zone,
+            Zone::Exile,
+            "Black Cat should exile the two selected looked-at cards"
+        );
+        assert!(
+            game.is_face_down(selected),
+            "Black Cat should exile selected cards face down"
+        );
+        assert!(
+            game.effect_store.grant_registry.card_can_play_from_zone(
+                &game,
+                selected,
+                Zone::Exile,
+                alice,
+            ),
+            "Black Cat should let its controller play selected exiled cards"
+        );
+        assert!(
+            !game.effect_store.grant_registry.card_can_play_from_zone(
+                &game,
+                selected,
+                Zone::Exile,
+                bob,
+            ),
+            "Black Cat should not let the target opponent play its selected exiled cards"
+        );
+    }
+    assert!(
+        game.can_spend_mana_as_any_color(alice, Some(selected_spell)),
+        "Black Cat should allow mana of any type to cast exiled spells"
+    );
+    assert!(
+        !game.can_spend_mana_as_any_color(bob, Some(selected_spell)),
+        "Black Cat's any-mana permission should belong to its controller"
+    );
+    assert!(
+        !game.effect_store.grant_registry.card_can_play_from_zone(
+            &game,
+            unrelated_exiled_id,
+            Zone::Exile,
+            alice,
+        ),
+        "Black Cat should not grant play permission for unrelated exiled cards"
+    );
+    assert!(
+        !game.can_spend_mana_as_any_color(alice, Some(unrelated_exiled_id)),
+        "Black Cat should not grant any-mana casting for unrelated exiled cards"
+    );
+    assert_eq!(
+        game.player(bob).expect("bob exists").library.len(),
+        7,
+        "Black Cat should put the seven unchosen looked-at cards back on the bottom of Bob's library"
+    );
+    assert!(
+        bob_library[..7].iter().all(|id| game
+            .object(*id)
+            .is_some_and(|object| object.zone == Zone::Library && object.owner == bob)),
+        "Black Cat should leave the unchosen looked-at cards in the target opponent's library"
+    );
+    assert_eq!(
+        game.object(alice_card_id).expect("alice card exists").zone,
+        Zone::Library,
+        "Black Cat should not touch its controller's library"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 fn mindleech_mass_definition() -> crate::cards::CardDefinition {
     CardDefinitionBuilder::new(CardId::from_raw(90_467), "Mindleech Mass")
         .mana_cost(ManaCost::from_pips(vec![


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Black Cat, Cunning Thief
Initial parse error:
```
unsupported target phrase (clause: 'two of them'); oracle-only fallback also failed: unsupported target phrase (clause: 'two of them')
```

Current worker: i-0f0611de6bd8d777f
Branch: codex/aws-card-fix-black-cat-cunning-thief
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260604T121212Z-controller-dev-loop-wave0024
