### PR TITLE
Fix Ironsmith parse failure: Aether Refinery

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -3303,6 +3303,9 @@ fn parse_static_ability_ast_line_lexed_single(
     if looks_like_trigger_intro_tokens(tokens) || looks_like_trigger_intro_after_label(tokens) {
         return Ok(None);
     }
+    if let Some(ability) = parse_double_counters_replacement_line(tokens)? {
+        return Ok(Some(vec![StaticAbilityAst::Static(ability)]));
+    }
     if looks_like_player_counter_gain_effect_tokens(tokens) {
         return Ok(None);
     }
@@ -9070,6 +9073,14 @@ pub(crate) fn parse_double_counters_replacement_line(
         )));
     }
 
+    if is_double_energy_counters_you_get_line(&line_words) {
+        return Ok(Some(StaticAbility::double_player_counters_replacement(
+            PlayerFilter::You,
+            Some(CounterType::Energy),
+            display_text_for_tokens(tokens, true),
+        )));
+    }
+
     let prefix_len = 10usize;
     if !PLUS_ONE_COUNTERS_WOULD_BE_PUT_PREFIX_PATTERN.matches_words(&line_words)
         || !TWICE_THAT_MANY_PLUS_ONE_COUNTERS_TAIL_PATTERN.matches_words(&line_words)
@@ -9094,6 +9105,47 @@ pub(crate) fn parse_double_counters_replacement_line(
         Some(crate::object::CounterType::PlusOnePlusOne),
         display_text_for_tokens(tokens, true),
     )))
+}
+
+fn is_double_energy_counters_you_get_line(line_words: &[&str]) -> bool {
+    let lowered: Vec<String> = line_words
+        .iter()
+        .copied()
+        .map(str::to_ascii_lowercase)
+        .collect();
+    let words: Vec<&str> = lowered
+        .iter()
+        .map(String::as_str)
+        .filter(|word| !matches!(*word, "," | "(" | ")"))
+        .collect();
+    let Some(you_get_idx) = words
+        .windows(2)
+        .position(|window| window == ["you", "get"])
+    else {
+        return false;
+    };
+    if you_get_idx < 7
+        || !word_slice_eq(&words[..7], &["if", "you", "would", "get", "one", "or", "more"])
+    {
+        return false;
+    }
+    let gained_counter_words = &words[7..you_get_idx];
+    // Reminder stripping can leave "one or more" with the energy symbol omitted.
+    let energy_gain = gained_counter_words.is_empty()
+        || word_slice_eq(gained_counter_words, &["{e}"])
+        || word_slice_eq(gained_counter_words, &["e"])
+        || word_slice_eq(gained_counter_words, &["{e}", "energy", "counters"])
+        || word_slice_eq(gained_counter_words, &["e", "energy", "counters"])
+        || word_slice_eq(gained_counter_words, &["energy", "counters"]);
+    energy_gain
+        && word_slice_eq_any(
+            &words[you_get_idx..],
+            &[
+                &["you", "get", "twice", "that", "many", "{e}", "instead"],
+                &["you", "get", "twice", "that", "many", "e", "instead"],
+                &["you", "get", "twice", "that", "many", "instead"],
+            ],
+        )
 }
 
 pub(crate) fn parse_double_token_creation_replacement_line(

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_cst_parsing.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_cst_parsing.rs
@@ -330,6 +330,11 @@ pub(super) fn parse_static_line_cst(
         chosen_option_label,
     };
     let lexed = &parse_tokens;
+    if super::super::families::keyword_static::parse_double_counters_replacement_line(lexed)?
+        .is_some()
+    {
+        return Ok(Some(make_static(None)));
+    }
     if matches!(
         normalized,
         "for each {B} in a cost, you may pay 2 life rather than pay that mana."

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_family_handlers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/line_family_handlers.rs
@@ -1551,6 +1551,9 @@ fn statement_probe_shape_prefers_statement(tokens: &[OwnedLexToken]) -> bool {
 pub(super) fn run_statement_probe_line_family(
     ctx: &LineDispatchContext<'_>,
 ) -> Result<Option<LineDispatchResult>, CardTextError> {
+    if parse_static_line_cst(ctx.line)?.is_some() {
+        return Ok(None);
+    }
     if (matches!(
         crate::runtime_backend::grammar::structure::classify_statement_line_family_lexed(
             &ctx.line.tokens

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
@@ -40,7 +40,6 @@ use crate::filter::{
 use crate::ids::CardId;
 #[allow(unused_imports)]
 use crate::mana::{ManaCost, ManaSymbol};
-#[allow(unused_imports)]
 use crate::static_abilities::{CopyTriggeredAbilities, StaticAbility};
 #[allow(unused_imports)]
 use crate::target::ChooseSpec;

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/parser_semantic_lowering.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/lower/parser_semantic_lowering.rs
@@ -691,6 +691,9 @@ fn linked_statement_should_stay_grouped(tokens: &[OwnedLexToken]) -> bool {
 }
 
 fn statement_group_should_parse_as_effects_first(tokens: &[OwnedLexToken]) -> bool {
+    if matches!(parse_static_ability_ast_line_lexed(tokens), Ok(Some(_))) {
+        return false;
+    }
     if linked_statement_should_stay_grouped(tokens) {
         return true;
     }
@@ -1663,6 +1666,16 @@ fn lower_rewrite_static_to_chunk_impl(
     {
         return wrap_chosen_option_static_chunk(
             LineAst::StaticAbilities(abilities),
+            chosen_option_label,
+        );
+    }
+    if let Some(ability) =
+        crate::runtime_backend::families::keyword_static::parse_double_counters_replacement_line(
+            &lexed,
+        )?
+    {
+        return wrap_chosen_option_static_chunk(
+            LineAst::StaticAbility(ability.into()),
             chosen_option_label,
         );
     }

--- a/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
@@ -1469,6 +1469,8 @@ fn effect_can_supply_prior_effect_memory(effect: &EffectAst) -> bool {
                 | SubjectVerbActionAst::RevealCardsFromHand { .. }
                 | SubjectVerbActionAst::LookAtTopCards { .. }
                 | SubjectVerbActionAst::Draw { .. }
+                | SubjectVerbActionAst::PayAnyEnergy { .. }
+                | SubjectVerbActionAst::PayAnyLife { .. }
         ),
         EffectAst::ForEachOpponent { effects }
         | EffectAst::ForEachPlayersFiltered { effects, .. }

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -8558,6 +8558,48 @@ fn rewrite_grammar_living_conundrum_empty_library_draw_skip_matches_static_shape
 }
 
 #[test]
+fn aether_refinery_energy_doubling_static_line_parses_as_replacement() {
+    let tokens = lex_line(
+        "if you would get one or more {e} (energy counters), you get twice that many {e} instead.",
+        0,
+    )
+    .expect("Aether Refinery energy replacement line should lex");
+
+    let parsed = super::keyword_static::parse_static_ability_ast_line_lexed(&tokens)
+        .expect("Aether Refinery energy replacement static parser should not error");
+    let direct = super::keyword_static::parse_double_counters_replacement_line(&tokens)
+        .expect("Aether Refinery direct energy replacement parser should not error");
+    assert!(
+        matches!(
+            parsed.as_deref(),
+            Some([crate::cards::builders::StaticAbilityAst::Static(ability)])
+                if ability.id() == crate::static_abilities::StaticAbilityId::DoubleCountersReplacement
+        ),
+        "expected player energy double-counters replacement, words={:?}, direct={direct:?}, got {parsed:?}",
+        super::token_word_refs(&tokens)
+    );
+}
+
+#[test]
+fn aether_refinery_oracle_dispatches_energy_doubling_line_as_static() {
+    let builder = CardDefinitionBuilder::new(CardId::new(), "Aether Refinery")
+        .card_types(vec![CardType::Artifact]);
+    let preprocessed = super::preprocess::preprocess_document(
+        builder,
+        "If you would get one or more {E} (energy counters), you get twice that many {E} instead.\n\
+         {T}: You get {E}, then you may pay one or more {E}. If you do, create an X/X black Aetherborn creature token, where X is the amount of {E} paid this way.",
+    )
+    .expect("Aether Refinery oracle should preprocess");
+    let cst = super::document_parser::parse_document_cst(&preprocessed, false)
+        .expect("Aether Refinery oracle should dispatch");
+
+    assert!(
+        matches!(cst.lines.first(), Some(super::cst::RewriteLineCst::Static(_))),
+        "expected Aether Refinery energy replacement to dispatch as static, got {cst:?}"
+    );
+}
+
+#[test]
 fn parse_sages_of_the_anima_draw_replacement_static_line() {
     let tokens = lex_line(
         "If you would draw a card, instead reveal the top three cards of your library. Put all creature cards revealed this way into your hand and the rest on the bottom of your library in any order.",

--- a/crates/ironsmith-core/src/static_ability_model.rs
+++ b/crates/ironsmith-core/src/static_ability_model.rs
@@ -471,6 +471,7 @@ pub enum StaticAbilityPayload<T, E, C, Cond> {
     },
     DoubleCountersReplacement {
         filter: ObjectFilter,
+        player_filter: Option<PlayerFilter>,
         counter_type: Option<CounterType>,
         display: String,
     },
@@ -1418,10 +1419,12 @@ where
             },
             StaticAbilityPayload::DoubleCountersReplacement {
                 filter,
+                player_filter,
                 counter_type,
                 display,
             } => StaticAbilityPayload::DoubleCountersReplacement {
                 filter,
+                player_filter,
                 counter_type,
                 display,
             },
@@ -3959,6 +3962,25 @@ impl<
             label: display.clone(),
             payload: StaticAbilityPayload::DoubleCountersReplacement {
                 filter,
+                player_filter: None,
+                counter_type,
+                display,
+            },
+        }
+    }
+
+    pub fn double_player_counters_replacement(
+        player_filter: PlayerFilter,
+        counter_type: Option<CounterType>,
+        display: impl Into<String>,
+    ) -> Self {
+        let display = display.into();
+        Self {
+            id: Some(StaticAbilityId::DoubleCountersReplacement),
+            label: display.clone(),
+            payload: StaticAbilityPayload::DoubleCountersReplacement {
+                filter: ObjectFilter::default(),
+                player_filter: Some(player_filter),
                 counter_type,
                 display,
             },

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -383,6 +383,31 @@ fn rampaging_aetherhood_strict_parser_and_compiled_text_regression() {
 }
 
 #[test]
+fn aether_refinery_strict_parser_compiled_text_and_model_regression() {
+    assert_oracle_card_parses_strict("Aether Refinery");
+
+    let def = parse_oracle_card_definition("Aether Refinery");
+    let ability_debug = format!("{:#?}", def.abilities);
+    let rendered = compiled_text_lines(&def).join("\n");
+
+    assert!(
+        ability_debug.contains("DoubleCountersReplacement")
+            && ability_debug.contains("Energy")
+            && ability_debug.contains("PayAnyEnergyEffect")
+            && ability_debug.contains("min_amount: 1")
+            && ability_debug.contains("CreateTokenEffect"),
+        "expected player energy replacement and paid-energy token activation, got {ability_debug}"
+    );
+    assert!(
+        rendered.contains("If you would get one or more {E}, you get twice that many {E} instead.")
+            && rendered.contains(
+                "{T}: You get {E}, then you may pay one or more {E}. If you do, create an X/X black Aetherborn creature token, where X is the amount of {E} paid this way."
+            ),
+        "expected Aether Refinery compiled text to preserve energy replacement and activation surface, got {rendered}"
+    );
+}
+
+#[test]
 fn wondrous_crucible_strict_parser_compiled_text_and_model_regression() {
     assert_oracle_card_parses_strict("Wondrous Crucible");
 

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -6630,6 +6630,70 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
         return compact;
     }
 
+    fn describe_energy_then_pay_any_then_create_paid_x_token(
+        effects: &[&Effect],
+    ) -> Option<String> {
+        let [energy_effect, may_effect, conditional_effect] = effects else {
+            return None;
+        };
+        let energy = unwrap_wrapped_effect(energy_effect)
+            .downcast_ref::<crate::effects::EnergyCountersEffect>()?;
+        if energy.player != PlayerFilter::You {
+            return None;
+        }
+        let may_with_id = may_effect.downcast_ref::<crate::effects::WithIdEffect>()?;
+        let may = may_with_id
+            .effect
+            .downcast_ref::<crate::effects::MayEffect>()?;
+        if !matches!(may.decider, None | Some(PlayerFilter::You)) || may.effects.len() != 1 {
+            return None;
+        }
+        let pay_any = unwrap_wrapped_effect(&may.effects[0])
+            .downcast_ref::<crate::effects::PayAnyEnergyEffect>()?;
+        if !matches!(pay_any.player, ChooseSpec::Player(PlayerFilter::You)) {
+            return None;
+        }
+        let if_effect = conditional_effect.downcast_ref::<crate::effects::IfEffect>()?;
+        if if_effect.condition != may_with_id.id
+            || if_effect.predicate != crate::effect::EffectPredicate::Happened
+            || !if_effect.else_.is_empty()
+            || if_effect.then.len() != 2
+        {
+            return None;
+        }
+        let create = unwrap_tag_wrappers(&if_effect.then[0])
+            .downcast_ref::<crate::effects::CreateTokenEffect>()?;
+        if create.count != Value::Fixed(1) || !create.token.card.is_token {
+            return None;
+        }
+        let set_pt = if_effect.then[1]
+            .downcast_ref::<crate::effects::SetBasePowerToughnessEffect>()?;
+        if !is_effect_count_reference(&set_pt.power, Some(may_with_id.id))
+            || !is_effect_count_reference(&set_pt.toughness, Some(may_with_id.id))
+        {
+            return None;
+        }
+
+        let payment = describe_pay_any_energy_amount(pay_any)?;
+        let if_text = describe_effect(conditional_effect)
+            .replace(
+                &format!("If effect #{} happened", may_with_id.id.0),
+                "If you do",
+            )
+            .replace(
+                "where X is X",
+                "where X is the amount of {E} paid this way",
+            );
+        Some(format!(
+            "{}, then you may pay {payment}. {if_text}",
+            describe_effect(energy_effect)
+        ))
+    }
+
+    if let Some(compact) = describe_energy_then_pay_any_then_create_paid_x_token(&raw_effects) {
+        return compact;
+    }
+
     fn describe_energy_then_pay_any_then_put_paid_counters(effects: &[&Effect]) -> Option<String> {
         let [energy_effect, may_effect, if_effect] = effects else {
             return None;

--- a/crates/ironsmith-runtime/src/events/counters/matchers.rs
+++ b/crates/ironsmith-runtime/src/events/counters/matchers.rs
@@ -69,10 +69,12 @@ impl ReplacementMatcher for WouldPutCountersMatcher {
         }
 
         // Check if target matches the filter
-        if let Some(obj) = ctx.game.object(put_counters.target) {
-            self.filter.matches(obj, &ctx.filter_ctx, ctx.game)
-        } else {
-            false
+        match put_counters.target {
+            crate::game_state::Target::Object(object) => ctx
+                .game
+                .object(object)
+                .is_some_and(|obj| self.filter.matches(obj, &ctx.filter_ctx, ctx.game)),
+            crate::game_state::Target::Player(_) => false,
         }
     }
 
@@ -166,7 +168,7 @@ mod tests {
         // The matcher needs an actual object in the game to match against
         // This test verifies the basic structure
         let event = PutCountersEvent::with_cause(
-            ObjectId::from_raw(1),
+            crate::game_state::Target::Object(ObjectId::from_raw(1)),
             CounterType::PlusOnePlusOne,
             3,
             crate::events::cause::EventCause::effect(),
@@ -186,7 +188,7 @@ mod tests {
 
         // Test with wrong counter type
         let event = PutCountersEvent::with_cause(
-            ObjectId::from_raw(1),
+            crate::game_state::Target::Object(ObjectId::from_raw(1)),
             CounterType::Loyalty,
             3,
             crate::events::cause::EventCause::effect(),
@@ -224,7 +226,7 @@ mod tests {
         });
 
         let event = PutCountersEvent::with_cause(
-            ObjectId::from_raw(1),
+            crate::game_state::Target::Object(ObjectId::from_raw(1)),
             CounterType::PlusOnePlusOne,
             1,
             crate::events::cause::EventCause::from_combat_damage(ObjectId::from_raw(2), alice),

--- a/crates/ironsmith-runtime/src/events/counters/put_counters.rs
+++ b/crates/ironsmith-runtime/src/events/counters/put_counters.rs
@@ -11,8 +11,8 @@ use crate::object::CounterType;
 /// A put counters event that can be processed through the replacement effect system.
 #[derive(Debug, Clone)]
 pub struct PutCountersEvent {
-    /// The permanent receiving counters
-    pub target: ObjectId,
+    /// The object or player receiving counters.
+    pub target: Target,
     /// The type of counter
     pub counter_type: CounterType,
     /// Number of counters to add
@@ -24,7 +24,7 @@ pub struct PutCountersEvent {
 impl PutCountersEvent {
     /// Create a new put counters event with an explicit cause.
     pub fn with_cause(
-        target: ObjectId,
+        target: Target,
         counter_type: CounterType,
         count: u32,
         cause: EventCause,
@@ -62,7 +62,7 @@ impl PutCountersEvent {
     }
 
     /// Return a new event with a different target.
-    pub fn with_target(&self, target: ObjectId) -> Self {
+    pub fn with_target(&self, target: Target) -> Self {
         Self {
             target,
             ..self.clone()
@@ -76,28 +76,36 @@ impl GameEventType for PutCountersEvent {
     }
 
     fn affected_player(&self, game: &GameState) -> PlayerId {
-        game.object(self.target)
-            .map(|o| game.controller_of(o))
-            .unwrap_or(game.turn.active_player)
+        match self.target {
+            Target::Object(object) => game
+                .object(object)
+                .map(|o| game.controller_of(o))
+                .unwrap_or(game.turn.active_player),
+            Target::Player(player) => player,
+        }
     }
 
     fn redirectable_targets(&self) -> Vec<RedirectableTarget> {
         vec![RedirectableTarget {
-            target: Target::Object(self.target),
+            target: self.target,
             description: "counter recipient",
-            valid_redirect_types: RedirectValidTypes::ObjectsOnly,
+            valid_redirect_types: match self.target {
+                Target::Object(_) => RedirectValidTypes::ObjectsOnly,
+                Target::Player(_) => RedirectValidTypes::PlayersOnly,
+            },
         }]
     }
 
     fn with_target_replaced(&self, old: &Target, new: &Target) -> Option<Box<dyn GameEventType>> {
-        if &Target::Object(self.target) != old {
+        if &self.target != old {
             return None;
         }
 
-        if let Target::Object(new_obj) = new {
-            Some(Box::new(self.with_target(*new_obj)))
-        } else {
-            None
+        match (self.target, *new) {
+            (Target::Object(_), Target::Object(_)) | (Target::Player(_), Target::Player(_)) => {
+                Some(Box::new(self.with_target(*new)))
+            }
+            _ => None,
         }
     }
 
@@ -124,7 +132,7 @@ mod tests {
 
     fn effect_counters(count: u32) -> PutCountersEvent {
         PutCountersEvent::with_cause(
-            ObjectId::from_raw(1),
+            Target::Object(ObjectId::from_raw(1)),
             CounterType::PlusOnePlusOne,
             count,
             EventCause::effect(),
@@ -176,11 +184,11 @@ mod tests {
             .as_any()
             .downcast_ref::<PutCountersEvent>()
             .unwrap();
-        assert_eq!(replaced_counters.target, ObjectId::from_raw(2));
+        assert_eq!(replaced_counters.target, Target::Object(ObjectId::from_raw(2)));
     }
 
     #[test]
-    fn test_put_counters_redirect_to_player_fails() {
+    fn test_put_counters_redirect_to_player() {
         let event = effect_counters(3);
 
         let old_target = Target::Object(ObjectId::from_raw(1));
@@ -188,6 +196,22 @@ mod tests {
 
         let replaced = event.with_target_replaced(&old_target, &new_target);
         assert!(replaced.is_none());
+    }
+
+    #[test]
+    fn test_put_player_counters_redirect_to_player() {
+        let event = PutCountersEvent::with_cause(
+            Target::Player(PlayerId::from_index(0)),
+            CounterType::Energy,
+            3,
+            EventCause::effect(),
+        );
+
+        let old_target = Target::Player(PlayerId::from_index(0));
+        let new_target = Target::Player(PlayerId::from_index(1));
+
+        let replaced = event.with_target_replaced(&old_target, &new_target);
+        assert!(replaced.is_some());
     }
 
     #[test]

--- a/crates/ironsmith-runtime/src/events/mod.rs
+++ b/crates/ironsmith-runtime/src/events/mod.rs
@@ -131,6 +131,7 @@ pub use tokens::matchers::*;
 pub use zones::matchers::*;
 
 use crate::ids::{ObjectId, PlayerId};
+use crate::game_state::Target;
 use crate::object::CounterType;
 use crate::provenance::ProvNodeId;
 pub use crate::snapshot::ObjectSnapshot;
@@ -360,7 +361,20 @@ impl Event {
         cause: EventCause,
     ) -> Self {
         Self::new_with_provenance(
-            PutCountersEvent::with_cause(target, counter_type, count, cause),
+            PutCountersEvent::with_cause(Target::Object(target), counter_type, count, cause),
+            ProvNodeId::default(),
+        )
+    }
+
+    /// Create a player counter event.
+    pub fn put_player_counters(
+        target: PlayerId,
+        counter_type: CounterType,
+        count: u32,
+        cause: EventCause,
+    ) -> Self {
+        Self::new_with_provenance(
+            PutCountersEvent::with_cause(Target::Player(target), counter_type, count, cause),
             ProvNodeId::default(),
         )
     }

--- a/crates/ironsmith-runtime/src/events/processing/mod.rs
+++ b/crates/ironsmith-runtime/src/events/processing/mod.rs
@@ -2729,6 +2729,34 @@ pub fn process_put_counters_with_event(
     }
 }
 
+/// Process a player counter event through replacement effects.
+///
+/// Returns the final number of counters to give that player.
+pub fn process_player_counters_with_event(
+    game: &mut GameState,
+    target: PlayerId,
+    counter_type: CounterType,
+    count: u32,
+    cause: crate::events::cause::EventCause,
+) -> u32 {
+    use crate::events::{PutCountersEvent, downcast_event};
+
+    let event = Event::put_player_counters(target, counter_type, count, cause);
+    let result = process_trait_event(game, event);
+
+    match result {
+        TraitEventResult::Prevented => 0,
+        TraitEventResult::Proceed(e) | TraitEventResult::Modified(e) => {
+            if let Some(put_counters) = downcast_event::<PutCountersEvent>(e.inner()) {
+                put_counters.count
+            } else {
+                count
+            }
+        }
+        _ => count,
+    }
+}
+
 /// Process a token creation event through replacement effects.
 ///
 /// Returns the final number of tokens to create.

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -1631,6 +1631,109 @@ fn put_rampaging_aetherhood_upkeep_trigger_on_stack(
 }
 
 #[cfg(ironsmith_runtime_parser_tests)]
+fn aether_refinery_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(74_201), "Aether Refinery")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(4)],
+            vec![ManaSymbol::Red],
+            vec![ManaSymbol::Red],
+        ]))
+        .card_types(vec![CardType::Artifact])
+        .parse_text(
+            "If you would get one or more {E} (energy counters), you get twice that many {E} instead.\n\
+             {T}: You get {E}, then you may pay one or more {E}. If you do, create an X/X black Aetherborn creature token, where X is the amount of {E} paid this way.",
+        )
+        .expect("Aether Refinery should parse for runtime tests")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+struct AetherRefineryDecisionMaker {
+    accept_payment: bool,
+    energy_to_pay: u32,
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+impl DecisionMaker for AetherRefineryDecisionMaker {
+    fn decide_boolean(
+        &mut self,
+        _game: &GameState,
+        _ctx: &crate::decisions::context::BooleanContext,
+    ) -> bool {
+        self.accept_payment
+    }
+
+    fn decide_number(
+        &mut self,
+        _game: &GameState,
+        ctx: &crate::decisions::context::NumberContext,
+    ) -> u32 {
+        self.energy_to_pay.clamp(ctx.min, ctx.max)
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn aether_refinery_activation_index(def: &crate::cards::CardDefinition) -> usize {
+    def.abilities
+        .iter()
+        .position(|ability| matches!(ability.kind, AbilityKind::Activated(_)))
+        .expect("Aether Refinery should have its energy payment activation")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn activate_aether_refinery(
+    game: &mut GameState,
+    refinery_id: ObjectId,
+    ability_index: usize,
+    dm: &mut impl DecisionMaker,
+) {
+    let alice = PlayerId::from_index(0);
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+
+    let activate_action = crate::decision::compute_legal_actions(game, alice)
+        .into_iter()
+        .find(|action| {
+            matches!(
+                action,
+                crate::decision::LegalAction::ActivateAbility { source, ability_index: idx }
+                    if *source == refinery_id && *idx == ability_index
+            )
+        })
+        .expect("Aether Refinery activation should be legal while untapped");
+    let mut trigger_queue = TriggerQueue::new();
+    let mut state = PriorityLoopState::new(game.players_in_game());
+    apply_priority_response_with_dm(
+        game,
+        &mut trigger_queue,
+        &mut state,
+        &PriorityResponse::PriorityAction(activate_action),
+        dm,
+    )
+    .expect("Aether Refinery activation should go on the stack");
+    resolve_stack_entry_with(game, dm).expect("Aether Refinery activation should resolve");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn aetherborn_tokens_controlled_by(game: &GameState, player: PlayerId) -> Vec<ObjectId> {
+    game.battlefield
+        .iter()
+        .copied()
+        .filter(|&id| {
+            game.object(id).is_some_and(|object| {
+                game.controller_of(object) == player
+                    && object.kind == ObjectKind::Token
+                    && object.name == "Aetherborn"
+                    && object.card_types.contains(&CardType::Creature)
+                    && object.subtypes.contains(&Subtype::Aetherborn)
+                    && game.current_colors(id) == Some(crate::color::ColorSet::BLACK)
+            })
+        })
+        .collect()
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
 fn lost_monarch_of_ifnir_definition() -> crate::cards::CardDefinition {
     CardDefinitionBuilder::new(CardId::from_raw(692_108), "Lost Monarch of Ifnir")
         .mana_cost(ManaCost::from_pips(vec![
@@ -2001,6 +2104,87 @@ fn lost_monarch_of_ifnir_second_main_return_is_optional() {
         game.object(creature_id).expect("creature card exists").zone,
         Zone::Graveyard,
         "declining the may choice should leave the creature card in the graveyard"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn aether_refinery_replacement_doubles_player_energy_gained() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let refinery = aether_refinery_definition();
+    let refinery_id = game.create_object_from_definition(&refinery, alice, Zone::Battlefield);
+    game.refresh_continuous_state();
+
+    game.add_player_counters_with_source(
+        alice,
+        crate::object::CounterType::Energy,
+        3,
+        Some(refinery_id),
+        Some(alice),
+    )
+    .expect("adding energy should emit a marker event");
+
+    assert_eq!(
+        game.player(alice).expect("alice exists").energy_counters,
+        6,
+        "Aether Refinery should double energy counters its controller would get"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn aether_refinery_activation_pays_energy_and_creates_paid_size_construct() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let refinery = aether_refinery_definition();
+    let refinery_id = game.create_object_from_definition(&refinery, alice, Zone::Battlefield);
+    let ability_index = aether_refinery_activation_index(&refinery);
+    game.refresh_continuous_state();
+
+    let mut dm = AetherRefineryDecisionMaker {
+        accept_payment: true,
+        energy_to_pay: 2,
+    };
+    activate_aether_refinery(&mut game, refinery_id, ability_index, &mut dm);
+
+    assert_eq!(
+        game.player(alice).expect("alice exists").energy_counters,
+        0,
+        "the activation should get two energy after replacement, then spend the chosen two"
+    );
+    assert!(game.is_tapped(refinery_id), "activation cost should tap Aether Refinery");
+    let tokens = aetherborn_tokens_controlled_by(&game, alice);
+    assert_eq!(tokens.len(), 1, "paying energy should create one Aetherborn token");
+    let token_id = tokens[0];
+    assert_eq!(game.current_power(token_id), Some(2));
+    assert_eq!(game.current_toughness(token_id), Some(2));
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn aether_refinery_declining_payment_keeps_energy_and_creates_no_token() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let refinery = aether_refinery_definition();
+    let refinery_id = game.create_object_from_definition(&refinery, alice, Zone::Battlefield);
+    let ability_index = aether_refinery_activation_index(&refinery);
+    game.refresh_continuous_state();
+
+    let mut dm = AetherRefineryDecisionMaker {
+        accept_payment: false,
+        energy_to_pay: 2,
+    };
+    activate_aether_refinery(&mut game, refinery_id, ability_index, &mut dm);
+
+    assert_eq!(
+        game.player(alice).expect("alice exists").energy_counters,
+        2,
+        "declining payment should keep the doubled energy from the activation"
+    );
+    assert!(
+        aetherborn_tokens_controlled_by(&game, alice).is_empty(),
+        "declining the optional energy payment should skip the if-you-do token branch"
     );
 }
 

--- a/crates/ironsmith-runtime/src/game_state.rs
+++ b/crates/ironsmith-runtime/src/game_state.rs
@@ -5551,6 +5551,23 @@ impl GameState {
             return None;
         }
 
+        let cause = match (source, source_controller) {
+            (Some(source), Some(controller)) => {
+                crate::events::cause::EventCause::from_effect(source, controller)
+            }
+            _ => crate::events::cause::EventCause::effect(),
+        };
+        let amount = crate::events::processing::process_player_counters_with_event(
+            self,
+            player_id,
+            counter_type,
+            amount,
+            cause,
+        );
+        if amount == 0 {
+            return None;
+        }
+
         let player = self.player_mut(player_id)?;
         match counter_type {
             crate::object::CounterType::Poison => {

--- a/crates/ironsmith-runtime/src/static_abilities/misc.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/misc.rs
@@ -3696,6 +3696,7 @@ impl StaticAbilityKind for DoubleDamageAmountReplacement {
 #[derive(Debug, Clone, PartialEq)]
 pub struct DoubleCountersReplacement {
     pub filter: ObjectFilter,
+    pub player_filter: Option<PlayerFilter>,
     pub counter_type: Option<CounterType>,
     pub display: String,
 }
@@ -3704,6 +3705,20 @@ impl DoubleCountersReplacement {
     pub fn new(filter: ObjectFilter, counter_type: Option<CounterType>, display: String) -> Self {
         Self {
             filter,
+            player_filter: None,
+            counter_type,
+            display,
+        }
+    }
+
+    pub fn new_for_player(
+        player_filter: PlayerFilter,
+        counter_type: Option<CounterType>,
+        display: String,
+    ) -> Self {
+        Self {
+            filter: ObjectFilter::default(),
+            player_filter: Some(player_filter),
             counter_type,
             display,
         }
@@ -3713,7 +3728,9 @@ impl DoubleCountersReplacement {
 #[derive(Debug, Clone)]
 struct WouldPutCountersOrEnterWithCountersMatcher {
     ability_source: ObjectId,
+    controller: PlayerId,
     filter: ObjectFilter,
+    player_filter: Option<PlayerFilter>,
     counter_type: Option<CounterType>,
 }
 
@@ -3735,9 +3752,19 @@ impl ReplacementMatcher for WouldPutCountersOrEnterWithCountersMatcher {
                 {
                     return false;
                 }
-                ctx.game
-                    .object(put_counters.target)
-                    .is_some_and(|obj| self.filter.matches(obj, &ctx.filter_ctx, ctx.game))
+                match put_counters.target {
+                    crate::game_state::Target::Object(object) => self.player_filter.is_none()
+                        && ctx.game.object(object).is_some_and(|obj| {
+                            self.filter.matches(obj, &ctx.filter_ctx, ctx.game)
+                        }),
+                    crate::game_state::Target::Player(player) => self
+                        .player_filter
+                        .as_ref()
+                        .is_some_and(|filter| {
+                            player_ids_for_filter(ctx.game, filter.clone(), self.controller)
+                                .contains(&player)
+                        }),
+                }
             }
             EventKind::EnterBattlefield => {
                 let Some(etb) = downcast_event::<EnterBattlefieldEvent>(event) else {
@@ -3792,7 +3819,9 @@ impl StaticAbilityKind for DoubleCountersReplacement {
             controller,
             WouldPutCountersOrEnterWithCountersMatcher {
                 ability_source: source,
+                controller,
                 filter: self.filter.clone(),
+                player_filter: self.player_filter.clone(),
                 counter_type: self.counter_type,
             },
             ReplacementAction::DoubleCounters {

--- a/crates/ironsmith-runtime/src/static_abilities/mod.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/mod.rs
@@ -3003,6 +3003,18 @@ impl StaticAbility {
         ))
     }
 
+    pub fn double_player_counters_replacement(
+        player_filter: crate::target::PlayerFilter,
+        counter_type: Option<crate::object::CounterType>,
+        display: String,
+    ) -> Self {
+        Self::new(DoubleCountersReplacement::new_for_player(
+            player_filter,
+            counter_type,
+            display,
+        ))
+    }
+
     pub fn double_token_creation_replacement(
         controller: crate::target::PlayerFilter,
         display: String,

--- a/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
@@ -1385,13 +1385,21 @@ impl StaticAbilityModelInterpreter {
             ),
             ironsmith_core::StaticAbilityPayload::DoubleCountersReplacement {
                 filter,
+                player_filter,
                 counter_type,
                 display,
-            } => StaticAbility::double_counters_replacement(
-                filter.clone(),
-                *counter_type,
-                display.clone(),
-            ),
+            } => match player_filter {
+                Some(player_filter) => StaticAbility::double_player_counters_replacement(
+                    player_filter.clone(),
+                    *counter_type,
+                    display.clone(),
+                ),
+                None => StaticAbility::double_counters_replacement(
+                    filter.clone(),
+                    *counter_type,
+                    display.clone(),
+                ),
+            },
             ironsmith_core::StaticAbilityPayload::DoubleTokenCreationReplacement {
                 controller,
                 display,


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Aether Refinery
Initial parse error:
```
unsupported predicate (predicate: 'you would get one or more e'); oracle-only fallback also failed: unsupported predicate (predicate: 'you would get one or more e')
```

Current worker: i-0ad7a9bf21e2f666e
Branch: codex/aws-card-fix-aether-refinery
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260604T121212Z-controller-dev-loop-wave0024
