### PR TITLE
Fix Ironsmith parse failure: Summoner's Grimoire

### DIFF
--- a/crates/ironsmith-compiler/src/cards/builders.rs
+++ b/crates/ironsmith-compiler/src/cards/builders.rs
@@ -435,6 +435,7 @@ impl CardDefinitionBuilder {
             KeywordAction::Devoid => self.devoid(),
             KeywordAction::Annihilator(amount) => self.annihilator(amount),
             KeywordAction::ForMirrodin => self.for_mirrodin(),
+            KeywordAction::JobSelect => self.job_select(),
             KeywordAction::LivingWeapon => self.living_weapon(),
             KeywordAction::Marker(name) if name.eq_ignore_ascii_case("fuse") => self.has_fuse(),
             KeywordAction::Marker(name)
@@ -1928,6 +1929,18 @@ impl CardDefinitionBuilder {
         ))
     }
 
+    pub fn job_select(self) -> Self {
+        let created_tag = crate::tag::TagKey::from("job_select_created");
+        self.with_ability(crate::ability::Ability::triggered(
+            crate::triggers::Trigger::this_enters_battlefield(),
+            vec![
+                crate::effect::Effect::create_tokens(Self::job_select_hero_token(), 1)
+                    .tag(created_tag.clone()),
+                crate::effect::Effect::attach_to(crate::target::ChooseSpec::Tagged(created_tag)),
+            ],
+        ))
+    }
+
     pub fn living_weapon(self) -> Self {
         let created_tag = crate::tag::TagKey::from("living_weapon_created");
         self.with_ability(crate::ability::Ability::triggered(
@@ -2398,6 +2411,15 @@ impl CardDefinitionBuilder {
             .subtypes(vec![Subtype::Rebel])
             .color_indicator(ColorSet::RED)
             .power_toughness(PowerToughness::fixed(2, 2))
+            .build()
+    }
+
+    fn job_select_hero_token() -> CardDefinition {
+        CardDefinitionBuilder::new(CardId::new(), "Hero")
+            .token()
+            .card_types(vec![CardType::Creature])
+            .subtypes(vec![Subtype::Hero])
+            .power_toughness(PowerToughness::fixed(1, 1))
             .build()
     }
 

--- a/crates/ironsmith-compiler/src/payload.rs
+++ b/crates/ironsmith-compiler/src/payload.rs
@@ -150,6 +150,7 @@ pub enum KeywordAction {
     Devoid,
     Annihilator(u32),
     ForMirrodin,
+    JobSelect,
     LivingWeapon,
     Crew {
         amount: u32,
@@ -458,6 +459,7 @@ impl KeywordAction {
             Self::Devoid => "Devoid".to_string(),
             Self::Annihilator(amount) => format!("Annihilator {amount}"),
             Self::ForMirrodin => "For Mirrodin!".to_string(),
+            Self::JobSelect => "Job select".to_string(),
             Self::LivingWeapon => "Living weapon".to_string(),
             Self::Crew { amount, .. } => format!("Crew {amount}"),
             Self::Saddle { amount, .. } => format!("Saddle {amount}"),

--- a/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/keyword_action_costs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/activation_and_restrictions/keyword_action_costs.rs
@@ -1116,6 +1116,7 @@ enum ExactAbilityPhrase {
     FirstStrike,
     DoubleStrike,
     ForMirrodin,
+    JobSelect,
     LivingWeapon,
     ModularSunburst,
     ProtectionFromAllColors,
@@ -1132,6 +1133,7 @@ const EXACT_ABILITY_PHRASES: &[(&[&str], ExactAbilityPhrase)] = &[
     (&["first", "strike"], ExactAbilityPhrase::FirstStrike),
     (&["double", "strike"], ExactAbilityPhrase::DoubleStrike),
     (&["for", "mirrodin"], ExactAbilityPhrase::ForMirrodin),
+    (&["job", "select"], ExactAbilityPhrase::JobSelect),
     (&["living", "weapon"], ExactAbilityPhrase::LivingWeapon),
     (
         &["modular", "sunburst"],
@@ -1175,6 +1177,7 @@ fn exact_ability_phrase_action(kind: ExactAbilityPhrase) -> KeywordAction {
         ExactAbilityPhrase::FirstStrike => KeywordAction::FirstStrike,
         ExactAbilityPhrase::DoubleStrike => KeywordAction::DoubleStrike,
         ExactAbilityPhrase::ForMirrodin => KeywordAction::ForMirrodin,
+        ExactAbilityPhrase::JobSelect => KeywordAction::JobSelect,
         ExactAbilityPhrase::LivingWeapon => KeywordAction::LivingWeapon,
         ExactAbilityPhrase::ModularSunburst => KeywordAction::ModularSunburst,
         ExactAbilityPhrase::ProtectionFromAllColors => KeywordAction::ProtectionFromAllColors,
@@ -1556,7 +1559,7 @@ pub(crate) fn parse_ability_phrase(tokens: &[OwnedLexToken]) -> Option<KeywordAc
         return marker_text_from_words(&words).map(KeywordAction::MarkerText);
     }
     if JOB_SELECT_PREFIX_PATTERN.matches_words(&words) {
-        return Some(KeywordAction::MarkerText("Job select".to_string()));
+        return Some(KeywordAction::JobSelect);
     }
     if UMBRA_ARMOR_PREFIX_PATTERN.matches_words(&words) {
         return Some(KeywordAction::UmbraArmor);
@@ -1668,6 +1671,7 @@ pub(crate) fn parse_ability_phrase(tokens: &[OwnedLexToken]) -> Option<KeywordAc
         phrase_tokens,
         &[
             &["for", "mirrodin"],
+            &["job", "select"],
             &["living", "weapon"],
             &["battle", "cry"],
             &["split", "second"],
@@ -1677,6 +1681,7 @@ pub(crate) fn parse_ability_phrase(tokens: &[OwnedLexToken]) -> Option<KeywordAc
     ) {
         return Some(match matched_phrase {
             ["for", "mirrodin"] => KeywordAction::ForMirrodin,
+            ["job", "select"] => KeywordAction::JobSelect,
             ["living", "weapon"] => KeywordAction::LivingWeapon,
             ["battle", "cry"] => KeywordAction::BattleCry,
             ["split", "second"] => KeywordAction::SplitSecond,

--- a/crates/ironsmith-compiler/src/runtime_backend/families/clause_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/clause_support.rs
@@ -70,6 +70,7 @@ const TWO_WORD_KEYWORD_ACTIONS: &[(&[&str], KeywordAction)] = &[
     (&["split", "second"], KeywordAction::SplitSecond),
     (&["read", "ahead"], KeywordAction::ReadAhead),
     (&["for", "mirrodin"], KeywordAction::ForMirrodin),
+    (&["job", "select"], KeywordAction::JobSelect),
     (&["living", "weapon"], KeywordAction::LivingWeapon),
     (&["umbra", "armor"], KeywordAction::UmbraArmor),
     (

--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_registry.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_registry.rs
@@ -28,6 +28,7 @@ use super::lower::{
     lower_exert_attack_keyword_line, lower_gift_keyword_line, lower_keyword_special_cases,
 };
 use super::preprocess::PreprocessedLine;
+use super::semantic::ParsedAbility;
 use super::token_primitives::{
     find_index as find_token_index, split_em_dash_label_prefix_tokens, str_strip_suffix,
 };
@@ -177,6 +178,60 @@ fn require_keyword_parse<T>(
             line.info.raw_line
         ))
     })
+}
+
+fn keyword_display_label(line: &RewriteKeywordLine) -> Option<String> {
+    if let Some((label, _)) = line.info.raw_line.split_once('—') {
+        let label = label.trim();
+        if !label.is_empty() {
+            return Some(label.to_string());
+        }
+    }
+    if let Some((label, _)) = line.text.split_once('—') {
+        let label = label.trim();
+        if !label.is_empty() {
+            return Some(label.to_string());
+        }
+    }
+    let (label_tokens, _) = split_em_dash_label_prefix_tokens(&line.full_parse_tokens)?;
+    let label = render_token_slice(label_tokens).trim().to_string();
+    (!label.is_empty()).then_some(label)
+}
+
+fn preserve_keyword_display_label(
+    line: &RewriteKeywordLine,
+    mut parsed: ParsedAbility,
+) -> ParsedAbility {
+    let Some(label) = keyword_display_label(line) else {
+        return parsed;
+    };
+    let Some(text) = parsed.text.as_mut() else {
+        return parsed;
+    };
+    if !text.starts_with(label.as_str()) {
+        *text = format!("{label} — {text}");
+    }
+    parsed
+}
+
+fn preserve_activated_keyword_label(
+    line: &RewriteKeywordLine,
+    mut parsed: ParsedAbility,
+) -> ParsedAbility {
+    let Some(label) = keyword_display_label(line) else {
+        return parsed;
+    };
+    if let crate::ability::AbilityKind::Activated(activated) = parsed.kind_mut() {
+        let marker = format!("__ironsmith_activation_label:{label}");
+        if !activated
+            .additional_restrictions
+            .iter()
+            .any(|restriction| restriction == &marker)
+        {
+            activated.additional_restrictions.push(marker);
+        }
+    }
+    preserve_keyword_display_label(line, parsed)
 }
 
 fn optional_cost_tail_effect_tokens(tokens: &[OwnedLexToken]) -> Option<&[OwnedLexToken]> {
@@ -434,11 +489,10 @@ pub(super) fn lower_equip(
     line: &RewriteKeywordLine,
     tokens: &[OwnedLexToken],
 ) -> Result<LineAst, CardTextError> {
-    Ok(LineAst::Ability(require_keyword_parse(
+    Ok(LineAst::Ability(preserve_activated_keyword_label(
         line,
-        "equip",
-        parse_equip_line_lexed(tokens)?,
-    )?))
+        require_keyword_parse(line, "equip", parse_equip_line_lexed(tokens)?)?,
+    )))
 }
 
 pub(super) fn lower_reconfigure(

--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/attached_object_static_lines.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/attached_object_static_lines.rs
@@ -1097,6 +1097,7 @@ pub(crate) fn parse_attached_type_transform_line(
     }
 
     let mut with_idx = None;
+    let mut has_idx = None;
     let mut lose_idx = None;
     let mut in_quotes = false;
     for (idx, token) in remainder.iter().enumerate() {
@@ -1111,13 +1112,25 @@ pub(crate) fn parse_attached_type_transform_line(
             with_idx = Some(idx);
             continue;
         }
+        if has_idx.is_none()
+            && ATTACHED_HAS_WORD_PATTERN.matches_token(token)
+            && idx > 0
+            && ATTACHED_AND_WORD_PATTERN.matches_token(&remainder[idx - 1])
+        {
+            has_idx = Some(idx);
+            continue;
+        }
         if ATTACHED_LOSE_OR_LOSES_WORD_PATTERN.matches_token(token) {
             lose_idx = Some(idx);
             break;
         }
     }
 
-    let descriptor_end = with_idx.or(lose_idx).unwrap_or(remainder.len());
+    let descriptor_end = [with_idx, has_idx.map(|idx| idx - 1), lose_idx]
+        .into_iter()
+        .flatten()
+        .min()
+        .unwrap_or(remainder.len());
     let mut descriptor_tokens = trim_commas(&remainder[1..descriptor_end]).to_vec();
     while descriptor_tokens
         .first()
@@ -1125,7 +1138,17 @@ pub(crate) fn parse_attached_type_transform_line(
     {
         descriptor_tokens.remove(0);
     }
-    let descriptor_words = crate::runtime_backend::lexer::token_word_refs(&descriptor_tokens);
+    let mut descriptor_words = crate::runtime_backend::lexer::token_word_refs(&descriptor_tokens);
+    let descriptor_preserve_other_types = descriptor_words
+        .len()
+        .checked_sub(6)
+        .is_some_and(|tail_start| {
+            ATTACHED_PRESERVE_OTHER_TYPES_TAIL_PATTERN.matches_words(&descriptor_words[tail_start..])
+                && {
+                    descriptor_words.truncate(tail_start);
+                    true
+                }
+        });
     if descriptor_words.is_empty() {
         return Ok(None);
     }
@@ -1164,7 +1187,7 @@ pub(crate) fn parse_attached_type_transform_line(
     }
 
     let mut out = Vec::new();
-    let mut preserve_other_types = false;
+    let mut preserve_other_types = descriptor_preserve_other_types;
     let mut loss_consumed = false;
 
     if let Some(with_idx) = with_idx {
@@ -1256,6 +1279,70 @@ pub(crate) fn parse_attached_type_transform_line(
             out.push(StaticAbilityAst::AttachedObjectAbilityGrant {
                 ability: parsed,
                 display: format!("{subject_text} has {display}"),
+                condition: None,
+            });
+        } else {
+            return Err(CardTextError::ParseError(format!(
+                "unsupported attached transform granted ability (clause: '{}')",
+                line_words.join(" ")
+            )));
+        }
+    } else if let Some(has_idx) = has_idx {
+        let ability_end = lose_idx.unwrap_or(remainder.len());
+        let ability_tokens = trim_edge_punctuation(&remainder[has_idx + 1..ability_end]);
+        if ability_tokens.is_empty() {
+            return Err(CardTextError::ParseError(format!(
+                "missing attached transform granted ability (clause: '{}')",
+                line_words.join(" ")
+            )));
+        }
+
+        if let Some(parsed) = parse_attached_granted_activated_line(&ability_tokens)? {
+            out.push(StaticAbilityAst::AttachedObjectAbilityGrant {
+                ability: parsed,
+                display: format!(
+                    "{subject_text} has {}",
+                    display_text_for_tokens(&ability_tokens, true)
+                ),
+                condition: None,
+            });
+        } else if let Some((parsed, display)) =
+            parse_attached_nonstatic_keyword_ability(&ability_tokens)?
+        {
+            out.push(StaticAbilityAst::AttachedObjectAbilityGrant {
+                ability: parsed,
+                display: format!("{subject_text} has {display}"),
+                condition: None,
+            });
+        } else if token_slice_first_is_any(&ability_tokens, &["when", "whenever", "at"])
+            && let LineAst::Triggered {
+                trigger,
+                effects,
+                max_triggers_per_turn,
+            } = crate::runtime_backend::clause_support::parse_triggered_line_lexed(&ability_tokens)?
+        {
+            let text = crate::runtime_backend::lexer::token_word_refs(&ability_tokens).join(" ");
+            let parsed = parsed_triggered_ability(
+                trigger,
+                effects,
+                vec![Zone::Battlefield],
+                Some(text.clone()),
+                crate::runtime_backend::trigger_frequency_condition(
+                    Some(&text),
+                    max_triggers_per_turn,
+                ),
+                None,
+                ReferenceImports::default(),
+            );
+            if parsed_triggered_ability_is_empty(&parsed) {
+                return Err(CardTextError::ParseError(format!(
+                    "unsupported empty attached triggered grant clause (clause: '{}')",
+                    line_words.join(" ")
+                )));
+            }
+            out.push(StaticAbilityAst::AttachedObjectAbilityGrant {
+                ability: parsed,
+                display: format!("{subject_text} has {text}"),
                 condition: None,
             });
         } else {

--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/etb_static_lines.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/etb_static_lines.rs
@@ -3012,6 +3012,9 @@ fn parse_entry_filter_clause<'a>(tokens: &'a [OwnedLexToken]) -> Option<EtbEntry
 pub(crate) fn parse_enters_tapped_for_filter_line(
     tokens: &[OwnedLexToken],
 ) -> Result<Option<StaticAbility>, CardTextError> {
+    if tokens.iter().any(OwnedLexToken::is_quote) {
+        return Ok(None);
+    }
     let clause_words = crate::runtime_backend::token_word_refs(tokens);
     if clause_words
         .first()

--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -8236,6 +8236,9 @@ pub(crate) fn parse_subject_are_card_types_in_addition_to_their_other_types_line
     {
         return Ok(None);
     }
+    if addition_idx + 6 != tail.len() {
+        return Ok(None);
+    }
 
     let subject_tokens = &tokens[..be_idx];
     if subject_tokens.is_empty() {

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/document/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/document/mod.rs
@@ -3444,7 +3444,10 @@ fn try_parse_labeled_line_dispatch(
         }
     }
 
-    if is_named_label && let Some(keyword_line) = parse_keyword_line_cst(&body_line)? {
+    if (is_named_label || looks_like_ability_word_label(label_tokens, preserve_as_choice_label))
+        && let Some(mut keyword_line) = parse_keyword_line_cst(&body_line)?
+    {
+        keyword_line.text = format!("{} — {}", label.trim(), keyword_line.text);
         return Ok(Some(LineDispatchResult::single(
             RewriteLineCst::Keyword(keyword_line),
             idx + 1,

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
@@ -2670,6 +2670,7 @@ fn compile_subject_verb_effect(
             battlefield_controller,
             battlefield_tapped,
             battlefield_attacking,
+            battlefield_tapped_and_attacking_if,
             battlefield_face_down,
             attached_to,
             all,
@@ -2737,6 +2738,16 @@ fn compile_subject_verb_effect(
                 };
                 let move_effect = if *zone == Zone::Battlefield && *battlefield_attacking {
                     move_effect.attacking()
+                } else {
+                    move_effect
+                };
+                let move_effect = if *zone == Zone::Battlefield
+                    && let Some(filter) = battlefield_tapped_and_attacking_if
+                {
+                    move_effect.tapped_and_attacking_if(resolve_it_tag(
+                        filter,
+                        &current_reference_env(ctx),
+                    )?)
                 } else {
                     move_effect
                 };
@@ -2820,6 +2831,16 @@ fn compile_subject_verb_effect(
             };
             let move_effect = if *zone == Zone::Battlefield && *battlefield_attacking {
                 move_effect.attacking()
+            } else {
+                move_effect
+            };
+            let move_effect = if *zone == Zone::Battlefield
+                && let Some(filter) = battlefield_tapped_and_attacking_if
+            {
+                move_effect.tapped_and_attacking_if(resolve_it_tag(
+                    filter,
+                    &current_reference_env(ctx),
+                )?)
             } else {
                 move_effect
             };

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -1183,6 +1183,7 @@ pub(crate) enum SubjectVerbActionAst {
         battlefield_controller: ReturnControllerAst,
         battlefield_tapped: bool,
         battlefield_attacking: bool,
+        battlefield_tapped_and_attacking_if: Option<ObjectFilter>,
         battlefield_face_down: bool,
         attached_to: Option<TargetAst>,
         all: bool,
@@ -2516,6 +2517,7 @@ impl std::fmt::Debug for SubjectVerbActionAst {
                 battlefield_controller,
                 battlefield_tapped,
                 battlefield_attacking,
+                battlefield_tapped_and_attacking_if,
                 battlefield_face_down,
                 attached_to,
                 all,
@@ -2527,6 +2529,10 @@ impl std::fmt::Debug for SubjectVerbActionAst {
                 .field("battlefield_controller", battlefield_controller)
                 .field("battlefield_tapped", battlefield_tapped)
                 .field("battlefield_attacking", battlefield_attacking)
+                .field(
+                    "battlefield_tapped_and_attacking_if",
+                    battlefield_tapped_and_attacking_if,
+                )
                 .field("battlefield_face_down", battlefield_face_down)
                 .field("attached_to", attached_to)
                 .field("all", all)
@@ -4296,6 +4302,7 @@ impl EffectAst {
                 battlefield_controller,
                 battlefield_tapped,
                 battlefield_attacking,
+                battlefield_tapped_and_attacking_if: None,
                 battlefield_face_down,
                 attached_to,
                 all: false,
@@ -4321,6 +4328,7 @@ impl EffectAst {
                 battlefield_controller,
                 battlefield_tapped,
                 battlefield_attacking: false,
+                battlefield_tapped_and_attacking_if: None,
                 battlefield_face_down: false,
                 attached_to,
                 all: true,

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/chain_carry.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/chain_carry.rs
@@ -46,7 +46,8 @@ use super::{
     parse_sentence_put_onto_battlefield_with_counters_on_it_lexed,
     parse_sentence_return_with_counters_on_it_lexed, parse_simple_gain_ability_clause_lexed,
     parse_simple_lose_ability_clause_lexed, parse_token_copy_followup_sentence_lexed,
-    try_apply_token_copy_followup,
+    parse_conditional_entry_modifier_followup_sentence_lexed,
+    try_apply_conditional_entry_modifier_followup, try_apply_token_copy_followup,
 };
 
 const ENCHANTED_TAG_NAME: &str = "enchanted";
@@ -1252,6 +1253,12 @@ pub(crate) fn parse_effect_chain_inner_lexed(
                 }
                 effects.push(effect);
             }
+            previous_segment = Some(segment);
+            continue;
+        }
+        if let Some(filter) = parse_conditional_entry_modifier_followup_sentence_lexed(&segment)
+            && try_apply_conditional_entry_modifier_followup(&mut effects, filter)?
+        {
             previous_segment = Some(segment);
             continue;
         }

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_entry.rs
@@ -73,6 +73,7 @@ use crate::runtime_backend::effect_sentences::clause_pattern_helpers::{ClauseSha
 use crate::target::{
     ChooseSpec, ObjectFilter, PlayerFilter, TaggedObjectConstraint, TaggedOpbjectRelation,
 };
+use crate::types::CardType;
 use crate::zone::Zone;
 use ironsmith_core::ValueSurfaceHint;
 use std::cell::OnceCell;
@@ -1238,6 +1239,13 @@ fn parse_effect_sentences_from_sentence_inputs(
         if let Some(replacement) = future_zone_replacement_from_sentence_tokens(&sentence_tokens) {
             effects.push(replacement);
             carried_context = None;
+            sentence_idx += 1;
+            continue;
+        }
+
+        if let Some(filter) = parse_conditional_entry_modifier_followup_sentence_lexed(&sentence_tokens)
+            && try_apply_conditional_entry_modifier_followup(&mut effects, filter)?
+        {
             sentence_idx += 1;
             continue;
         }
@@ -3572,4 +3580,87 @@ pub(crate) fn try_apply_token_copy_followup(
             try_apply_token_copy_followup(nested_effects.as_mut_slice(), followup)
         }
     }
+}
+
+pub(crate) fn try_apply_conditional_entry_modifier_followup(
+    effects: &mut [EffectAst],
+    filter: ObjectFilter,
+) -> Result<bool, CardTextError> {
+    let Some(last) = effects.last_mut() else {
+        return Ok(false);
+    };
+
+    match last {
+        EffectAst::SubjectVerb(subject_verb) => match &mut subject_verb.action {
+            SubjectVerbActionAst::MoveToZone {
+                zone,
+                battlefield_tapped_and_attacking_if,
+                ..
+            } if *zone == Zone::Battlefield => {
+                *battlefield_tapped_and_attacking_if = Some(filter);
+                Ok(true)
+            }
+            _ => Ok(false),
+        },
+        EffectAst::Conditional {
+            if_true, if_false, ..
+        }
+        | EffectAst::SelfReplacement {
+            if_true, if_false, ..
+        } => {
+            if try_apply_conditional_entry_modifier_followup(if_true.as_mut_slice(), filter.clone())?
+            {
+                return Ok(true);
+            }
+            if try_apply_conditional_entry_modifier_followup(if_false.as_mut_slice(), filter)? {
+                return Ok(true);
+            }
+            Ok(false)
+        }
+        _ => {
+            let Some(nested_effects) = token_copy_followup_container_effects_mut(last) else {
+                return Ok(false);
+            };
+            if nested_effects.is_empty() {
+                return Ok(false);
+            }
+            try_apply_conditional_entry_modifier_followup(nested_effects.as_mut_slice(), filter)
+        }
+    }
+}
+
+pub(crate) fn parse_conditional_entry_modifier_followup_sentence_lexed(
+    tokens: &[OwnedLexToken],
+) -> Option<ObjectFilter> {
+    let words = crate::runtime_backend::util::non_article_token_word_refs(tokens);
+    if matches!(
+        words.as_slice(),
+        [
+            "if",
+            "that",
+            "card",
+            "is",
+            "enchantment",
+            "card",
+            "it",
+            "enters",
+            "tapped",
+            "and",
+            "attacking"
+        ] | [
+            "if",
+            "it",
+            "is",
+            "enchantment",
+            "card",
+            "it",
+            "enters",
+            "tapped",
+            "and",
+            "attacking"
+        ]
+    ) {
+        return Some(ObjectFilter::default().with_type(CardType::Enchantment));
+    }
+    None
 }

--- a/crates/ironsmith-core/src/effect.rs
+++ b/crates/ironsmith-core/src/effect.rs
@@ -1496,6 +1496,7 @@ pub struct MoveToZoneEffect {
     pub battlefield_controller: BattlefieldController,
     pub enters_tapped: bool,
     pub enters_attacking: bool,
+    pub enters_tapped_and_attacking_if: Option<ObjectFilter>,
     pub enters_face_down: bool,
     pub transfer_exiled_with_source_links: bool,
 }
@@ -1509,6 +1510,7 @@ impl MoveToZoneEffect {
             battlefield_controller: BattlefieldController::Preserve,
             enters_tapped: false,
             enters_attacking: false,
+            enters_tapped_and_attacking_if: None,
             enters_face_down: false,
             transfer_exiled_with_source_links: false,
         }
@@ -1552,6 +1554,11 @@ impl MoveToZoneEffect {
 
     pub fn attacking(mut self) -> Self {
         self.enters_attacking = true;
+        self
+    }
+
+    pub fn tapped_and_attacking_if(mut self, filter: ObjectFilter) -> Self {
+        self.enters_tapped_and_attacking_if = Some(filter);
         self
     }
 

--- a/crates/ironsmith-runtime/src/cards/builders.rs
+++ b/crates/ironsmith-runtime/src/cards/builders.rs
@@ -603,6 +603,7 @@ pub(crate) enum KeywordAction {
     Devoid,
     Annihilator(u32),
     ForMirrodin,
+    JobSelect,
     LivingWeapon,
     Crew {
         amount: u32,
@@ -900,6 +901,7 @@ impl KeywordAction {
             Self::Devoid => "Devoid".to_string(),
             Self::Annihilator(amount) => format!("Annihilator {amount}"),
             Self::ForMirrodin => "For Mirrodin!".to_string(),
+            Self::JobSelect => "Job select".to_string(),
             Self::LivingWeapon => "Living weapon".to_string(),
             Self::Crew { amount, .. } => format!("Crew {amount}"),
             Self::Saddle { amount, .. } => format!("Saddle {amount}"),
@@ -1857,6 +1859,7 @@ impl CardDefinitionBuilder {
                 functional_zones: vec![Zone::Battlefield],
             }),
             KeywordAction::ForMirrodin => self.for_mirrodin(),
+            KeywordAction::JobSelect => self.job_select(),
             KeywordAction::LivingWeapon => self.living_weapon(),
             KeywordAction::Crew {
                 amount,
@@ -3835,6 +3838,20 @@ impl CardDefinitionBuilder {
         ))
     }
 
+    /// Add job select.
+    ///
+    /// "When this Equipment enters, create a 1/1 colorless Hero creature token, then attach this to it."
+    pub fn job_select(self) -> Self {
+        let created_tag = TagKey::from("job_select_created");
+        self.with_ability(Ability::triggered(
+            Trigger::this_enters_battlefield(),
+            vec![
+                Effect::create_tokens(Self::job_select_hero_token(), 1).tag(created_tag.clone()),
+                Effect::attach_to(ChooseSpec::Tagged(created_tag)),
+            ],
+        ))
+    }
+
     /// Add living weapon.
     ///
     /// "When this Equipment enters, create a 0/0 black Phyrexian Germ creature token, then attach this to it."
@@ -4524,6 +4541,15 @@ impl CardDefinitionBuilder {
             .subtypes(vec![Subtype::Rebel])
             .color_indicator(ColorSet::RED)
             .power_toughness(PowerToughness::fixed(2, 2))
+            .build()
+    }
+
+    fn job_select_hero_token() -> CardDefinition {
+        CardDefinitionBuilder::new(CardId::new(), "Hero")
+            .token()
+            .card_types(vec![CardType::Creature])
+            .subtypes(vec![Subtype::Hero])
+            .power_toughness(PowerToughness::fixed(1, 1))
             .build()
     }
 

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -5146,6 +5146,193 @@ fn summoners_grimoire_job_select_creates_hero_and_attaches_equipment() {
     );
 }
 
+struct SummonersGrimoireAttackDecisionMaker {
+    chosen_card: ObjectId,
+}
+
+impl crate::decision::DecisionMaker for SummonersGrimoireAttackDecisionMaker {
+    fn decide_boolean(
+        &mut self,
+        _game: &crate::game_state::GameState,
+        _ctx: &crate::decisions::context::BooleanContext,
+    ) -> bool {
+        true
+    }
+
+    fn decide_objects(
+        &mut self,
+        _game: &crate::game_state::GameState,
+        ctx: &crate::decisions::context::SelectObjectsContext,
+    ) -> Vec<ObjectId> {
+        if ctx
+            .candidates
+            .iter()
+            .any(|candidate| candidate.id == self.chosen_card && candidate.legal)
+        {
+            vec![self.chosen_card]
+        } else {
+            ctx.candidates
+                .iter()
+                .filter(|candidate| candidate.legal)
+                .map(|candidate| candidate.id)
+                .take(ctx.min)
+                .collect()
+        }
+    }
+}
+
+fn resolve_summoners_grimoire_attack_trigger(
+    game: &mut crate::game_state::GameState,
+    equipped_creature: ObjectId,
+    chosen_card: ObjectId,
+) {
+    let bob = PlayerId::from_index(1);
+    game.combat = Some(crate::combat_state::CombatState {
+        attackers: vec![crate::combat_state::AttackerInfo {
+            creature: equipped_creature,
+            target: crate::combat_state::AttackTarget::Player(bob),
+        }],
+        ..crate::combat_state::CombatState::default()
+    });
+    let event = crate::triggers::TriggerEvent::new_with_provenance(
+        crate::events::combat::CreatureAttackedEvent::new(
+            equipped_creature,
+            crate::triggers::AttackEventTarget::Player(bob),
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+    let mut trigger_queue = crate::triggers::TriggerQueue::new();
+    let mut matching_count = 0;
+    for entry in crate::triggers::check_triggers(game, &event)
+        .into_iter()
+        .filter(|entry| entry.source == equipped_creature)
+    {
+        matching_count += 1;
+        trigger_queue.add(entry);
+    }
+    assert_eq!(
+        matching_count, 1,
+        "Summoner's Grimoire should grant the equipped creature one attack trigger"
+    );
+    crate::game_loop::put_triggers_on_stack(game, &mut trigger_queue)
+        .expect("Summoner's Grimoire attack trigger should go on the stack");
+    let mut dm = SummonersGrimoireAttackDecisionMaker { chosen_card };
+    crate::game_loop::resolve_stack_entry_with(game, &mut dm)
+        .expect("Summoner's Grimoire attack trigger should resolve");
+}
+
+fn summoners_grimoire_attached_game(
+    hand_card_types: Vec<CardType>,
+) -> (crate::game_state::GameState, PlayerId, ObjectId, ObjectId) {
+    let grimoire_def = parse_oracle_card_definition("Summoner's Grimoire");
+    let equipped_def = CardDefinitionBuilder::new(CardId::new(), "Equipped Adept")
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    let hand_def = CardDefinitionBuilder::new(CardId::new(), "Hand Summon")
+        .card_types(hand_card_types)
+        .power_toughness(PowerToughness::fixed(3, 3))
+        .build();
+
+    let alice = PlayerId::from_index(0);
+    let mut game = crate::tests::test_helpers::setup_two_player_game();
+    let grimoire = game.create_object_from_definition(&grimoire_def, alice, Zone::Battlefield);
+    let equipped_creature =
+        game.create_object_from_definition(&equipped_def, alice, Zone::Battlefield);
+    let hand_card = game.create_object_from_definition(&hand_def, alice, Zone::Hand);
+    assert!(
+        game.attach_object_to_target(
+            grimoire,
+            crate::object::AttachmentTarget::Object(equipped_creature)
+        ),
+        "Summoner's Grimoire should attach to the test creature"
+    );
+
+    (game, alice, equipped_creature, hand_card)
+}
+
+#[test]
+fn summoners_grimoire_attack_trigger_puts_enchantment_creature_tapped_and_attacking() {
+    let (mut game, alice, equipped_creature, hand_card) = summoners_grimoire_attached_game(vec![
+        CardType::Enchantment,
+        CardType::Creature,
+    ]);
+    let hand_card_stable_id = game
+        .object(hand_card)
+        .expect("chosen card should exist in hand")
+        .stable_id;
+
+    resolve_summoners_grimoire_attack_trigger(&mut game, equipped_creature, hand_card);
+    let moved_card = game
+        .find_object_by_stable_id(hand_card_stable_id)
+        .expect("chosen enchantment creature card should still be tracked after moving zones");
+
+    assert!(
+        !game
+            .player(alice)
+            .expect("Alice should exist")
+            .hand
+            .contains(&hand_card),
+        "chosen enchantment creature card should leave Alice's hand"
+    );
+    assert!(
+        game.battlefield.contains(&moved_card),
+        "chosen enchantment creature card should move to the battlefield"
+    );
+    assert!(
+        game.is_tapped(moved_card),
+        "chosen enchantment creature card should enter tapped"
+    );
+    let combat = game.combat.as_ref().expect("combat should remain active");
+    assert!(
+        combat
+            .attackers
+            .iter()
+            .any(|attacker| attacker.creature == moved_card),
+        "chosen enchantment creature card should enter attacking"
+    );
+}
+
+#[test]
+fn summoners_grimoire_attack_trigger_puts_non_enchantment_creature_normally() {
+    let (mut game, alice, equipped_creature, hand_card) =
+        summoners_grimoire_attached_game(vec![CardType::Creature]);
+    let hand_card_stable_id = game
+        .object(hand_card)
+        .expect("chosen card should exist in hand")
+        .stable_id;
+
+    resolve_summoners_grimoire_attack_trigger(&mut game, equipped_creature, hand_card);
+    let moved_card = game
+        .find_object_by_stable_id(hand_card_stable_id)
+        .expect("chosen creature card should still be tracked after moving zones");
+
+    assert!(
+        !game
+            .player(alice)
+            .expect("Alice should exist")
+            .hand
+            .contains(&hand_card),
+        "chosen creature card should leave Alice's hand"
+    );
+    assert!(
+        game.battlefield.contains(&moved_card),
+        "chosen creature card should move to the battlefield"
+    );
+    assert!(
+        !game.is_tapped(moved_card),
+        "non-enchantment creature card should not enter tapped"
+    );
+    let combat = game.combat.as_ref().expect("combat should remain active");
+    assert!(
+        !combat
+            .attackers
+            .iter()
+            .any(|attacker| attacker.creature == moved_card),
+        "non-enchantment creature card should not enter attacking"
+    );
+}
+
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn shiny_impetus_buffs_and_goads_enchanted_creature_away_from_aura_controller() {

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -5074,6 +5074,78 @@ fn parse_equipment_attached_goaded_anthem_preserves_equipped_subject() {
     );
 }
 
+#[test]
+fn summoners_grimoire_compiles_job_select_granted_trigger_and_labeled_equip() {
+    let def = parse_oracle_card_definition("Summoner's Grimoire");
+    let lines = canonical_compiled_lines(&def);
+    let rendered = lines.join("\n");
+
+    assert!(
+        lines.iter().any(|line| line == "Job select."),
+        "expected Job select keyword action, got {rendered}"
+    );
+    assert!(
+        lines.iter().any(|line| line == "Equipped creature is a Shaman in addition to its other types and has \"Whenever this creature attacks, you may put a creature card from your hand onto the battlefield. If that card is an enchantment card, it enters tapped and attacking\"."),
+        "expected merged equipped Shaman grant with quoted attack trigger, got {rendered}"
+    );
+    assert!(
+        lines.iter().any(|line| line == "Abraxas — Equip {3}."),
+        "expected labeled equip line, got {rendered}"
+    );
+
+    let debug = format!("{:#?}", def.abilities);
+    assert!(
+        debug.contains("job_select_created")
+            && debug.contains("CreateTokenEffect")
+            && debug.contains("AttachToEffect")
+            && debug.contains("AttachedAbilityGrant")
+            && debug.contains("enters_tapped_and_attacking_if: Some")
+            && debug.contains("Enchantment"),
+        "expected structural Job select and conditional enchantment entry support, got {debug}"
+    );
+}
+
+#[test]
+fn summoners_grimoire_job_select_creates_hero_and_attaches_equipment() {
+    let def = parse_oracle_card_definition("Summoner's Grimoire");
+    let alice = PlayerId::from_index(0);
+    let mut game = crate::game_state::GameState::new(vec!["Alice".to_string()], 20);
+    let grimoire = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let event = crate::events::RawEvent::new(
+        crate::events::ZoneChangeEvent::with_cause(
+            grimoire,
+            Zone::Hand,
+            Zone::Battlefield,
+            crate::events::cause::EventCause::effect(),
+            None,
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+
+    assert_eq!(
+        resolve_triggers_for_source(&mut game, grimoire, &event),
+        1,
+        "Summoner's Grimoire should trigger Job select when it enters"
+    );
+
+    let hero = game
+        .objects_in_zone(Zone::Battlefield)
+        .into_iter()
+        .find(|&id| game.object(id).is_some_and(|object| object.name == "Hero"))
+        .expect("Job select should create a Hero token");
+    let hero_object = game.object(hero).expect("Hero should exist");
+    assert_eq!(hero_object.card_types, [CardType::Creature]);
+    assert_eq!(hero_object.subtypes, [Subtype::Hero]);
+    assert_eq!(hero_object.base_power, Some(crate::card::PtValue::Fixed(1)));
+    assert_eq!(hero_object.base_toughness, Some(crate::card::PtValue::Fixed(1)));
+    assert_eq!(game.controller_of(hero_object), alice);
+    assert_eq!(
+        game.object(grimoire).and_then(|object| object.attached_to),
+        Some(crate::object::AttachmentTarget::Object(hero)),
+        "Job select should attach the Equipment to the created Hero"
+    );
+}
+
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn shiny_impetus_buffs_and_goads_enchanted_creature_away_from_aura_controller() {

--- a/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
@@ -1687,6 +1687,9 @@ fn describe_structural_equipment_token_keyword(ability: &Ability) -> Option<Stri
     if is_for_mirrodin_rebel_token(&create.token) {
         return Some("For Mirrodin!".to_string());
     }
+    if is_job_select_hero_token(&create.token) {
+        return Some("Job select".to_string());
+    }
     None
 }
 
@@ -1734,6 +1737,22 @@ fn is_for_mirrodin_rebel_token(token: &CardDefinition) -> bool {
             Some(crate::card::PowerToughness {
                 power: crate::card::PtValue::Fixed(2),
                 toughness: crate::card::PtValue::Fixed(2),
+            })
+        )
+        && token.abilities.is_empty()
+}
+
+fn is_job_select_hero_token(token: &CardDefinition) -> bool {
+    token.card.is_token
+        && token.card.name == "Hero"
+        && token.card.colors() == crate::color::ColorSet::COLORLESS
+        && token.card.card_types == [CardType::Creature]
+        && token.card.subtypes == [Subtype::Hero]
+        && matches!(
+            token.card.power_toughness,
+            Some(crate::card::PowerToughness {
+                power: crate::card::PtValue::Fixed(1),
+                toughness: crate::card::PtValue::Fixed(1),
             })
         )
         && token.abilities.is_empty()

--- a/crates/ironsmith-runtime/src/compiled_text/merge_passes.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/merge_passes.rs
@@ -350,6 +350,61 @@ pub(super) fn merge_same_true_type_addition_lines(lines: Vec<String>) -> Vec<Str
     merged
 }
 
+pub(super) fn merge_attached_type_and_ability_grant_lines(lines: Vec<String>) -> Vec<String> {
+    let mut merged = Vec::with_capacity(lines.len());
+    let mut idx = 0usize;
+    while idx < lines.len() {
+        if idx + 1 < lines.len()
+            && let Some(line) = merge_attached_type_and_ability_grant_pair(&lines[idx], &lines[idx + 1])
+        {
+            merged.push(line);
+            idx += 2;
+            continue;
+        }
+        merged.push(lines[idx].clone());
+        idx += 1;
+    }
+    merged
+}
+
+fn merge_attached_type_and_ability_grant_pair(left: &str, right: &str) -> Option<String> {
+    let left = left.trim().trim_end_matches('.');
+    let right = right.trim().trim_end_matches('.');
+    let left_lower = left.to_ascii_lowercase();
+    let right_lower = right.to_ascii_lowercase();
+    let subject = if left_lower.starts_with("equipped creature is ")
+        && right_lower.starts_with("equipped creature has ")
+    {
+        "Equipped creature"
+    } else if left_lower.starts_with("enchanted creature is ")
+        && right_lower.starts_with("enchanted creature has ")
+    {
+        "Enchanted creature"
+    } else {
+        return None;
+    };
+
+    let type_tail = left
+        .strip_prefix(subject)?
+        .trim()
+        .strip_prefix("is")?
+        .trim();
+    if !type_tail
+        .to_ascii_lowercase()
+        .ends_with(" in addition to its other types")
+    {
+        return None;
+    }
+    let ability = right.strip_prefix(subject)?.trim().strip_prefix("has")?.trim();
+    if ability.is_empty() || ability.starts_with('"') {
+        return None;
+    }
+    Some(format!(
+        "{subject} is {type_tail} and has \"{}\".",
+        capitalize_first(ability)
+    ))
+}
+
 #[derive(Debug, Clone)]
 struct ColorLine {
     subject: String,

--- a/crates/ironsmith-runtime/src/compiled_text/mod.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/mod.rs
@@ -968,8 +968,10 @@ fn merge_ast_surface_lines(mut lines: Vec<String>) -> Vec<String> {
                     merge_lose_all_transform_lines(merge_attached_transform_keyword_loss_lines(
                         merge_blockability_lines(annotate_color_choice_exclusions(
                             merge_same_true_color_lines(merge_same_true_type_addition_lines(
-                                merge_same_true_keyword_grant_lines(
-                                    merge_subject_predicate_surface_lines(previous.clone()),
+                                merge_attached_type_and_ability_grant_lines(
+                                    merge_same_true_keyword_grant_lines(
+                                        merge_subject_predicate_surface_lines(previous.clone()),
+                                    ),
                                 ),
                             )),
                         )),

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -39719,6 +39719,11 @@ pub(super) fn describe_keyword_ability(ability: &Ability) -> Option<String> {
                 rendered.push_str(". ");
                 rendered.push_str(&join_activation_restriction_clauses(&restriction_clauses));
             }
+            if let Some(label) = activated_presentation_label(activated)
+                && !rendered.starts_with(label)
+            {
+                rendered = format!("{label} — {rendered}");
+            }
         }
         return Some(rendered);
     }
@@ -39761,6 +39766,9 @@ pub(super) fn describe_keyword_ability(ability: &Ability) -> Option<String> {
     }
     if text == "for mirrodin!" {
         return Some("For Mirrodin!".to_string());
+    }
+    if text == "job select" {
+        return Some("Job select".to_string());
     }
     if text.starts_with("afterlife ")
         || text.starts_with("annihilator ")
@@ -40198,6 +40206,11 @@ fn describe_structural_equip_keyword(
     if !restriction_clauses.is_empty() {
         rendered.push_str(". ");
         rendered.push_str(&join_activation_restriction_clauses(&restriction_clauses));
+    }
+    if let Some(label) = activated_presentation_label(activated)
+        && !rendered.starts_with(label)
+    {
+        rendered = format!("{label} — {rendered}");
     }
 
     Some(rendered)

--- a/crates/ironsmith-runtime/src/effects/zones/move_to_zone.rs
+++ b/crates/ironsmith-runtime/src/effects/zones/move_to_zone.rs
@@ -241,16 +241,27 @@ impl EffectExecutor for MoveToZoneEffect {
                 }
                 EventOutcome::Proceed(final_zone) => {
                     if final_zone == Zone::Battlefield {
+                        let conditional_tapped_and_attacking = self
+                            .enters_tapped_and_attacking_if
+                            .as_ref()
+                            .is_some_and(|filter| {
+                                let filter_ctx = FilterContext::new(ctx.controller)
+                                    .with_source(ctx.source);
+                                filter.matches_snapshot(&target_lki_before_move, &filter_ctx, game)
+                            });
+                        let enters_tapped = self.enters_tapped || conditional_tapped_and_attacking;
+                        let enters_attacking =
+                            self.enters_attacking || conditional_tapped_and_attacking;
                         let options = match self.battlefield_controller {
                             BattlefieldController::Preserve => {
-                                BattlefieldEntryOptions::preserve(self.enters_tapped)
+                                BattlefieldEntryOptions::preserve(enters_tapped)
                             }
                             BattlefieldController::Owner => {
-                                BattlefieldEntryOptions::owner(self.enters_tapped)
+                                BattlefieldEntryOptions::owner(enters_tapped)
                             }
                             BattlefieldController::You => BattlefieldEntryOptions::specific(
                                 ctx.controller,
-                                self.enters_tapped,
+                                enters_tapped,
                             ),
                         };
                         if self.enters_face_down
@@ -260,7 +271,7 @@ impl EffectExecutor for MoveToZoneEffect {
                         }
                         match move_to_battlefield_with_options(game, ctx, object_id, options) {
                             BattlefieldEntryOutcome::Moved(new_id) => {
-                                if self.enters_attacking
+                                if enters_attacking
                                     && let Some(target) =
                                         choose_enters_attacking_target(game, ctx, new_id)
                                     && let Some(combat) = game.combat.as_mut()
@@ -484,6 +495,20 @@ mod tests {
         id
     }
 
+    fn create_named_creature_with_types_in_zone(
+        game: &mut GameState,
+        owner: PlayerId,
+        name: &str,
+        card_types: Vec<CardType>,
+        zone: Zone,
+    ) -> crate::ids::ObjectId {
+        let card = CardBuilder::new(CardId::new(), name)
+            .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(2)]]))
+            .card_types(card_types)
+            .build();
+        game.create_object_from_card(&card, owner, zone)
+    }
+
     struct ChooseLastOptionDecisionMaker;
 
     impl crate::decision::DecisionMaker for ChooseLastOptionDecisionMaker {
@@ -601,6 +626,108 @@ mod tests {
         assert!(
             game.combat.is_none(),
             "no attacker should be added without combat"
+        );
+    }
+
+    #[test]
+    fn conditional_move_enters_tapped_and_attacking_when_filter_matches() {
+        let mut game = setup_game();
+        let alice = PlayerId::from_index(0);
+        let bob = PlayerId::from_index(1);
+        let source = create_named_creature_in_zone(&mut game, alice, "Attack Source", Zone::Battlefield);
+        let existing_attacker =
+            create_named_creature_in_zone(&mut game, alice, "Existing Attacker", Zone::Battlefield);
+        let enchantment_creature = create_named_creature_with_types_in_zone(
+            &mut game,
+            alice,
+            "Enchantment Creature",
+            vec![CardType::Enchantment, CardType::Creature],
+            Zone::Hand,
+        );
+        game.combat = Some(CombatState {
+            attackers: vec![AttackerInfo {
+                creature: existing_attacker,
+                target: AttackTarget::Player(bob),
+            }],
+            ..CombatState::default()
+        });
+
+        let mut ctx = ExecutionContext::new_default(source, alice);
+        let outcome = MoveToZoneEffect::new(
+            ChooseSpec::SpecificObject(enchantment_creature),
+            Zone::Battlefield,
+            false,
+        )
+        .tapped_and_attacking_if(ObjectFilter::default().with_type(CardType::Enchantment))
+        .execute(&mut game, &mut ctx)
+        .expect("conditional move should resolve");
+        let moved = match outcome.value {
+            crate::effect::OutcomeValue::Objects(ids) => ids[0],
+            _ => panic!("expected moved object id"),
+        };
+
+        assert!(game
+            .object(moved)
+            .is_some_and(|object| object.zone == Zone::Battlefield));
+        assert!(
+            game.is_tapped(moved),
+            "matching enchantment creature should enter tapped"
+        );
+        assert!(
+            game.combat.as_ref().is_some_and(|combat| combat
+                .attackers
+                .iter()
+                .any(|info| info.creature == moved)),
+            "matching enchantment creature should enter attacking"
+        );
+    }
+
+    #[test]
+    fn conditional_move_enters_normally_when_filter_does_not_match() {
+        let mut game = setup_game();
+        let alice = PlayerId::from_index(0);
+        let bob = PlayerId::from_index(1);
+        let source = create_named_creature_in_zone(&mut game, alice, "Attack Source", Zone::Battlefield);
+        let existing_attacker =
+            create_named_creature_in_zone(&mut game, alice, "Existing Attacker", Zone::Battlefield);
+        let creature = create_named_creature_with_types_in_zone(
+            &mut game,
+            alice,
+            "Plain Creature",
+            vec![CardType::Creature],
+            Zone::Hand,
+        );
+        game.combat = Some(CombatState {
+            attackers: vec![AttackerInfo {
+                creature: existing_attacker,
+                target: AttackTarget::Player(bob),
+            }],
+            ..CombatState::default()
+        });
+
+        let mut ctx = ExecutionContext::new_default(source, alice);
+        let outcome = MoveToZoneEffect::new(ChooseSpec::SpecificObject(creature), Zone::Battlefield, false)
+            .tapped_and_attacking_if(ObjectFilter::default().with_type(CardType::Enchantment))
+            .execute(&mut game, &mut ctx)
+            .expect("conditional move should resolve");
+        let moved = match outcome.value {
+            crate::effect::OutcomeValue::Objects(ids) => ids[0],
+            _ => panic!("expected moved object id"),
+        };
+
+        assert!(game
+            .object(moved)
+            .is_some_and(|object| object.zone == Zone::Battlefield));
+        assert!(
+            !game.is_tapped(moved),
+            "nonmatching creature should not enter tapped"
+        );
+        assert!(
+            game.combat.as_ref().is_some_and(|combat| !combat
+                .attackers
+                .iter()
+                .any(|info| info.creature == moved)),
+            "nonmatching creature should not enter attacking"
         );
     }
 


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Summoner's Grimoire
Initial parse error:
```
parser does not yet support line family: 'Abraxas — Equip {3}'; oracle-only fallback also failed: parser does not yet support line family: 'Abraxas — Equip {3}'
```

Current worker: i-074c6c78e275dd65e
Branch: codex/aws-card-fix-summoner-s-grimoire
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260604T121212Z-controller-dev-loop-wave0024
