### PR TITLE
Fix Ironsmith parse failure: Flycatcher Giraffid

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/etb_static_lines.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/etb_static_lines.rs
@@ -768,6 +768,20 @@ pub(crate) fn parse_enters_with_counters_line(
             after_with = &after_with[and_with_end..];
         }
     }
+
+    if let Some(choice) = parse_enters_with_counter_choice_tokens(after_with) {
+        if condition.is_some() || !added_abilities.is_empty() {
+            return Err(CardTextError::ParseError(format!(
+                "unsupported conditional self ETB counter choice clause (clause: '{}')",
+                full_words.join(" ")
+            )));
+        }
+        return Ok(Some(StaticAbility::enters_with_counter_choice(
+            choice.counter_types,
+            choice.count,
+        )));
+    }
+
     let (mut count, used) = if after_with
         .first()
         .is_some_and(|token| ETB_ARTICLE_WORD_PATTERN.matches_token(token))
@@ -945,6 +959,65 @@ pub(crate) fn parse_enters_with_counters_line(
         counter_type,
         count,
     )))
+}
+
+struct EntersWithCounterChoiceTokens {
+    counter_types: Vec<CounterType>,
+    count: Value,
+}
+
+fn parse_enters_with_counter_choice_tokens(
+    tokens: &[OwnedLexToken],
+) -> Option<EntersWithCounterChoiceTokens> {
+    let words = crate::runtime_backend::lexer::token_word_refs(tokens);
+    if !words.starts_with(&["your", "choice", "of"]) {
+        return None;
+    }
+
+    let mut idx = 3usize;
+    let mut counter_types = Vec::new();
+    loop {
+        while tokens
+            .get(idx)
+            .is_some_and(|token| ETB_ARTICLE_WORD_PATTERN.matches_token(token))
+        {
+            idx += 1;
+        }
+        let counter_end = tokens[idx..]
+            .iter()
+            .position(|token| ETB_COUNTER_OR_COUNTERS_WORD_PATTERN.matches_token(token))?
+            + idx;
+        let counter_tokens = &tokens[idx..=counter_end];
+        let counter_type = parse_counter_type_from_tokens(counter_tokens)?;
+        counter_types.push(counter_type);
+        idx = counter_end + 1;
+
+        if tokens.get(idx).is_some_and(|token| token.is_comma()) {
+            idx += 1;
+        }
+        if tokens.get(idx).and_then(OwnedLexToken::as_word) == Some("or") {
+            idx += 1;
+            continue;
+        }
+        break;
+    }
+
+    let mut tail = trim_commas(&tokens[idx..]);
+    if token_slice_first_is(tail, "on") {
+        tail = &tail[1..];
+    }
+    if token_slice_first_is(tail, "it") {
+        tail = &tail[1..];
+    }
+    let tail_has_words = tail.iter().any(|token| token.as_word().is_some());
+    if counter_types.len() < 2 || tail_has_words {
+        return None;
+    }
+
+    Some(EntersWithCounterChoiceTokens {
+        counter_types,
+        count: Value::Fixed(1),
+    })
 }
 
 fn parse_enters_with_added_abilities_tail(tokens: &[OwnedLexToken]) -> Option<Vec<Ability>> {

--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/etb_static_lines.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/etb_static_lines.rs
@@ -1002,7 +1002,8 @@ fn parse_enters_with_counter_choice_tokens(
         break;
     }
 
-    let mut tail = trim_commas(&tokens[idx..]);
+    let tail_tokens = trim_commas(&tokens[idx..]);
+    let mut tail = tail_tokens.as_slice();
     if token_slice_first_is(tail, "on") {
         tail = &tail[1..];
     }

--- a/crates/ironsmith-core/src/static_ability_model.rs
+++ b/crates/ironsmith-core/src/static_ability_model.rs
@@ -562,6 +562,10 @@ pub enum StaticAbilityPayload<T, E, C, Cond> {
         counter: CounterType,
         count: Value,
     },
+    EntersWithCounterChoice {
+        counter_types: Vec<CounterType>,
+        count: Value,
+    },
     EntersTappedForFilter(ObjectFilter),
     EntersUntappedForFilter(ObjectFilter),
     EntersWithCountersAndSubtypesForFilter {
@@ -1590,6 +1594,13 @@ where
             StaticAbilityPayload::EntersWithCountersValue { counter, count } => {
                 StaticAbilityPayload::EntersWithCountersValue { counter, count }
             }
+            StaticAbilityPayload::EntersWithCounterChoice {
+                counter_types,
+                count,
+            } => StaticAbilityPayload::EntersWithCounterChoice {
+                counter_types,
+                count,
+            },
             StaticAbilityPayload::EntersTappedForFilter(filter) => {
                 StaticAbilityPayload::EntersTappedForFilter(filter)
             }
@@ -4085,6 +4096,18 @@ impl<
             payload: StaticAbilityPayload::EntersWithCountersValue { counter, count },
         }
     }
+
+    pub fn enters_with_counter_choice(counter_types: Vec<CounterType>, count: Value) -> Self {
+        Self {
+            id: Some(StaticAbilityId::EnterWithCounters),
+            label: "enters with counter choice".to_string(),
+            payload: StaticAbilityPayload::EntersWithCounterChoice {
+                counter_types,
+                count,
+            },
+        }
+    }
+
     pub fn enters_tapped_for_filter(filter: ObjectFilter) -> Self {
         Self {
             id: Some(StaticAbilityId::EnterTappedForFilter),

--- a/crates/ironsmith-core/src/types.rs
+++ b/crates/ironsmith-core/src/types.rs
@@ -161,6 +161,7 @@ pub enum Subtype {
     Ally,
     Alien,
     Angel,
+    Antelope,
     Ape,
     Army,
     Archer,
@@ -461,6 +462,7 @@ impl Subtype {
             Subtype::Ally,
             Subtype::Alien,
             Subtype::Angel,
+            Subtype::Antelope,
             Subtype::Ape,
             Subtype::Army,
             Subtype::Archer,
@@ -799,6 +801,7 @@ impl Subtype {
                 | Subtype::Ally
                 | Subtype::Alien
                 | Subtype::Angel
+                | Subtype::Antelope
                 | Subtype::Ape
                 | Subtype::Army
                 | Subtype::Archer

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -13876,6 +13876,122 @@ fn test_rix_maadi_reveler_etb_uses_spectacle_branch_when_paid() {
     );
 }
 
+#[test]
+fn flycatcher_giraffid_strict_parser_compiled_text_and_model_regression() {
+    assert_oracle_card_parses_strict("Flycatcher Giraffid");
+    let def = parse_oracle_card_definition("Flycatcher Giraffid");
+
+    let debug = format!("{def:#?}");
+    assert!(
+        debug.contains("EntersWithCounterChoice")
+            && debug.contains("Vigilance")
+            && debug.contains("Reach")
+            && !debug.contains("KeywordFallbackText")
+            && !debug.contains("RuleFallbackText")
+            && !debug.contains("UnsupportedParserLine"),
+        "expected Flycatcher Giraffid to lower its ETB counter choice without unsupported placeholders, got {debug}"
+    );
+
+    let rendered = compiled_text_lines(&def).join(" ");
+    assert!(
+        rendered.contains(
+            "This creature enters with your choice of a vigilance counter or a reach counter on it"
+        ),
+        "expected Flycatcher Giraffid compiled text to preserve its counter-choice clause, got {rendered}"
+    );
+}
+
+#[test]
+fn flycatcher_giraffid_enters_with_chosen_vigilance_counter() {
+    use crate::tests::test_helpers::setup_two_player_game;
+
+    struct ChooseCounter(usize);
+    impl crate::decision::DecisionMaker for ChooseCounter {
+        fn decide_options(
+            &mut self,
+            _game: &crate::game_state::GameState,
+            ctx: &crate::decisions::context::SelectOptionsContext,
+        ) -> Vec<usize> {
+            assert!(
+                ctx.description.contains("Flycatcher Giraffid"),
+                "counter choice should name the entering creature, got {:?}",
+                ctx.description
+            );
+            assert_eq!(ctx.min, 1);
+            assert_eq!(ctx.max, 1);
+            assert_eq!(ctx.options.len(), 2);
+            vec![self.0]
+        }
+    }
+
+    let def = parse_oracle_card_definition("Flycatcher Giraffid");
+    let mut game = setup_two_player_game();
+    let alice = PlayerId::from_index(0);
+    let stack_id = game.create_object_from_definition(&def, alice, Zone::Stack);
+    let mut dm = ChooseCounter(0);
+
+    let result = game
+        .move_object_with_etb_processing_with_dm(stack_id, Zone::Battlefield, &mut dm)
+        .expect("Flycatcher Giraffid should enter the battlefield");
+    let giraffid_id = result.new_id;
+
+    assert_eq!(
+        game.counter_count(giraffid_id, crate::object::CounterType::Vigilance),
+        1,
+        "choosing the first option should put one vigilance counter on Flycatcher Giraffid"
+    );
+    assert_eq!(
+        game.counter_count(giraffid_id, crate::object::CounterType::Reach),
+        0,
+        "choosing vigilance should not also put a reach counter on Flycatcher Giraffid"
+    );
+}
+
+#[test]
+fn flycatcher_giraffid_enters_with_chosen_reach_counter() {
+    use crate::tests::test_helpers::setup_two_player_game;
+
+    struct ChooseCounter(usize);
+    impl crate::decision::DecisionMaker for ChooseCounter {
+        fn decide_options(
+            &mut self,
+            _game: &crate::game_state::GameState,
+            ctx: &crate::decisions::context::SelectOptionsContext,
+        ) -> Vec<usize> {
+            assert!(
+                ctx.options
+                    .iter()
+                    .any(|option| option.description == "reach counter"),
+                "counter choice should include a reach-counter option, got {:?}",
+                ctx.options
+            );
+            vec![self.0]
+        }
+    }
+
+    let def = parse_oracle_card_definition("Flycatcher Giraffid");
+    let mut game = setup_two_player_game();
+    let alice = PlayerId::from_index(0);
+    let stack_id = game.create_object_from_definition(&def, alice, Zone::Stack);
+    let mut dm = ChooseCounter(1);
+
+    let result = game
+        .move_object_with_etb_processing_with_dm(stack_id, Zone::Battlefield, &mut dm)
+        .expect("Flycatcher Giraffid should enter the battlefield");
+    let giraffid_id = result.new_id;
+
+    assert_eq!(
+        game.counter_count(giraffid_id, crate::object::CounterType::Reach),
+        1,
+        "choosing the second option should put one reach counter on Flycatcher Giraffid"
+    );
+    assert_eq!(
+        game.counter_count(giraffid_id, crate::object::CounterType::Vigilance),
+        0,
+        "choosing reach should not also put a vigilance counter on Flycatcher Giraffid"
+    );
+}
+
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
 fn thunder_brute_strict_parser_and_compiled_text_regression() {

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -13945,6 +13945,23 @@ fn flycatcher_giraffid_enters_with_chosen_vigilance_counter() {
         0,
         "choosing vigilance should not also put a reach counter on Flycatcher Giraffid"
     );
+    let chars = game
+        .calculated_characteristics(giraffid_id)
+        .expect("Flycatcher Giraffid should have calculated characteristics");
+    assert!(
+        chars
+            .static_abilities
+            .iter()
+            .any(|ability| ability.id() == StaticAbilityId::Vigilance),
+        "a vigilance counter should grant vigilance to Flycatcher Giraffid"
+    );
+    assert!(
+        chars
+            .static_abilities
+            .iter()
+            .all(|ability| ability.id() != StaticAbilityId::Reach),
+        "choosing vigilance should not grant reach to Flycatcher Giraffid"
+    );
 }
 
 #[test]
@@ -13989,6 +14006,23 @@ fn flycatcher_giraffid_enters_with_chosen_reach_counter() {
         game.counter_count(giraffid_id, crate::object::CounterType::Vigilance),
         0,
         "choosing reach should not also put a vigilance counter on Flycatcher Giraffid"
+    );
+    let chars = game
+        .calculated_characteristics(giraffid_id)
+        .expect("Flycatcher Giraffid should have calculated characteristics");
+    assert!(
+        chars
+            .static_abilities
+            .iter()
+            .any(|ability| ability.id() == StaticAbilityId::Reach),
+        "a reach counter should grant reach to Flycatcher Giraffid"
+    );
+    assert!(
+        chars
+            .static_abilities
+            .iter()
+            .all(|ability| ability.id() != StaticAbilityId::Vigilance),
+        "choosing reach should not grant vigilance to Flycatcher Giraffid"
     );
 }
 

--- a/crates/ironsmith-runtime/src/continuous.rs
+++ b/crates/ironsmith-runtime/src/continuous.rs
@@ -4729,7 +4729,11 @@ fn add_abilities_from_counters(object: &Object, chars: &mut CalculatedCharacteri
                 .iter()
                 .any(|a| a.id() == StaticAbilityId::CantBlock)
             {
-                chars.static_abilities.push(StaticAbility::cant_block());
+                let ability = StaticAbility::cant_block();
+                chars
+                    .abilities
+                    .push(crate::ability::Ability::static_ability(ability.clone()));
+                chars.static_abilities.push(ability);
             }
             chars.abilities.push(crate::ability::Ability::triggered(
                 crate::triggers::Trigger::this_attacks(),
@@ -4772,6 +4776,9 @@ fn add_abilities_from_counters(object: &Object, chars: &mut CalculatedCharacteri
             };
 
             if let Some(sa) = ability {
+                chars
+                    .abilities
+                    .push(crate::ability::Ability::static_ability(sa.clone()));
                 chars.static_abilities.push(sa);
             }
         }
@@ -5060,6 +5067,12 @@ mod tests {
                 .any(|a| a.id() == StaticAbilityId::Deathtouch),
             "Creature with deathtouch counter should have deathtouch ability"
         );
+        assert!(
+            extract_static_abilities(&chars.abilities)
+                .iter()
+                .any(|a| a.id() == StaticAbilityId::Deathtouch),
+            "ability-counter grants must survive static ability extraction from abilities"
+        );
     }
 
     #[test]
@@ -5118,6 +5131,13 @@ mod tests {
                 .any(|a| a.id() == StaticAbilityId::Vigilance)
         );
         assert_eq!(chars.static_abilities.len(), 3);
+
+        let extracted = extract_static_abilities(&chars.abilities);
+        assert!(extracted.iter().any(|a| a.id() == StaticAbilityId::Flying));
+        assert!(extracted.iter().any(|a| a.id() == StaticAbilityId::Trample));
+        assert!(extracted
+            .iter()
+            .any(|a| a.id() == StaticAbilityId::Vigilance));
     }
 
     #[test]

--- a/crates/ironsmith-runtime/src/events/processing/application.rs
+++ b/crates/ironsmith-runtime/src/events/processing/application.rs
@@ -107,6 +107,25 @@ pub(super) fn apply_trait_replacement(
             }
         }
 
+        ReplacementAction::EnterWithCounterChoice { counter_types, .. } => {
+            if counter_types.is_empty() {
+                return TraitApplyResult::Unchanged(event);
+            }
+            TraitApplyResult::NeedsInteraction {
+                decision_ctx: super::counter_choice_context(
+                    game,
+                    effect.source,
+                    effect.controller,
+                    counter_types,
+                ),
+                redirect_zone: Zone::Battlefield,
+                effect_id: effect.id,
+                object_id: effect.source,
+                filter: None,
+                destinations: None,
+            }
+        }
+
         ReplacementAction::Tribute { count, .. } => {
             let opponents = super::tribute_opponents(game, effect.controller);
             if opponents.is_empty() {

--- a/crates/ironsmith-runtime/src/events/processing/application.rs
+++ b/crates/ironsmith-runtime/src/events/processing/application.rs
@@ -956,6 +956,14 @@ fn resolve_value_for_etb(
     resolve_value_for_replacement(count, game, source)
 }
 
+pub(super) fn resolve_value_for_etb_for_choice(
+    count: &crate::effect::Value,
+    game: &GameState,
+    source: crate::ids::ObjectId,
+) -> u32 {
+    resolve_value_for_etb(count, game, source)
+}
+
 fn resolve_value_for_replacement(
     count: &crate::effect::Value,
     game: &GameState,

--- a/crates/ironsmith-runtime/src/events/processing/mod.rs
+++ b/crates/ironsmith-runtime/src/events/processing/mod.rs
@@ -59,6 +59,35 @@ fn apply_tribute_response(
     apply_trait_enter_with_counters(&event, counter_type, count, &[], &[]).unwrap_or(event)
 }
 
+fn apply_enter_counter_choice_response(
+    game: &GameState,
+    event: Event,
+    response: &InteractiveReplacementResponse,
+    source: ObjectId,
+    counter_types: &[CounterType],
+    count: &crate::effect::Value,
+) -> Event {
+    let Some(counter_type) = response
+        .selected_option_index()
+        .and_then(|index| counter_types.get(index))
+        .copied()
+        .or_else(|| counter_types.first().copied())
+    else {
+        return event;
+    };
+    let resolved_count = application::resolve_value_for_etb_for_choice(count, game, source);
+    apply_trait_enter_with_counters(&event, counter_type, resolved_count, &[], &[]).unwrap_or(event)
+}
+
+impl InteractiveReplacementResponse {
+    fn selected_option_index(&self) -> Option<usize> {
+        match self {
+            InteractiveReplacementResponse::Options(selected) => selected.first().copied(),
+            _ => None,
+        }
+    }
+}
+
 pub(super) fn tribute_opponents(game: &GameState, controller: PlayerId) -> Vec<PlayerId> {
     let mut opponents = game
         .players
@@ -3203,6 +3232,21 @@ pub fn process_etb_with_event_and_dm_with_initial_counters(
                             );
                             continue;
                         }
+                        if let ReplacementAction::EnterWithCounterChoice {
+                            counter_types,
+                            count,
+                        } = &chosen_effect.replacement
+                        {
+                            current_event = apply_enter_counter_choice_response(
+                                game,
+                                current_event,
+                                &response,
+                                chosen_effect.source,
+                                counter_types,
+                                count,
+                            );
+                            continue;
+                        }
                         let interactive_result = continue_interactive_replacement(
                             game,
                             &response,
@@ -3279,6 +3323,22 @@ pub fn process_etb_with_event_and_dm_with_initial_counters(
                         &paid_label,
                         &mut paid_labels,
                         dm,
+                    );
+                    continue;
+                }
+                if let Some(ReplacementAction::EnterWithCounterChoice {
+                    counter_types,
+                    count,
+                }) = find_effect_for_choice(game, &current_additional_effects, effect_id)
+                    .map(|effect| effect.replacement)
+                {
+                    current_event = apply_enter_counter_choice_response(
+                        game,
+                        *event,
+                        &response,
+                        object_id,
+                        &counter_types,
+                        &count,
                     );
                     continue;
                 }

--- a/crates/ironsmith-runtime/src/events/processing/mod.rs
+++ b/crates/ironsmith-runtime/src/events/processing/mod.rs
@@ -105,6 +105,35 @@ fn tribute_source_name(game: &GameState, source: ObjectId) -> String {
         .unwrap_or_else(|| "this creature".to_string())
 }
 
+pub(super) fn counter_choice_context(
+    game: &GameState,
+    source: ObjectId,
+    controller: PlayerId,
+    counter_types: &[CounterType],
+) -> crate::decisions::context::DecisionContext {
+    let source_name = tribute_source_name(game, source);
+    let options = counter_types
+        .iter()
+        .enumerate()
+        .map(|(index, counter_type)| {
+            crate::decisions::context::SelectableOption::new(
+                index,
+                format!("{} counter", counter_type.description()),
+            )
+        })
+        .collect();
+    crate::decisions::context::DecisionContext::SelectOptions(
+        crate::decisions::context::SelectOptionsContext::new(
+            controller,
+            Some(source),
+            format!("Choose a counter type for {source_name}"),
+            options,
+            1,
+            1,
+        ),
+    )
+}
+
 pub(super) fn tribute_boolean_context(
     game: &GameState,
     source: ObjectId,

--- a/crates/ironsmith-runtime/src/replacement.rs
+++ b/crates/ironsmith-runtime/src/replacement.rs
@@ -139,6 +139,12 @@ pub enum ReplacementAction {
         added_abilities: Vec<Ability>,
     },
 
+    /// Enter with the controller's choice of one counter type.
+    EnterWithCounterChoice {
+        counter_types: Vec<CounterType>,
+        count: Value,
+    },
+
     /// As this enters, an opponent may put counters on it and mark a keyword paid.
     Tribute {
         counter_type: CounterType,

--- a/crates/ironsmith-runtime/src/static_abilities/misc.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/misc.rs
@@ -1303,6 +1303,69 @@ impl StaticAbilityKind for EntersWithCounters {
     }
 }
 
+/// Enters the battlefield with the controller's choice of one counter type.
+#[derive(Debug, Clone, PartialEq)]
+pub struct EntersWithCounterChoice {
+    pub counter_types: Vec<CounterType>,
+    pub count: Value,
+}
+
+impl EntersWithCounterChoice {
+    pub fn new(counter_types: Vec<CounterType>, count: Value) -> Self {
+        Self {
+            counter_types,
+            count,
+        }
+    }
+}
+
+impl StaticAbilityKind for EntersWithCounterChoice {
+    fn id(&self) -> StaticAbilityId {
+        StaticAbilityId::EnterWithCounters
+    }
+
+    fn display(&self) -> String {
+        let counter_choices = self
+            .counter_types
+            .iter()
+            .map(|counter_type| {
+                let counter = counter_type.description();
+                let article = match counter.chars().next().map(|ch| ch.to_ascii_lowercase()) {
+                    Some('a' | 'e' | 'i' | 'o' | 'u') => "an",
+                    _ => "a",
+                };
+                format!("{article} {counter} counter")
+            })
+            .collect::<Vec<_>>();
+        let choices = match counter_choices.as_slice() {
+            [] => "a counter".to_string(),
+            [single] => single.clone(),
+            [head @ .., last] => format!("{} or {last}", head.join(", ")),
+        };
+        let count_prefix = match &self.count {
+            Value::Fixed(1) => String::new(),
+            value => format!("{} ", describe_value(value)),
+        };
+        format!("Enters the battlefield with your choice of {count_prefix}{choices} on it")
+    }
+
+    fn generate_replacement_effect(
+        &self,
+        source: ObjectId,
+        controller: PlayerId,
+    ) -> Option<ReplacementEffect> {
+        Some(ReplacementEffect::with_matcher(
+            source,
+            controller,
+            ThisWouldEnterBattlefieldMatcher,
+            ReplacementAction::EnterWithCounterChoice {
+                counter_types: self.counter_types.clone(),
+                count: self.count.clone(),
+            },
+        ))
+    }
+}
+
 /// Enters the battlefield with counters if a condition is true.
 #[derive(Debug, Clone, PartialEq)]
 pub struct EntersWithCountersIfCondition {

--- a/crates/ironsmith-runtime/src/static_abilities/mod.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/mod.rs
@@ -2153,6 +2153,16 @@ impl StaticAbility {
         Self::new(EntersWithCounters::new(counter_type, count))
     }
 
+    pub fn enters_with_counter_choice(
+        counter_types: Vec<crate::object::CounterType>,
+        count: crate::effect::Value,
+    ) -> Self {
+        Self::new(crate::static_abilities::misc::EntersWithCounterChoice::new(
+            counter_types,
+            count,
+        ))
+    }
+
     pub fn enters_with_counters_if_condition(
         counter_type: crate::object::CounterType,
         count: crate::effect::Value,

--- a/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/model_interpreter.rs
@@ -1551,6 +1551,10 @@ impl StaticAbilityModelInterpreter {
             ironsmith_core::StaticAbilityPayload::EntersWithCountersValue { counter, count } => {
                 StaticAbility::enters_with_counters_value(*counter, count.clone())
             }
+            ironsmith_core::StaticAbilityPayload::EntersWithCounterChoice {
+                counter_types,
+                count,
+            } => StaticAbility::enters_with_counter_choice(counter_types.clone(), count.clone()),
             ironsmith_core::StaticAbilityPayload::EntersTappedForFilter(filter) => {
                 StaticAbility::enters_tapped_for_filter(filter.clone())
             }


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Flycatcher Giraffid
Initial parse error:
```
missing counter count in self ETB counters (clause: 'this creature enters with your choice of a vigilance counter or a reach counter on it'); oracle-only fallback also failed: missing counter count in self ETB counters (clause: 'this creature enters with your choice of a vigilance counter or a reach counter on it')
```

Current worker: i-082ee249e8e32a1dc
Branch: codex/aws-card-fix-flycatcher-giraffid
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260604T121212Z-controller-dev-loop-wave0025
