### PR TITLE
Fix Ironsmith parse failure: Glissa Sunseeker

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/shared/util.rs
@@ -2731,6 +2731,17 @@ fn parse_value_expr_term_words(words: &[&str]) -> Option<(Value, usize)> {
         return Some((Value::Fixed(value), 1));
     }
 
+    if let Some(used) = [
+        &["the", "amount", "of", "unspent", "mana", "you", "have"][..],
+        &["amount", "of", "unspent", "mana", "you", "have"][..],
+        &["unspent", "mana", "you", "have"][..],
+    ]
+    .iter()
+    .find_map(|pattern| words.starts_with(pattern).then_some(pattern.len()))
+    {
+        return Some((Value::UnspentMana(PlayerFilter::You), used));
+    }
+
     if YOUR_SPEED_VALUE_PATTERN.matches_words(words) {
         return Some((Value::Speed(PlayerFilter::You), 2));
     }

--- a/crates/ironsmith-core/src/filter_model.rs
+++ b/crates/ironsmith-core/src/filter_model.rs
@@ -2566,6 +2566,15 @@ fn describe_comparison(cmp: &Comparison) -> String {
                     "that card's mana value".to_string()
                 }
             }
+            Value::UnspentMana(player) => {
+                let subject = player.description();
+                let verb = if matches!(player, PlayerFilter::You) {
+                    "have"
+                } else {
+                    "has"
+                };
+                format!("the amount of unspent mana {subject} {verb}")
+            }
             Value::Add(left, right) => {
                 format!(
                     "{} plus {}",

--- a/crates/ironsmith-core/src/value_model.rs
+++ b/crates/ironsmith-core/src/value_model.rs
@@ -90,6 +90,7 @@ pub enum Value {
     LifeTotal(PlayerFilter),
     LifeTotalAsTurnBegan(PlayerFilter),
     LifeTotalDifference(PlayerFilter),
+    UnspentMana(PlayerFilter),
     Speed(PlayerFilter),
     StartingLifeTotal(PlayerFilter),
     HalfLifeTotalRoundedUp(PlayerFilter),

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -35424,6 +35424,205 @@ fn zone_has_named_object(game: &crate::game_state::GameState, zone: Zone, name: 
         .any(|id| game.object(*id).is_some_and(|object| object.name == name))
 }
 
+fn glissa_sunseeker_conditional_destroy_effect(def: &CardDefinition) -> Effect {
+    def.abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Activated(activated) => activated.effects.segments[0]
+                .default_effects
+                .iter()
+                .find(|effect| {
+                    effect
+                        .downcast_ref::<crate::effects::ConditionalEffect>()
+                        .is_some()
+                })
+                .cloned(),
+            _ => None,
+        })
+        .expect("Glissa Sunseeker should have a conditional destroy effect")
+}
+
+fn glissa_sunseeker_target_only_effect(
+    def: &CardDefinition,
+) -> &crate::effects::TargetOnlyEffect {
+    def.abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Activated(activated) => activated.effects.segments[0]
+                .default_effects
+                .iter()
+                .find_map(|effect| {
+                    effect
+                        .downcast_ref::<crate::effects::TaggedEffect>()
+                        .and_then(|tagged| {
+                            tagged
+                                .effect
+                                .downcast_ref::<crate::effects::TargetOnlyEffect>()
+                        })
+                }),
+            _ => None,
+        })
+        .expect("Glissa Sunseeker should require an artifact target")
+}
+
+fn create_glissa_runtime_artifact(
+    game: &mut crate::game_state::GameState,
+    controller: PlayerId,
+    name: &str,
+    mana_value: u8,
+) -> ObjectId {
+    let def = CardDefinitionBuilder::new(CardId::new(), name)
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(
+            mana_value,
+        )]]))
+        .card_types(vec![CardType::Artifact])
+        .build();
+    game.create_object_from_definition(&def, controller, Zone::Battlefield)
+}
+
+fn create_glissa_runtime_creature(
+    game: &mut crate::game_state::GameState,
+    controller: PlayerId,
+    name: &str,
+) -> ObjectId {
+    let def = CardDefinitionBuilder::new(CardId::new(), name)
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(3)]]))
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(2, 2))
+        .build();
+    game.create_object_from_definition(&def, controller, Zone::Battlefield)
+}
+
+fn resolve_glissa_conditional_destroy(
+    game: &mut crate::game_state::GameState,
+    glissa_id: ObjectId,
+    controller: PlayerId,
+    target_id: ObjectId,
+) {
+    let def = parse_oracle_card_definition("Glissa Sunseeker");
+    let effect = glissa_sunseeker_conditional_destroy_effect(&def);
+    let target_snapshot = crate::snapshot::ObjectSnapshot::from_object(
+        game.object(target_id)
+            .expect("Glissa Sunseeker target should exist"),
+        game,
+    );
+    let tagged = HashMap::from([(
+        crate::tag::TagKey::from("targeted_0"),
+        vec![target_snapshot],
+    )]);
+    let mut ctx = crate::effects::ExecutionContext::new_default(glissa_id, controller)
+        .with_targets(vec![crate::effects::ResolvedTarget::Object(target_id)])
+        .with_tagged_objects(tagged);
+    crate::effects::execute_effect(game, &effect, &mut ctx)
+        .expect("Glissa Sunseeker conditional destroy should resolve");
+}
+
+#[test]
+fn glissa_sunseeker_strict_parser_and_compiled_text_regression() {
+    assert_oracle_card_parses_strict("Glissa Sunseeker");
+    let def = parse_oracle_card_definition("Glissa Sunseeker");
+    let rendered = crate::compiled_text::compiled_text_lines(&def);
+    let ability_debug = format!("{:?}", def.abilities);
+
+    assert_eq!(
+        rendered,
+        vec![
+            "First strike".to_string(),
+            "{T}: Destroy target artifact if its mana value is equal to the amount of unspent mana you have.".to_string(),
+        ],
+        "Glissa Sunseeker compiled text should preserve the conditional unspent-mana destroy clause"
+    );
+    assert!(
+        ability_debug.contains("ConditionalEffect")
+            && ability_debug.contains("EqualExpr")
+            && ability_debug.contains("UnspentMana"),
+        "Glissa Sunseeker should structurally compare target mana value to unspent mana, got {ability_debug}"
+    );
+}
+
+#[test]
+fn glissa_sunseeker_targets_artifacts_only() {
+    let def = parse_oracle_card_definition("Glissa Sunseeker");
+    let target_only = glissa_sunseeker_target_only_effect(&def);
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let mut game = crate::tests::test_helpers::setup_two_player_game();
+    let glissa_id = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let artifact_id = create_glissa_runtime_artifact(&mut game, bob, "Matching Artifact", 3);
+    let creature_id = create_glissa_runtime_creature(&mut game, bob, "Nonartifact Creature");
+    let ctx = crate::effects::ExecutionContext::new_default(glissa_id, alice);
+
+    assert!(
+        crate::effects::validate_target(
+            &game,
+            &crate::effects::ResolvedTarget::Object(artifact_id),
+            &target_only.target,
+            &ctx,
+        ),
+        "Glissa Sunseeker should allow artifact targets"
+    );
+    assert!(
+        !crate::effects::validate_target(
+            &game,
+            &crate::effects::ResolvedTarget::Object(creature_id),
+            &target_only.target,
+            &ctx,
+        ),
+        "Glissa Sunseeker should not allow nonartifact targets"
+    );
+}
+
+#[test]
+fn glissa_sunseeker_destroys_artifact_when_mana_value_equals_unspent_mana() {
+    let def = parse_oracle_card_definition("Glissa Sunseeker");
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let mut game = crate::tests::test_helpers::setup_two_player_game();
+    let glissa_id = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let artifact_id = create_glissa_runtime_artifact(&mut game, bob, "Matching Artifact", 3);
+    let artifact_stable = game.object(artifact_id).expect("artifact exists").stable_id;
+    game.player_mut(alice)
+        .expect("Alice exists")
+        .mana_pool
+        .add(ManaSymbol::Green, 3);
+
+    resolve_glissa_conditional_destroy(&mut game, glissa_id, alice, artifact_id);
+    let moved_id = game
+        .find_object_by_stable_id(artifact_stable)
+        .expect("destroyed artifact should still be tracked");
+    assert!(
+        game.player(bob)
+            .expect("Bob exists")
+            .graveyard
+            .contains(&moved_id),
+        "Glissa Sunseeker should destroy the artifact when its mana value equals your unspent mana"
+    );
+}
+
+#[test]
+fn glissa_sunseeker_leaves_artifact_when_unspent_mana_differs() {
+    let def = parse_oracle_card_definition("Glissa Sunseeker");
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let mut game = crate::tests::test_helpers::setup_two_player_game();
+    let glissa_id = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let artifact_id = create_glissa_runtime_artifact(&mut game, bob, "Mismatched Artifact", 3);
+    game.player_mut(alice)
+        .expect("Alice exists")
+        .mana_pool
+        .add(ManaSymbol::Green, 2);
+
+    resolve_glissa_conditional_destroy(&mut game, glissa_id, alice, artifact_id);
+    assert!(
+        game.objects_in_zone(Zone::Battlefield).contains(&artifact_id),
+        "Glissa Sunseeker should leave the artifact on the battlefield when unspent mana differs"
+    );
+    assert!(
+        !zone_has_named_object(&game, Zone::Graveyard, "Mismatched Artifact"),
+        "the failed conditional branch should not move the artifact to a graveyard"
+    );
+}
+
 #[test]
 fn death_rattle_oni_strict_parser_and_compiled_text_regression() {
     assert_oracle_card_parses_strict("Death-Rattle Oni");

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -8656,6 +8656,11 @@ pub(crate) fn describe_value(value: &Value) -> String {
             "the number of colors of mana spent to cast this spell".to_string()
         }
         Value::ManaSpentToCastThisSpell => "the amount of mana spent to cast this spell".to_string(),
+        Value::UnspentMana(player) => {
+            let subject = describe_player_filter(player);
+            let verb = player_verb(&subject, "have", "has");
+            format!("the amount of unspent mana {subject} {verb}")
+        }
         Value::MagicGamesLostToOpponentsSinceLastWin => {
             "the number of Magic games you've lost to one of your opponents since you last won a game against them".to_string()
         }

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -7326,6 +7326,9 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
     if let Some(compact) = describe_targeted_most_common_color_conditional_destroy(&filtered) {
         return compact;
     }
+    if let Some(compact) = describe_targeted_conditional_destroy(&filtered) {
+        return compact;
+    }
 
     fn describe_search_two_split_hand_graveyard(effects: &[&Effect]) -> Option<String> {
         let [
@@ -9259,6 +9262,42 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
             ));
         }
         if downcast_destroy(true_effect).is_some() {
+            return Some(format!("Destroy {target_text} if {condition_text}"));
+        }
+        None
+    }
+
+    fn describe_targeted_conditional_destroy(effects: &[&Effect]) -> Option<String> {
+        let [target_effect, conditional_effect] = effects else {
+            return None;
+        };
+        let target_tag = effect_tag(target_effect)?;
+        let target_only = downcast_target_only(target_effect)?;
+        let conditional = conditional_effect.downcast_ref::<crate::effects::ConditionalEffect>()?;
+        if !conditional.if_false.is_empty() || conditional.if_true.len() != 1 {
+            return None;
+        }
+        let crate::effect::Condition::TaggedObjectMatches(condition_tag, _) = &conditional.condition
+        else {
+            return None;
+        };
+        if condition_tag != target_tag {
+            return None;
+        }
+
+        let target_text = describe_choose_spec(&target_only.target);
+        let condition_text = describe_condition(&conditional.condition);
+        let true_effect = conditional.if_true.first()?;
+        if let Some(destroy) = downcast_destroy_no_regeneration(true_effect)
+            && destroy.spec == target_only.target
+        {
+            return Some(format!(
+                "Destroy {target_text} if {condition_text}. A creature destroyed this way can't be regenerated"
+            ));
+        }
+        if let Some(destroy) = downcast_destroy(true_effect)
+            && destroy.spec == target_only.target
+        {
             return Some(format!("Destroy {target_text} if {condition_text}"));
         }
         None

--- a/crates/ironsmith-runtime/src/continuous.rs
+++ b/crates/ironsmith-runtime/src/continuous.rs
@@ -4441,6 +4441,16 @@ fn resolve_value_with_context(
                 .map(|player| ctx.game.devotion_to_color(player.id, chosen) as i32)
                 .sum()
         }
+        Value::UnspentMana(player_filter) => {
+            let filter_ctx = continuous_filter_context(ctx.game, controller, source);
+            ctx.game
+                .players
+                .iter()
+                .filter(|player| player.is_in_game())
+                .filter(|player| player_filter.matches_player(player.id, &filter_ctx))
+                .map(|player| player.mana_pool.total() as i32)
+                .sum()
+        }
         Value::GreatestToughness(filter) => {
             let filter_ctx = continuous_filter_context(ctx.game, controller, source);
             let mut max_toughness = 0i32;

--- a/crates/ironsmith-runtime/src/dependency.rs
+++ b/crates/ironsmith-runtime/src/dependency.rs
@@ -1373,6 +1373,7 @@ fn value_references_pt(value: &Value) -> bool {
         | Value::Devotion { .. }
         | Value::DevotionToChosenColor(_)
         | Value::ManaSpentToCastThisSpell
+        | Value::UnspentMana(_)
         | Value::ColorsOfManaSpentToCastThisSpell
         | Value::ManaValueOf(_)
         | Value::LifeTotal(_)

--- a/crates/ironsmith-runtime/src/effects/helpers.rs
+++ b/crates/ironsmith-runtime/src/effects/helpers.rs
@@ -1545,6 +1545,17 @@ pub fn resolve_value(
             Ok(source_obj.mana_spent_to_cast.total() as i32)
         }
 
+        Value::UnspentMana(player) => {
+            let player_ids =
+                resolve_player_filter_to_list(game, player, &ctx.filter_context(game), ctx)?;
+            let total = player_ids
+                .iter()
+                .filter_map(|player_id| game.player(*player_id))
+                .map(|player| player.mana_pool.total() as i32)
+                .sum();
+            Ok(total)
+        }
+
         Value::ColorsOfManaSpentToCastThisSpell => {
             let Some(source_obj) = game.object(ctx.source) else {
                 return Ok(0);

--- a/crates/ironsmith-runtime/src/filter.rs
+++ b/crates/ironsmith-runtime/src/filter.rs
@@ -1015,6 +1015,15 @@ fn resolve_filter_comparison_rhs_value(
             }
             _ => None,
         },
+        Value::UnspentMana(player_filter) => Some(
+            game.players
+                .iter()
+                .filter(|player| {
+                    player.is_in_game() && player_filter.matches_player(player.id, ctx)
+                })
+                .map(|player| player.mana_pool.total() as i32)
+                .sum(),
+        ),
         _ => None,
     }
 }
@@ -4936,6 +4945,15 @@ fn describe_comparison(cmp: &Comparison) -> String {
                 } else {
                     "that card's mana value".to_string()
                 }
+            }
+            Value::UnspentMana(player) => {
+                let subject = player.description();
+                let verb = if matches!(player, PlayerFilter::You) {
+                    "have"
+                } else {
+                    "has"
+                };
+                format!("the amount of unspent mana {subject} {verb}")
             }
             Value::EffectValue(_) => "that result".to_string(),
             Value::EffectMetric {


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Glissa Sunseeker
Initial parse error:
```
unsupported conditional destroy clause (clause: 'target artifact if its mana value is equal to the amount of unspent mana you have'); oracle-only fallback also failed: unsupported conditional destroy clause (clause: 'target artifact if its mana value is equal to the amount of unspent mana you have')
```

Current worker: i-0761afd00790fa8f5
Branch: codex/aws-card-fix-glissa-sunseeker
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260604T121212Z-controller-dev-loop-wave0025
