### PR TITLE
Fix Ironsmith parse failure: Will Kenrith

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
@@ -5913,7 +5913,11 @@ fn compile_subject_verb_effect(
                 Vec::new(),
             ))
         }
-        SubjectVerbActionAst::ReduceMatchingSpellCostThisTurn { filter, reduction } => {
+        SubjectVerbActionAst::ReduceMatchingSpellCostThisTurn {
+            filter,
+            reduction,
+            duration,
+        } => {
             let subject = resolve_subject_verb_subject(role, player, ctx, false, false, true)?;
             let mut player_filter = subject.into_player_filter();
             let mut resolved_filter = resolve_it_tag(filter, &current_reference_env(ctx))?;
@@ -5926,10 +5930,11 @@ fn compile_subject_verb_effect(
             }
             Ok((
                 vec![Effect::new(
-                    crate::effects::GrantNextSpellCostReductionEffect::all_matching_this_turn(
+                    crate::effects::GrantNextSpellCostReductionEffect::all_matching_until(
                         player_filter,
                         resolved_filter,
                         reduction.clone(),
+                        duration.clone(),
                     ),
                 )],
                 Vec::new(),

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -1759,6 +1759,7 @@ pub(crate) enum SubjectVerbActionAst {
     ReduceMatchingSpellCostThisTurn {
         filter: ObjectFilter,
         reduction: Value,
+        duration: Until,
     },
     GrantNextSpellAbilityThisTurn {
         filter: ObjectFilter,
@@ -3359,10 +3360,15 @@ impl std::fmt::Debug for SubjectVerbActionAst {
                 .field("filter", filter)
                 .field("reduction", reduction)
                 .finish(),
-            Self::ReduceMatchingSpellCostThisTurn { filter, reduction } => f
+            Self::ReduceMatchingSpellCostThisTurn {
+                filter,
+                reduction,
+                duration,
+            } => f
                 .debug_struct("ReduceMatchingSpellCostThisTurn")
                 .field("filter", filter)
                 .field("reduction", reduction)
+                .field("duration", duration)
                 .finish(),
             Self::GrantNextSpellAbilityThisTurn { filter, ability } => f
                 .debug_struct("GrantNextSpellAbilityThisTurn")
@@ -5922,10 +5928,23 @@ impl EffectAst {
         filter: ObjectFilter,
         reduction: Value,
     ) -> Self {
+        Self::subject_verb_reduce_matching_spell_cost(player, filter, reduction, Until::EndOfTurn)
+    }
+
+    pub(crate) fn subject_verb_reduce_matching_spell_cost(
+        player: PlayerAst,
+        filter: ObjectFilter,
+        reduction: Value,
+        duration: Until,
+    ) -> Self {
         Self::subject_verb(
             SubjectVerbRoleAst::AffectedPlayer,
             player,
-            SubjectVerbActionAst::ReduceMatchingSpellCostThisTurn { filter, reduction },
+            SubjectVerbActionAst::ReduceMatchingSpellCostThisTurn {
+                filter,
+                reduction,
+                duration,
+            },
         )
     }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_pattern_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/clause_pattern_helpers.rs
@@ -1063,6 +1063,12 @@ pub(crate) fn parse_copy_spell_clause(
     let clause = LexedClause::new(tokens);
     let clause_words = clause.word_refs();
     let clause_text = clause.text();
+    if clause_words
+        .windows(2)
+        .any(|words| matches!(words, ["emblem", "with"]))
+    {
+        return Ok(None);
+    }
     let Some(copy_idx) = find_token_index(tokens, |token| {
         CLAUSE_COPY_OR_COPIES_WORD_PATTERN.matches_token(token)
     }) else {

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_inner/generic_subject_verb_programs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_inner/generic_subject_verb_programs.rs
@@ -477,6 +477,20 @@ const TARGET_GETS_THEN_GAINS_PATTERN: LexPattern<'static> = LexPattern::new(&[
     LexPattern::any_phrase(TARGET_GETS_THEN_GAINS_GRANT_PHRASES),
     LexPattern::tail("ability_tail", LexCaptureKind::Rest),
 ]);
+const TARGET_HAS_BASE_PT_THEN_LOSES_PHRASES: &[&[&str]] = &[&["and", "lose"], &["and", "loses"]];
+const TARGET_HAS_BASE_PT_THEN_LOSES_PATTERN: LexPattern<'static> = LexPattern::new(&[
+    LexPattern::subject(
+        "subject",
+        LexCaptureKind::UntilAnyPhrase(&[&["has"], &["have"]]),
+    ),
+    LexPattern::action("has_action", LexCaptureKind::OneOf(&["has", "have"])),
+    LexPattern::capture(
+        "base_pt_clause",
+        LexCaptureKind::UntilAnyPhrase(TARGET_HAS_BASE_PT_THEN_LOSES_PHRASES),
+    ),
+    LexPattern::any_phrase(TARGET_HAS_BASE_PT_THEN_LOSES_PHRASES),
+    LexPattern::tail("ability_tail", LexCaptureKind::Rest),
+]);
 const TARGET_CONTROLLED_PUMP_GRANTED_ABILITY_PATTERN: LexPattern<'static> = LexPattern::new(&[
     LexPattern::any_phrase(TARGET_GETS_THEN_GAINS_GRANT_PHRASES),
     LexPattern::tail("ability_tail", LexCaptureKind::Rest),
@@ -736,6 +750,12 @@ pub(crate) fn parse_top_level_subject_verb_recognition(
             effects,
         )));
     }
+    if let Some(effects) = parse_target_has_base_pt_then_loses_subject_verb(tokens)? {
+        return Ok(Some((
+            "subject-verb verb=Have subject=target recognizer=shared-subject-base-pt-lose",
+            effects,
+        )));
+    }
 
     let program = if let Some(effect) = parse_generic_meld_subject_verb(tokens)? {
         Some(GenericTopLevelProgram::Meld { effect })
@@ -923,6 +943,25 @@ fn parse_target_gets_then_gains_subject_verb(
     if has_where_x_value_binding(tokens) {
         return Ok(None);
     }
+    super::gain_ability::parse_gain_ability_sentence(tokens)
+}
+
+fn parse_target_has_base_pt_then_loses_subject_verb(
+    tokens: &[OwnedLexToken],
+) -> Result<Option<Vec<EffectAst>>, CardTextError> {
+    let clause = LexedClause::new(tokens).trimmed();
+    let Some(matched) = TARGET_HAS_BASE_PT_THEN_LOSES_PATTERN.match_clause(clause) else {
+        return Ok(None);
+    };
+    let Some(base_pt_clause) = matched.capture_clause("base_pt_clause", clause) else {
+        return Ok(None);
+    };
+    if !base_pt_clause.starts_with(&["base", "power", "and", "toughness"]) {
+        return Ok(None);
+    }
+    let Some(_ability_tail) = matched.capture_clause_by_role(LexCaptureRole::Tail, clause) else {
+        return Ok(None);
+    };
     super::gain_ability::parse_gain_ability_sentence(tokens)
 }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_inner/labeled_prefixes.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_inner/labeled_prefixes.rs
@@ -533,13 +533,16 @@ fn parse_matching_spell_cost_reduction_this_turn_sentence_lexed(
     let less_idx = word_slice_find_word(clause_words.as_slice(), "less")?;
 
     let has_you_cast = word_slice_contains_phrase(&clause_words, &["you", "cast"]);
+    let has_that_player_casts = word_slice_contains_phrase(&clause_words, &["that", "player", "casts"]);
     let has_chosen_name = word_slice_contains_phrase(&clause_words, &["with", "chosen", "name"])
         || word_slice_contains_phrase(&clause_words, &["with", "the", "chosen", "name"]);
+    let has_this_turn_duration = word_slice_contains_phrase(&clause_words, &["this", "turn"]);
+    let has_until_your_next_turn_duration = clause_words.starts_with(&["until", "your", "next", "turn"]);
 
     if cost_idx <= spell_idx
         || less_idx <= cost_idx
-        || (!has_you_cast && !has_chosen_name)
-        || !word_slice_contains_phrase(&clause_words, &["this", "turn"])
+        || (!has_you_cast && !has_that_player_casts && !has_chosen_name)
+        || (!has_this_turn_duration && !has_until_your_next_turn_duration)
         || clause_words.get(less_idx + 1).copied() != Some("to")
         || clause_words.get(less_idx + 2).copied() != Some("cast")
     {
@@ -549,7 +552,12 @@ fn parse_matching_spell_cost_reduction_this_turn_sentence_lexed(
     let spell_token_idx = words.token_index_for_word_index(spell_idx)?;
     let cost_token_idx = words.token_index_for_word_index(cost_idx)?;
     let less_token_idx = words.token_index_for_word_index(less_idx)?;
-    let subject_tokens = trim_edge_punctuation(&tokens[..=spell_token_idx]);
+    let subject_start_token_idx = if has_until_your_next_turn_duration {
+        words.token_index_for_word_index(4)?
+    } else {
+        0
+    };
+    let subject_tokens = trim_edge_punctuation(&tokens[subject_start_token_idx..=spell_token_idx]);
     let reduction_tokens = trim_edge_punctuation(&tokens[cost_token_idx + 1..less_token_idx]);
     let (mut reduction, used) = parse_value(&reduction_tokens)?;
     if used != reduction_tokens.len() {
@@ -568,6 +576,9 @@ fn parse_matching_spell_cost_reduction_this_turn_sentence_lexed(
     let player = if has_you_cast {
         filter.cast_by = Some(PlayerFilter::You);
         PlayerAst::You
+    } else if has_that_player_casts {
+        filter.cast_by = Some(PlayerFilter::IteratedPlayer);
+        PlayerAst::That
     } else {
         PlayerAst::Any
     };
@@ -593,11 +604,20 @@ fn parse_matching_spell_cost_reduction_this_turn_sentence_lexed(
             mana_reduction,
         ))
     } else {
-        Some(EffectAst::subject_verb_reduce_matching_spell_cost_this_turn(
-            player,
-            filter,
-            reduction,
-        ))
+        let duration = if has_until_your_next_turn_duration {
+            Until::YourNextTurn
+        } else {
+            Until::EndOfTurn
+        };
+        if duration == Until::EndOfTurn {
+            Some(EffectAst::subject_verb_reduce_matching_spell_cost_this_turn(
+                player, filter, reduction,
+            ))
+        } else {
+            Some(EffectAst::subject_verb_reduce_matching_spell_cost(
+                player, filter, reduction, duration,
+            ))
+        }
     }
 }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/for_each_helpers.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/for_each_helpers.rs
@@ -477,7 +477,15 @@ pub(crate) fn parse_has_base_power_toughness_clause(
     }
     let is_shared_gain_tail = matches!(
         tail,
-        ["until", "end", "of", "turn", "and", "gain", ..]
+        ["and", "gain", ..]
+            | ["and", "gains", ..]
+            | ["and", "lose", ..]
+            | ["and", "loses", ..]
+            | ["and", "has", ..]
+            | ["and", "have", ..]
+            | ["and", "get", ..]
+            | ["and", "gets", ..]
+            | ["until", "end", "of", "turn", "and", "gain", ..]
             | ["until", "end", "of", "turn", "and", "gains", ..]
             | ["until", "end", "of", "turn", "and", "lose", ..]
             | ["until", "end", "of", "turn", "and", "loses", ..]

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/gain_ability.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/gain_ability.rs
@@ -106,6 +106,7 @@ const GET_OR_GETS_WORD_PATTERN: ClauseShape<'static> =
     clause_shape!(exact_any & [&["get"], &["gets"]]);
 const AND_WORD_PATTERN: ClauseShape<'static> = clause_shape!(exact & ["and"]);
 const SHARED_GAIN_TAIL_PATTERNS: &[&[&str]] = &[&["and", "gain"], &["and", "gains"]];
+const SHARED_LOSE_TAIL_PATTERNS: &[&[&str]] = &[&["and", "lose"], &["and", "loses"]];
 const SHARED_GET_TAIL_PATTERNS: &[&[&str]] = &[&["and", "get"], &["and", "gets"]];
 const SHARED_HAS_TAIL_PATTERNS: &[&[&str]] = &[&["and", "has"], &["and", "have"]];
 const SIMPLE_DURATION_PATTERNS: &[(&[&str], (usize, Until))] = &[
@@ -336,6 +337,7 @@ fn parse_leading_subject_base_pt_before_gain(
     before_gain: &[&str],
     subject_start_word_idx: usize,
     gain_idx: usize,
+    duration: &Until,
 ) -> Result<Option<SharedSubjectBasePt>, CardTextError> {
     let Some(local_has_idx) = before_gain
         .iter()
@@ -357,7 +359,9 @@ fn parse_leading_subject_base_pt_before_gain(
         ))
     })?;
     let tail = &rest[5..];
+    let is_shared_tail_separator = tail == ["and"];
     if !tail.is_empty()
+        && !is_shared_tail_separator
         && !is_until_end_of_turn(tail)
         && !UNTIL_END_OF_TURN_AND_TAIL_PATTERN.matches_words(tail)
     {
@@ -370,7 +374,7 @@ fn parse_leading_subject_base_pt_before_gain(
     if has_word_idx >= gain_idx {
         return Ok(None);
     }
-    Ok(Some((power, toughness, has_word_idx, Until::EndOfTurn)))
+    Ok(Some((power, toughness, has_word_idx, duration.clone())))
 }
 
 fn parse_shared_subject_pump_from_get_tail(
@@ -1281,6 +1285,7 @@ pub(crate) fn parse_gain_ability_sentence(
         let after_has = &word_list[gain_idx + 1..];
         if BASE_POWER_TOUGHNESS_PREFIX_PATTERN.matches_words(after_has) {
             gain_find_any_phrase_start(after_has, SHARED_GAIN_TAIL_PATTERNS)
+                .or_else(|| gain_find_any_phrase_start(after_has, SHARED_LOSE_TAIL_PATTERNS))
                 .map(|(_, shared_idx)| gain_idx + 1 + shared_idx + 1)
                 .unwrap_or(gain_idx)
         } else {
@@ -1526,11 +1531,8 @@ pub(crate) fn parse_gain_ability_sentence(
         None
     };
     let get_idx = GET_OR_GETS_WORD_PATTERN.find_word(before_gain);
-    let leading_base_pt_effect = if !losing {
-        parse_leading_subject_base_pt_before_gain(before_gain, subject_start_word_idx, gain_idx)?
-    } else {
-        None
-    };
+    let leading_base_pt_effect =
+        parse_leading_subject_base_pt_before_gain(before_gain, subject_start_word_idx, gain_idx, &duration)?;
     let pump_effect = if let Some(gi) = get_idx {
         let modifier_start_word_idx = subject_start_word_idx + gi + 1;
         let Some(modifier_start_token_idx) =

--- a/crates/ironsmith-core/src/effect.rs
+++ b/crates/ironsmith-core/src/effect.rs
@@ -1988,6 +1988,7 @@ pub struct GrantNextSpellCostReductionEffect {
     pub reduction: crate::mana::ManaCost,
     pub generic_reduction: Option<Value>,
     pub applies_to_all_matching_this_turn: bool,
+    pub duration: Until,
 }
 
 impl GrantNextSpellCostReductionEffect {
@@ -2002,6 +2003,7 @@ impl GrantNextSpellCostReductionEffect {
             reduction,
             generic_reduction: None,
             applies_to_all_matching_this_turn: false,
+            duration: Until::EndOfTurn,
         }
     }
 
@@ -2016,6 +2018,23 @@ impl GrantNextSpellCostReductionEffect {
             reduction: crate::mana::ManaCost::new(),
             generic_reduction: Some(generic_reduction.into()),
             applies_to_all_matching_this_turn: true,
+            duration: Until::EndOfTurn,
+        }
+    }
+
+    pub fn all_matching_until(
+        player: PlayerFilter,
+        filter: ObjectFilter,
+        generic_reduction: impl Into<Value>,
+        duration: Until,
+    ) -> Self {
+        Self {
+            player,
+            filter,
+            reduction: crate::mana::ManaCost::new(),
+            generic_reduction: Some(generic_reduction.into()),
+            applies_to_all_matching_this_turn: true,
+            duration,
         }
     }
 }

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -241,6 +241,57 @@ fn rayne_academy_chancellor_strict_parser_and_compiled_text_regression() {
 }
 
 #[test]
+fn will_kenrith_strict_parser_compiled_text_and_model_regression() {
+    assert_oracle_card_parses_strict("Will Kenrith");
+
+    let oracle = oracle_text_by_name()
+        .get("Will Kenrith")
+        .expect("Will Kenrith oracle text should exist")
+        .clone();
+    let def = CardDefinitionBuilder::new(CardId::new(), "Will Kenrith")
+        .supertypes(vec![Supertype::Legendary])
+        .card_types(vec![CardType::Planeswalker])
+        .loyalty(4)
+        .parse_text(oracle)
+        .expect("Will Kenrith oracle text should parse");
+    let rendered = compiled_text_lines(&def).join("\n");
+    let abilities_debug = format!("{:#?}", def.abilities);
+
+    assert!(
+        rendered.contains(
+            "+2: Until your next turn, up to two target creatures each have base power and toughness 0/3 and lose all abilities."
+        ),
+        "expected Will Kenrith +2 compiled text to preserve shared base P/T and lose-abilities clause, got {rendered}"
+    );
+    assert!(
+        rendered.contains(
+            "Target player draws two cards. Until your next turn, instant, sorcery, and planeswalker spells that player casts cost {2} less to cast."
+        ),
+        "expected Will Kenrith -2 compiled text to preserve target-player cost reduction, got {rendered}"
+    );
+    assert!(
+        rendered.contains(
+            "Target player gets an emblem with \"Whenever you cast an instant or sorcery spell, copy it. You may choose new targets for the copy.\""
+        ),
+        "expected Will Kenrith -8 compiled text to preserve target-player emblem, got {rendered}"
+    );
+    assert!(
+        rendered.contains("Partner with Rowan Kenrith")
+            && rendered.contains("Will Kenrith can be your commander."),
+        "expected Will Kenrith commander text to render, got {rendered}"
+    );
+    assert!(
+        abilities_debug.contains("SetPowerToughness")
+            && abilities_debug.contains("RemoveAllAbilities")
+            && abilities_debug.contains("max: Some")
+            && abilities_debug.contains("GrantNextSpellCostReductionEffect")
+            && abilities_debug.contains("duration: YourNextTurn")
+            && abilities_debug.contains("CreateEmblemEffect"),
+        "expected Will Kenrith to model shared targets, timed cost reduction, and target-player emblem, got {abilities_debug}"
+    );
+}
+
+#[test]
 fn rayne_academy_chancellor_targeting_trigger_draws_conditionally_at_runtime() {
     struct AcceptMayDecisionMaker;
     impl crate::decision::DecisionMaker for AcceptMayDecisionMaker {

--- a/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
@@ -2938,6 +2938,9 @@ fn ability_prefers_card_name_subject(ability: &Ability) -> bool {
     let AbilityKind::Static(static_ability) = &ability.kind else {
         return false;
     };
+    if static_ability.id() == crate::static_abilities::StaticAbilityId::CanBeCommander {
+        return true;
+    }
     static_ability
         .enter_as_copy_as_enters()
         .is_some_and(|spec| spec.linked_exile_pair.is_some())

--- a/crates/ironsmith-runtime/src/compiled_text/debug_safe.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/debug_safe.rs
@@ -34,7 +34,48 @@ fn mechanical_cleanup(line: String) -> String {
     let line = normalize_debug_safe_mana_symbol_case(&line);
     let line = strip_parenthetical_text(&line);
     let line = normalize_debug_safe_spelling_surface(&line);
+    let line = normalize_until_your_next_turn_duration_order(&line);
     normalize_each_player_x_token_damage_pair(&line)
+}
+
+fn lower_first_ascii(text: &str) -> String {
+    let Some(first) = text.chars().next() else {
+        return String::new();
+    };
+    let rest = &text[first.len_utf8()..];
+    format!("{}{}", first.to_ascii_lowercase(), rest)
+}
+
+fn normalize_until_your_next_turn_duration_order(line: &str) -> String {
+    let trimmed = line.trim();
+    let had_period = trimmed.ends_with('.');
+    let without_period = trimmed.trim_end_matches('.');
+    let Some(body) = without_period.strip_suffix(" until your next turn") else {
+        return line.to_string();
+    };
+    if body.starts_with("Until your next turn") {
+        return line.to_string();
+    }
+    let (prefix, duration_body) = if let Some((head, tail)) = body.rsplit_once(". ") {
+        (format!("{head}. "), tail)
+    } else if let Some((head, tail)) = body.split_once(": ") {
+        (format!("{head}: "), tail)
+    } else {
+        (String::new(), body)
+    };
+    let mut normalized = format!(
+        "{}Until your next turn, {}",
+        prefix,
+        lower_first_ascii(duration_body)
+    );
+    normalized = normalized.replace(
+        " target creatures have base power and toughness ",
+        " target creatures each have base power and toughness ",
+    );
+    if had_period {
+        normalized.push('.');
+    }
+    normalized
 }
 
 fn normalize_debug_safe_sentence_surface(line: &str) -> String {

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -9323,7 +9323,11 @@ pub(super) fn describe_apply_continuous_clauses(
                 ));
             }
             crate::effects::continuous::RuntimeModification::RemoveAllAbilities => {
-                clauses.push("loses all abilities".to_string());
+                clauses.push(if plural_target {
+                    "lose all abilities".to_string()
+                } else {
+                    "loses all abilities".to_string()
+                });
             }
             crate::effects::continuous::RuntimeModification::RemoveThisAbility => {
                 clauses.push("loses this ability".to_string());

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -32097,6 +32097,22 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
         );
     }
     if let Some(for_players) = effect.downcast_ref::<crate::effects::ForPlayersEffect>() {
+        if let [inner] = for_players.effects.as_slice()
+            && let Some(create_emblem) = inner.downcast_ref::<crate::effects::CreateEmblemEffect>()
+        {
+            let subject = match &for_players.filter {
+                PlayerFilter::Target(inner) if **inner == PlayerFilter::Any => {
+                    "Target player".to_string()
+                }
+                filter => capitalize_first(&describe_player_filter(filter)),
+            };
+            let emblem_text = create_emblem.emblem.text.trim();
+            if !emblem_text.is_empty() {
+                let emblem_text = capitalize_first(&ensure_trailing_period(emblem_text));
+                return format!("{subject} gets an emblem with \"{emblem_text}\"");
+            }
+            return format!("{subject} gets an emblem named {}", create_emblem.emblem.name);
+        }
         if let Some(compact) = describe_each_player_return_from_graveyard_to_hand(for_players) {
             return compact;
         }
@@ -38568,10 +38584,27 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
             })
             .unwrap_or(spell_text);
         let player_suffix = format!(" cast by {player_text}");
+        let cast_by_text = grant_next_spell_cost_reduction
+            .filter
+            .cast_by
+            .as_ref()
+            .map(describe_player_filter);
+        let cast_by_suffix = cast_by_text
+            .as_ref()
+            .map(|text| format!(" cast by {text}"));
         let spell_text = spell_text
             .strip_suffix(player_suffix.as_str())
+            .or_else(|| {
+                cast_by_suffix
+                    .as_ref()
+                    .and_then(|suffix| spell_text.strip_suffix(suffix.as_str()))
+            })
             .unwrap_or(spell_text.as_str());
         if grant_next_spell_cost_reduction.applies_to_all_matching_this_turn {
+            let duration_text = match grant_next_spell_cost_reduction.duration {
+                Until::EndOfTurn => "this turn".to_string(),
+                _ => describe_until(&grant_next_spell_cost_reduction.duration),
+            };
             let (reduction, where_suffix) = grant_next_spell_cost_reduction
                 .generic_reduction
                 .as_ref()
@@ -38606,23 +38639,51 @@ pub(super) fn describe_effect_impl(effect: &Effect) -> String {
             } else {
                 format!("{spell_text} spells")
             };
+            if let Some(cast_by) = grant_next_spell_cost_reduction.filter.cast_by.as_ref() {
+                let caster_text = if matches!(cast_by, PlayerFilter::Target(_)) {
+                    "that player".to_string()
+                } else {
+                    describe_player_filter(cast_by)
+                };
+                let plural_spell_text = if !grant_next_spell_cost_reduction.filter.card_types.is_empty()
+                {
+                    let card_type_words = grant_next_spell_cost_reduction
+                        .filter
+                        .card_types
+                        .iter()
+                        .map(|card_type| describe_card_type_word_local(*card_type).to_string())
+                        .collect::<Vec<_>>();
+                    format!("{} spells", join_with_and(&card_type_words))
+                } else {
+                    plural_spell_text
+                };
+                return format!(
+                    "{} {} casts cost {} less to cast {}{}",
+                    plural_spell_text, caster_text, reduction, duration_text, where_suffix,
+                );
+            }
             if grant_next_spell_cost_reduction.filter.cast_by.is_none()
                 && grant_next_spell_cost_reduction.filter.zone.is_none()
             {
                 return format!(
-                    "{} cost {} less to cast this turn{}",
-                    plural_spell_text, reduction, where_suffix,
+                    "{} cost {} less to cast {}{}",
+                    plural_spell_text, reduction, duration_text, where_suffix,
                 );
             }
             return format!(
-                "{} this turn cost {} less to cast{}",
-                plural_spell_text, reduction, where_suffix,
+                "{} {} cost {} less to cast{}",
+                plural_spell_text, duration_text, reduction, where_suffix,
             );
         }
+        let duration_text = match grant_next_spell_cost_reduction.duration {
+            Until::EndOfTurn => "this turn".to_string(),
+            _ => describe_until(&grant_next_spell_cost_reduction.duration),
+        };
         return format!(
-            "The next {} {} cast this turn costs {} less to cast",
+            "The next {} {} cast {} costs {} less to cast",
             spell_text,
             player_text,
+            duration_text,
             grant_next_spell_cost_reduction.reduction.to_oracle(),
         );
     }
@@ -42314,6 +42375,11 @@ pub(super) fn describe_ability(
                     }
                 }
                 return lines;
+            }
+            if static_ability.id() == crate::static_abilities::StaticAbilityId::CanBeCommander {
+                return vec![format!(
+                    "Static ability {index}: {subject} can be your commander"
+                )];
             }
             let normalized = normalize_sentence_surface_style(static_ability.display().trim());
             let lower = normalized.to_ascii_lowercase();

--- a/crates/ironsmith-runtime/src/decision/mana.rs
+++ b/crates/ironsmith-runtime/src/decision/mana.rs
@@ -3095,7 +3095,7 @@ pub(crate) fn apply_spell_cost_modifiers(
 
     let current_turn = game.turn.turn_number;
     for effect in &game.effect_store.temporary_spell_cost_reductions {
-        if effect.player != player || effect.is_expired(current_turn) {
+        if effect.player != player || effect.is_expired(current_turn, game.turn.active_player) {
             continue;
         }
         let temporary_ctx = with_source_exiled_tagged_objects(

--- a/crates/ironsmith-runtime/src/decision/types.rs
+++ b/crates/ironsmith-runtime/src/decision/types.rs
@@ -403,7 +403,10 @@ impl<'a> CastLegalityContext<'a> {
                 .effect_store
                 .temporary_spell_cost_reductions
                 .iter()
-                .any(|effect| effect.player == player && !effect.is_expired(game.turn.turn_number)),
+                .any(|effect| {
+                    effect.player == player
+                        && !effect.is_expired(game.turn.turn_number, game.turn.active_player)
+                }),
             minimum_total_spell_mana_payment: game.minimum_total_spell_mana_payment(),
             strips_life_pips_for_casts: game.player_cant_pay_life_to_cast_or_activate(player),
             perf: RefCell::new(CastLegalityPerfBreakdown::default()),

--- a/crates/ironsmith-runtime/src/effects/player/create_emblem.rs
+++ b/crates/ironsmith-runtime/src/effects/player/create_emblem.rs
@@ -44,8 +44,8 @@ impl EffectExecutor for CreateEmblemEffect {
             .collect();
 
         // Create emblem using the proper constructor
-        let emblem_obj =
-            Object::new_emblem(id, ctx.controller, self.emblem.name.clone(), abilities);
+        let owner = ctx.iteration.iterated_player.unwrap_or(ctx.controller);
+        let emblem_obj = Object::new_emblem(id, owner, self.emblem.name.clone(), abilities);
 
         // add_object handles adding to command_zone for Zone::Command
         game.add_object(emblem_obj);

--- a/crates/ironsmith-runtime/src/effects/player/grant_next_spell_cost_reduction.rs
+++ b/crates/ironsmith-runtime/src/effects/player/grant_next_spell_cost_reduction.rs
@@ -5,6 +5,7 @@ use crate::effects::EffectExecutor;
 use crate::effects::helpers::{resolve_player_filter_to_list, resolve_value};
 use crate::effects::{ExecutionContext, ExecutionError};
 use crate::game_state::GameState;
+use crate::ids::PlayerId;
 
 pub type GrantNextSpellCostReductionEffect = ironsmith_core::GrantNextSpellCostReductionEffect;
 
@@ -25,24 +26,77 @@ impl EffectExecutor for GrantNextSpellCostReductionEffect {
                 .unwrap_or(0)
                 .max(0);
             for player in players {
-                game.add_temporary_matching_spell_cost_reduction_this_turn(
+                let mut filter = self.filter.clone();
+                lock_target_player_filters_for_player(&mut filter, player);
+                game.add_temporary_matching_spell_cost_reduction_until(
                     player,
                     ctx.source,
-                    self.filter.clone(),
+                    ctx.controller,
+                    filter,
                     crate::effect::Value::Fixed(amount),
+                    self.duration.clone(),
                 );
             }
         } else {
             for player in players {
-                game.add_temporary_spell_cost_reduction(
+                let mut filter = self.filter.clone();
+                lock_target_player_filters_for_player(&mut filter, player);
+                game.add_temporary_spell_cost_reduction_until(
                     player,
                     ctx.source,
-                    self.filter.clone(),
+                    ctx.controller,
+                    filter,
                     self.reduction.clone(),
                     1,
+                    self.duration.clone(),
                 );
             }
         }
         Ok(EffectOutcome::resolved())
+    }
+}
+
+fn lock_target_player_filters_for_player(
+    filter: &mut crate::target::ObjectFilter,
+    player: PlayerId,
+) {
+    if let Some(controller) = &mut filter.controller {
+        lock_target_player_filter(controller, player);
+    }
+    if let Some(owner) = &mut filter.owner {
+        lock_target_player_filter(owner, player);
+    }
+    if let Some(cast_by) = &mut filter.cast_by {
+        lock_target_player_filter(cast_by, player);
+    }
+    if let Some(targets_player) = &mut filter.targets_player {
+        lock_target_player_filter(targets_player, player);
+    }
+    if let Some(targets_only_player) = &mut filter.targets_only_player {
+        lock_target_player_filter(targets_only_player, player);
+    }
+    if let Some(entered_controller) = &mut filter.entered_battlefield_controller {
+        lock_target_player_filter(entered_controller, player);
+    }
+    for nested in &mut filter.any_of {
+        lock_target_player_filters_for_player(nested, player);
+    }
+}
+
+fn lock_target_player_filter(filter: &mut crate::target::PlayerFilter, player: PlayerId) {
+    match filter {
+        crate::target::PlayerFilter::Target(_) => {
+            *filter = crate::target::PlayerFilter::Specific(player);
+        }
+        crate::target::PlayerFilter::CardsInHandAtLeastMoreThanYou { base, .. }
+        | crate::target::PlayerFilter::HasMoreLifeThanYou { base }
+        | crate::target::PlayerFilter::MaxSpeed { base, .. } => {
+            lock_target_player_filter(base, player);
+        }
+        crate::target::PlayerFilter::Excluding { base, excluded } => {
+            lock_target_player_filter(base, player);
+            lock_target_player_filter(excluded, player);
+        }
+        _ => {}
     }
 }

--- a/crates/ironsmith-runtime/src/game_loop/priority_mana.rs
+++ b/crates/ironsmith-runtime/src/game_loop/priority_mana.rs
@@ -3953,7 +3953,7 @@ pub(super) fn finalize_spell_cast(
             .iter()
             .enumerate()
             .filter_map(|(idx, effect)| {
-                if effect.player != caster || effect.is_expired(current_turn) {
+                if effect.player != caster || effect.is_expired(current_turn, game.turn.active_player) {
                     return None;
                 }
                 let mut cast_filter = effect.filter.clone();

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -38,6 +38,57 @@ fn setup_three_player_game() -> GameState {
     )
 }
 
+fn will_kenrith_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::from_raw(567_555), "Will Kenrith")
+        .mana_cost(ManaCost::from_pips(vec![
+            vec![ManaSymbol::Generic(4)],
+            vec![ManaSymbol::Blue],
+            vec![ManaSymbol::Blue],
+        ]))
+        .supertypes(vec![Supertype::Legendary])
+        .card_types(vec![CardType::Planeswalker])
+        .loyalty(4)
+        .parse_text(
+            "+2: Until your next turn, up to two target creatures each have base power and toughness 0/3 and lose all abilities.\n\
+             -2: Target player draws two cards. Until your next turn, instant, sorcery, and planeswalker spells that player casts cost {2} less to cast.\n\
+             -8: Target player gets an emblem with \"Whenever you cast an instant or sorcery spell, copy it. You may choose new targets for the copy.\"\n\
+             Partner with Rowan Kenrith\n\
+             Will Kenrith can be your commander.",
+        )
+        .expect("Will Kenrith should parse for runtime tests")
+}
+
+fn resolve_will_kenrith_loyalty_ability(
+    game: &mut GameState,
+    source: ObjectId,
+    controller: PlayerId,
+    cost_markers: &[&str],
+    targets: Vec<crate::effects::ResolvedTarget>,
+) {
+    let def = will_kenrith_definition();
+    let activated = def
+        .abilities
+        .iter()
+        .find_map(|ability| match &ability.kind {
+            AbilityKind::Activated(activated) => {
+                let cost_debug = format!("{:?}", activated.mana_cost);
+                cost_markers
+                    .iter()
+                    .all(|marker| cost_debug.contains(marker))
+                    .then_some(activated)
+            }
+            _ => None,
+        })
+        .unwrap_or_else(|| panic!("Will Kenrith should have loyalty ability matching {cost_markers:?}"));
+
+    let mut ctx = crate::effects::ExecutionContext::new_default(source, controller)
+        .with_targets(targets);
+    for effect in activated.effects.flattened_default_effects() {
+        crate::effects::execute_effect(game, effect, &mut ctx)
+            .expect("Will Kenrith loyalty ability effect should resolve");
+    }
+}
+
 fn component_pouch_definition() -> crate::cards::CardDefinition {
     CardDefinitionBuilder::new(CardId::from_raw(900_071), "Component Pouch")
         .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(3)]]))
@@ -40199,6 +40250,266 @@ fn commander_liara_portyr_runtime_has_no_reduction_without_attacked_players() {
         game.exile.len(),
         exile_before,
         "without attacked players, Commander Liara Portyr should leave exile unchanged"
+    );
+}
+
+#[test]
+fn will_kenrith_plus_two_sets_base_pt_and_removes_abilities_until_next_turn() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let will_def = will_kenrith_definition();
+    let will = game.create_object_from_definition(&will_def, alice, Zone::Battlefield);
+
+    let creature_with_keywords = |name: &str, power: i32, toughness: i32| {
+        CardDefinitionBuilder::new(CardId::new(), name)
+            .card_types(vec![CardType::Creature])
+            .power_toughness(PowerToughness::fixed(power, toughness))
+            .parse_text("Flying\nTrample")
+            .expect("keyword creature should parse")
+    };
+    let first = game.create_object_from_definition(
+        &creature_with_keywords("Will Kenrith First Target", 4, 4),
+        bob,
+        Zone::Battlefield,
+    );
+    let second = game.create_object_from_definition(
+        &creature_with_keywords("Will Kenrith Second Target", 6, 6),
+        bob,
+        Zone::Battlefield,
+    );
+    let untouched = game.create_object_from_definition(
+        &creature_with_keywords("Will Kenrith Untouched Creature", 5, 5),
+        bob,
+        Zone::Battlefield,
+    );
+
+    resolve_will_kenrith_loyalty_ability(
+        &mut game,
+        will,
+        alice,
+        &["PutCountersEffect"],
+        vec![
+            crate::effects::ResolvedTarget::Object(first),
+            crate::effects::ResolvedTarget::Object(second),
+        ],
+    );
+
+    for target in [first, second] {
+        let characteristics = game
+            .calculated_characteristics(target)
+            .expect("targeted creature should have calculated characteristics");
+        assert_eq!(
+            (characteristics.power, characteristics.toughness),
+            (Some(0), Some(3)),
+            "Will Kenrith +2 should set each targeted creature's base power/toughness to 0/3"
+        );
+        assert!(
+            !game.object_has_ability(target, &StaticAbility::flying())
+                && !game.object_has_ability(target, &StaticAbility::trample()),
+            "Will Kenrith +2 should remove all abilities from each targeted creature"
+        );
+    }
+
+    assert_eq!(
+        (game.calculated_power(untouched), game.calculated_toughness(untouched)),
+        (Some(5), Some(5)),
+        "Will Kenrith +2 should not affect creatures beyond the two selected targets"
+    );
+    assert!(
+        game.object_has_ability(untouched, &StaticAbility::flying())
+            && game.object_has_ability(untouched, &StaticAbility::trample()),
+        "unselected creature should keep its abilities"
+    );
+
+    game.turn.turn_number += 1;
+    game.turn.active_player = bob;
+    assert_eq!(
+        (game.calculated_power(first), game.calculated_toughness(first)),
+        (Some(0), Some(3)),
+        "Will Kenrith +2 should last through other players' turns"
+    );
+
+    game.turn.turn_number += 1;
+    game.turn.active_player = alice;
+    assert_eq!(
+        (game.calculated_power(first), game.calculated_toughness(first)),
+        (Some(4), Some(4)),
+        "Will Kenrith +2 should expire when Will's controller reaches their next turn"
+    );
+    assert!(
+        game.object_has_ability(first, &StaticAbility::flying())
+            && game.object_has_ability(first, &StaticAbility::trample()),
+        "targeted creature should regain printed abilities after Will Kenrith +2 expires"
+    );
+}
+
+#[test]
+fn will_kenrith_minus_two_draws_and_reduces_only_target_players_matching_spells_until_next_turn() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let will_def = will_kenrith_definition();
+    let will = game.create_object_from_definition(&will_def, alice, Zone::Battlefield);
+
+    for idx in 0..2 {
+        let draw_card = CardDefinitionBuilder::new(
+            CardId::new(),
+            format!("Will Kenrith Bob Draw Probe {idx}"),
+        )
+        .card_types(vec![CardType::Instant])
+        .build();
+        game.create_object_from_definition(&draw_card, bob, Zone::Library);
+    }
+    let bob_hand_before = game.player(bob).expect("bob exists").hand.len();
+
+    resolve_will_kenrith_loyalty_ability(
+        &mut game,
+        will,
+        alice,
+        &["RemoveCountersEffect", "Fixed(2)"],
+        vec![crate::effects::ResolvedTarget::Player(bob)],
+    );
+
+    assert_eq!(
+        game.player(bob).expect("bob exists").hand.len(),
+        bob_hand_before + 2,
+        "Will Kenrith -2 should make the targeted player draw two cards"
+    );
+
+    let costed_spell = |name: &str, card_type: CardType| {
+        let mut builder = CardDefinitionBuilder::new(CardId::new(), name)
+            .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(4)]]))
+            .card_types(vec![card_type]);
+        if card_type == CardType::Creature {
+            builder = builder.power_toughness(PowerToughness::fixed(2, 2));
+        }
+        if card_type == CardType::Planeswalker {
+            builder = builder.loyalty(3);
+        }
+        builder.build()
+    };
+    let bob_instant = game.create_object_from_definition(
+        &costed_spell("Will Kenrith Bob Instant Probe", CardType::Instant),
+        bob,
+        Zone::Hand,
+    );
+    let bob_sorcery = game.create_object_from_definition(
+        &costed_spell("Will Kenrith Bob Sorcery Probe", CardType::Sorcery),
+        bob,
+        Zone::Hand,
+    );
+    let bob_planeswalker = game.create_object_from_definition(
+        &costed_spell(
+            "Will Kenrith Bob Planeswalker Probe",
+            CardType::Planeswalker,
+        ),
+        bob,
+        Zone::Hand,
+    );
+    let bob_creature = game.create_object_from_definition(
+        &costed_spell("Will Kenrith Bob Creature Probe", CardType::Creature),
+        bob,
+        Zone::Hand,
+    );
+    let alice_instant = game.create_object_from_definition(
+        &costed_spell("Will Kenrith Alice Instant Probe", CardType::Instant),
+        alice,
+        Zone::Hand,
+    );
+
+    for (spell_id, expected, message) in [
+        (bob_instant, "{2}", "target player's instant should be reduced"),
+        (bob_sorcery, "{2}", "target player's sorcery should be reduced"),
+        (
+            bob_planeswalker,
+            "{2}",
+            "target player's planeswalker should be reduced",
+        ),
+        (bob_creature, "{4}", "target player's creature should not be reduced"),
+        (
+            alice_instant,
+            "{4}",
+            "non-target player's instant should not be reduced",
+        ),
+    ] {
+        let spell = game.object(spell_id).expect("spell exists");
+        let caster = game.controller_of(spell);
+        let cost = crate::decision::calculate_effective_mana_cost(
+            &game,
+            caster,
+            spell,
+            spell.mana_cost.as_ref().expect("spell should have mana cost"),
+        );
+        assert_eq!(cost.to_oracle(), expected, "{message}");
+    }
+
+    game.turn.turn_number += 1;
+    game.turn.active_player = bob;
+    let spell = game.object(bob_instant).expect("bob instant exists");
+    let cost = crate::decision::calculate_effective_mana_cost(
+        &game,
+        bob,
+        spell,
+        spell.mana_cost.as_ref().expect("bob instant mana cost"),
+    );
+    assert_eq!(
+        cost.to_oracle(),
+        "{2}",
+        "Will Kenrith -2 reduction should last through the target player's next turn"
+    );
+
+    game.turn.turn_number += 1;
+    game.turn.active_player = alice;
+    let spell = game.object(bob_instant).expect("bob instant exists");
+    let cost = crate::decision::calculate_effective_mana_cost(
+        &game,
+        bob,
+        spell,
+        spell.mana_cost.as_ref().expect("bob instant mana cost"),
+    );
+    assert_eq!(
+        cost.to_oracle(),
+        "{4}",
+        "Will Kenrith -2 reduction should expire on Will controller's next turn"
+    );
+}
+
+#[test]
+fn will_kenrith_minus_eight_gives_emblem_to_target_player() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let will_def = will_kenrith_definition();
+    let will = game.create_object_from_definition(&will_def, alice, Zone::Battlefield);
+    let command_zone_before = game.command_zone.len();
+
+    resolve_will_kenrith_loyalty_ability(
+        &mut game,
+        will,
+        alice,
+        &["RemoveCountersEffect", "Fixed(8)"],
+        vec![crate::effects::ResolvedTarget::Player(bob)],
+    );
+
+    assert_eq!(
+        game.command_zone.len(),
+        command_zone_before + 1,
+        "Will Kenrith -8 should create one emblem"
+    );
+    let emblem_id = *game.command_zone.last().expect("emblem should be in command zone");
+    let emblem = game.object(emblem_id).expect("emblem object should exist");
+    assert_eq!(emblem.kind, ObjectKind::Emblem);
+    assert_eq!(
+        emblem.owner, bob,
+        "Will Kenrith -8 should give the emblem to the targeted player, not Will's controller"
+    );
+    let emblem_debug = format!("{:#?}", emblem.abilities);
+    assert!(
+        emblem_debug.contains("SpellCastTrigger")
+            && emblem_debug.contains("CopySpellEffect")
+            && emblem_debug.contains("RetargetStackObjectEffect"),
+        "Will Kenrith emblem should keep its instant/sorcery copy trigger, got {emblem_debug}"
     );
 }
 

--- a/crates/ironsmith-runtime/src/game_state.rs
+++ b/crates/ironsmith-runtime/src/game_state.rs
@@ -821,17 +821,28 @@ impl GoadEffectInstance {
 pub struct TemporarySpellCostReductionEffectInstance {
     pub player: PlayerId,
     pub source: ObjectId,
+    pub duration_controller: PlayerId,
     pub filter: crate::target::ObjectFilter,
     pub reduction: crate::mana::ManaCost,
     pub generic_reduction: Option<crate::effect::Value>,
     pub applies_to_all_matching_this_turn: bool,
+    pub duration: crate::effect::Until,
     pub remaining_uses: u32,
     pub expires_end_of_turn: u32,
 }
 
 impl TemporarySpellCostReductionEffectInstance {
-    pub fn is_expired(&self, current_turn: u32) -> bool {
-        self.remaining_uses == 0 || current_turn > self.expires_end_of_turn
+    pub fn is_expired(&self, current_turn: u32, active_player: PlayerId) -> bool {
+        if self.remaining_uses == 0 {
+            return true;
+        }
+        match self.duration {
+            crate::effect::Until::YourNextTurn => {
+                current_turn > self.expires_end_of_turn && active_player == self.duration_controller
+            }
+            crate::effect::Until::Forever => false,
+            _ => current_turn > self.expires_end_of_turn,
+        }
     }
 }
 
@@ -2912,14 +2923,37 @@ impl GameState {
         reduction: crate::mana::ManaCost,
         remaining_uses: u32,
     ) {
+        self.add_temporary_spell_cost_reduction_until(
+            player,
+            source,
+            player,
+            filter,
+            reduction,
+            remaining_uses,
+            crate::effect::Until::EndOfTurn,
+        );
+    }
+
+    pub fn add_temporary_spell_cost_reduction_until(
+        &mut self,
+        player: PlayerId,
+        source: ObjectId,
+        duration_controller: PlayerId,
+        filter: crate::target::ObjectFilter,
+        reduction: crate::mana::ManaCost,
+        remaining_uses: u32,
+        duration: crate::effect::Until,
+    ) {
         self.effect_store.temporary_spell_cost_reductions.push(
             TemporarySpellCostReductionEffectInstance {
                 player,
                 source,
+                duration_controller,
                 filter,
                 reduction,
                 generic_reduction: None,
                 applies_to_all_matching_this_turn: false,
+                duration,
                 remaining_uses,
                 expires_end_of_turn: self.turn.turn_number,
             },
@@ -2933,14 +2967,35 @@ impl GameState {
         filter: crate::target::ObjectFilter,
         generic_reduction: crate::effect::Value,
     ) {
+        self.add_temporary_matching_spell_cost_reduction_until(
+            player,
+            source,
+            player,
+            filter,
+            generic_reduction,
+            crate::effect::Until::EndOfTurn,
+        );
+    }
+
+    pub fn add_temporary_matching_spell_cost_reduction_until(
+        &mut self,
+        player: PlayerId,
+        source: ObjectId,
+        duration_controller: PlayerId,
+        filter: crate::target::ObjectFilter,
+        generic_reduction: crate::effect::Value,
+        duration: crate::effect::Until,
+    ) {
         self.effect_store.temporary_spell_cost_reductions.push(
             TemporarySpellCostReductionEffectInstance {
                 player,
                 source,
+                duration_controller,
                 filter,
                 reduction: crate::mana::ManaCost::new(),
                 generic_reduction: Some(generic_reduction),
                 applies_to_all_matching_this_turn: true,
+                duration,
                 remaining_uses: u32::MAX,
                 expires_end_of_turn: self.turn.turn_number,
             },
@@ -3169,9 +3224,10 @@ impl GameState {
 
     pub fn cleanup_temporary_spell_cost_reductions_end_of_turn(&mut self) {
         let current_turn = self.turn.turn_number;
+        let active_player = self.turn.active_player;
         self.effect_store
             .temporary_spell_cost_reductions
-            .retain(|effect| !effect.is_expired(current_turn));
+            .retain(|effect| !effect.is_expired(current_turn, active_player));
     }
 
     pub fn cleanup_temporary_spell_ability_grants_end_of_turn(&mut self) {


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Will Kenrith
Initial parse error:
```
unsupported trailing base power/toughness clause (clause: 'until your next turn up to two target creatures each have base power and toughness 0/3 and lose all abilities'); oracle-only fallback also failed: unsupported trailing base power/toughness clause (clause: 'until your next turn up to two target creatures each have base power and toughness 0/3 and lose all abilities')
```

Current worker: i-0e26922745fca1de4
Branch: codex/aws-card-fix-will-kenrith
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260604T121212Z-controller-dev-loop-wave0025
