### PR TITLE
Fix Ironsmith parse failure: Eternal Scourge

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_inner/sentence_shape_predicates.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_inner/sentence_shape_predicates.rs
@@ -713,6 +713,13 @@ fn parse_effect_sentence_lexed_inner(
     }
 
     let sentence_words = crate::runtime_backend::token_word_refs(tokens);
+    if sentence_words.first().is_some_and(|word| *word == "exile")
+        && is_source_reference_words(&sentence_words[1..])
+    {
+        let target_tokens = trim_commas(&tokens[1..]);
+        let target = parse_target_phrase(&target_tokens)?;
+        return Ok(vec![EffectAst::subject_verb_exile(target, false)]);
+    }
     if let Some(effect) = parse_source_and_blocked_creatures_top_library_shuffle_sentence(tokens) {
         return Ok(vec![effect]);
     }

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -57,6 +57,34 @@ fn test_creature_with_mana_ability() {
 }
 
 #[test]
+fn eternal_scourge_parses_and_renders_exile_target_trigger() {
+    let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Eternal Scourge")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(3)]]))
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Eldrazi, Subtype::Horror])
+        .power_toughness(PowerToughness::fixed(3, 3))
+        .parse_text(
+            "You may cast this card from exile.\n\
+             When this creature becomes the target of a spell or ability an opponent controls, exile this creature.",
+        )
+        .expect("Eternal Scourge oracle text should parse strictly");
+
+    let lines = compiled_text_lines(&def);
+    let compiled = lines.join("\n");
+
+    assert!(
+        compiled.contains("You may cast this card from exile."),
+        "compiled Eternal Scourge text should preserve exile casting permission, got {compiled}"
+    );
+    assert!(
+        compiled.contains(
+            "When this creature becomes the target of a spell or ability an opponent controls, exile this creature."
+        ),
+        "compiled Eternal Scourge text should preserve opponent-targeted exile trigger, got {compiled}"
+    );
+}
+
+#[test]
 fn test_spell_with_effects() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Test Bolt")
         .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Red]]))

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -93,6 +93,100 @@ fn component_pouch_d20_ability_index(def: &crate::cards::CardDefinition) -> usiz
 }
 
 #[test]
+fn eternal_scourge_static_permission_applies_only_to_its_controller_from_exile() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let eternal_scourge = CardDefinitionBuilder::new(CardId::new(), "Eternal Scourge")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(3)]]))
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Eldrazi, Subtype::Horror])
+        .power_toughness(PowerToughness::fixed(3, 3))
+        .parse_text(
+            "You may cast this card from exile.\n\
+             When this creature becomes the target of a spell or ability an opponent controls, exile this creature.",
+        )
+        .expect("Eternal Scourge should parse for exile permission test");
+    let scourge_id = game.create_object_from_definition(&eternal_scourge, alice, Zone::Exile);
+
+    assert!(
+        game.effect_store.grant_registry.card_can_play_from_zone(
+            &game,
+            scourge_id,
+            Zone::Exile,
+            alice
+        ),
+        "Eternal Scourge should let its controller cast it from exile"
+    );
+    assert!(
+        !game.effect_store.grant_registry.card_can_play_from_zone(
+            &game,
+            scourge_id,
+            Zone::Exile,
+            bob
+        ),
+        "Eternal Scourge should not let an opponent cast it from exile"
+    );
+}
+
+#[test]
+fn eternal_scourge_targeting_trigger_exiles_it_on_resolution() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+
+    let eternal_scourge = CardDefinitionBuilder::new(CardId::new(), "Eternal Scourge")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(3)]]))
+        .card_types(vec![CardType::Creature])
+        .subtypes(vec![Subtype::Eldrazi, Subtype::Horror])
+        .power_toughness(PowerToughness::fixed(3, 3))
+        .parse_text(
+            "You may cast this card from exile.\n\
+             When this creature becomes the target of a spell or ability an opponent controls, exile this creature.",
+        )
+        .expect("Eternal Scourge should parse for trigger resolution test");
+    let scourge_id =
+        game.create_object_from_definition(&eternal_scourge, alice, Zone::Battlefield);
+    let opponent_source = CardBuilder::new(CardId::new(), "Opponent Targeting Source")
+        .card_types(vec![CardType::Creature])
+        .build();
+    let opponent_source_id =
+        game.create_object_from_card(&opponent_source, bob, Zone::Battlefield);
+
+    let event = TriggerEvent::new_with_provenance(
+        crate::events::spells::BecomesTargetedEvent::new(
+            scourge_id,
+            opponent_source_id,
+            bob,
+            true,
+        ),
+        crate::provenance::ProvNodeId::default(),
+    );
+    let mut trigger_queue = TriggerQueue::new();
+    queue_triggers_from_event(&mut game, &mut trigger_queue, event, false);
+    assert_eq!(trigger_queue.entries.len(), 1);
+
+    put_triggers_on_stack(&mut game, &mut trigger_queue)
+        .expect("Eternal Scourge trigger should go on the stack");
+    resolve_stack_entry(&mut game).expect("Eternal Scourge trigger should resolve");
+
+    let exiled_scourges = game
+        .objects_in_zone(Zone::Exile)
+        .into_iter()
+        .filter(|id| {
+            game.object(*id)
+                .is_some_and(|object| object.name == "Eternal Scourge")
+        })
+        .count();
+    assert_eq!(
+        exiled_scourges,
+        1,
+        "Eternal Scourge should exile itself when its targeting trigger resolves"
+    );
+}
+
+#[test]
 fn component_pouch_mana_activation_requires_counter_pays_cost_and_adds_distinct_mana_runtime() {
     let mut game = setup_game();
     let alice = PlayerId::from_index(0);

--- a/crates/ironsmith-runtime/src/triggers/check.rs
+++ b/crates/ironsmith-runtime/src/triggers/check.rs
@@ -3080,6 +3080,50 @@ mod tests {
     }
 
     #[test]
+    fn eternal_scourge_triggers_only_for_opponent_controlled_targeting_sources() {
+        let mut game = crate::tests::test_helpers::setup_two_player_game();
+        let alice = PlayerId::from_index(0);
+        let bob = PlayerId::from_index(1);
+
+        let eternal_scourge = CardDefinitionBuilder::new(CardId::new(), "Eternal Scourge")
+            .card_types(vec![CardType::Creature])
+            .power_toughness(PowerToughness::fixed(3, 3))
+            .parse_text(
+                "You may cast this card from exile.\n\
+                 When this creature becomes the target of a spell or ability an opponent controls, exile this creature.",
+            )
+            .expect("Eternal Scourge should parse for trigger behavior tests");
+        let scourge_id =
+            game.create_object_from_definition(&eternal_scourge, alice, Zone::Battlefield);
+        let opponent_source =
+            make_battlefield_creature(&mut game, bob, "Opponent Targeting Source");
+        let friendly_source =
+            make_battlefield_creature(&mut game, alice, "Friendly Targeting Source");
+
+        let opponent_event = TriggerEvent::new_with_provenance(
+            BecomesTargetedEvent::new(scourge_id, opponent_source, bob, true),
+            crate::provenance::ProvNodeId::default(),
+        );
+        let opponent_triggers = check_triggers(&game, &opponent_event);
+        assert_eq!(
+            opponent_triggers.len(),
+            1,
+            "Eternal Scourge should trigger when targeted by an opponent-controlled spell or ability"
+        );
+        assert_eq!(opponent_triggers[0].source, scourge_id);
+
+        let friendly_event = TriggerEvent::new_with_provenance(
+            BecomesTargetedEvent::new(scourge_id, friendly_source, alice, true),
+            crate::provenance::ProvNodeId::default(),
+        );
+        let friendly_triggers = check_triggers(&game, &friendly_event);
+        assert!(
+            friendly_triggers.is_empty(),
+            "Eternal Scourge should not trigger when targeted by its controller's own spell or ability"
+        );
+    }
+
+    #[test]
     fn ring_designation_block_trigger_schedules_end_of_combat_sacrifice() {
         let mut game = crate::tests::test_helpers::setup_two_player_game();
         let alice = PlayerId::from_index(0);


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Eternal Scourge
Initial parse error:
```
unsupported look clause (clause: ''); oracle-only fallback also failed: unsupported look clause (clause: '')
```

Current worker: i-043a6db613c8f392b
Branch: codex/aws-card-fix-eternal-scourge
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260604T121212Z-controller-dev-loop-wave0029
