### PR TITLE
Fix Ironsmith parse failure: Decode Transmissions

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/conditions.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/conditions.rs
@@ -339,6 +339,7 @@ pub(crate) struct PlayerWouldActionConditionAst {
 pub(crate) enum BattlefieldChangeThisTurnConditionAst {
     PermanentLeftBattlefield { negated: bool },
     PermanentLeftBattlefieldUnderYourControl,
+    ObjectLeftBattlefield { filter: ObjectFilter },
     ObjectPutIntoGraveyardFromBattlefield { filter: ObjectFilter },
 }
 
@@ -1561,8 +1562,8 @@ fn parse_battlefield_change_this_turn_shape(
     parse_no_permanent_left_battlefield_shape(tokens)
         .or_else(|| parse_permanent_left_battlefield_under_your_control_shape(tokens))
         .or_else(|| parse_object_put_into_graveyard_from_battlefield_shape(tokens))
-        .or_else(|| parse_nonland_permanent_or_spell_warped_this_turn_shape(tokens))
         .or_else(|| parse_permanent_left_battlefield_shape(tokens))
+        .or_else(|| parse_object_left_battlefield_shape(tokens))
 }
 
 fn parse_no_permanent_left_battlefield_shape(
@@ -1588,9 +1589,7 @@ fn parse_permanent_left_battlefield_shape(
     tokens: &[OwnedLexToken],
 ) -> Option<BattlefieldChangeThisTurnConditionAst> {
     let clause = LexedClause::new(tokens);
-    let optional_article = [LexPattern::any_word(&[
-        "a", "an",
-    ])];
+    let optional_article = [LexPattern::any_word(&["a", "an"])];
     let optional_the = [LexPattern::word("the")];
     let atoms = [
         LexPattern::optional(&optional_article),
@@ -1670,24 +1669,29 @@ fn parse_object_put_into_graveyard_from_battlefield_shape(
     )
 }
 
-fn parse_nonland_permanent_or_spell_warped_this_turn_shape(
+fn parse_object_left_battlefield_shape(
     tokens: &[OwnedLexToken],
 ) -> Option<BattlefieldChangeThisTurnConditionAst> {
     let clause = LexedClause::new(tokens);
+    let optional_article = [LexPattern::any_word(&[
+        "a", "an",
+    ])];
+    let optional_the = [LexPattern::word("the")];
     let atoms = [
-        LexPattern::phrase(&[
-            "nonland",
-            "permanent",
-            "left",
-            "battlefield",
-            "this",
-            "turn",
-        ]),
-        LexPattern::word("or"),
-        LexPattern::phrase(&["spell", "was", "warped", "this", "turn"]),
+        LexPattern::optional(&optional_article),
+        LexPattern::object("object", LexCaptureKind::UntilPhrase(&["left"])),
+        LexPattern::action("action", LexCaptureKind::OneOf(&["left"])),
+        LexPattern::optional(&optional_the),
+        LexPattern::phrase(&["battlefield", "this", "turn"]),
     ];
-    LexPattern::new(&atoms).match_clause(clause)?;
-    Some(BattlefieldChangeThisTurnConditionAst::PermanentLeftBattlefield { negated: false })
+    let matched = LexPattern::new(&atoms).match_clause(clause)?;
+    let object_clause = matched.capture_clause_by_role(LexCaptureRole::Object, clause)?;
+    let mut filter =
+        parse_object_filter_with_grammar_entrypoint(object_clause.tokens(), false).ok()?;
+    filter.zone = Some(Zone::Battlefield);
+    Some(BattlefieldChangeThisTurnConditionAst::ObjectLeftBattlefield {
+        filter,
+    })
 }
 
 pub(crate) fn parse_object_death_this_turn_condition(

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/filters/predicate_phrases.rs
@@ -3652,6 +3652,9 @@ fn parse_battlefield_change_this_turn_predicate(tokens: &[OwnedLexToken]) -> Opt
         crate::runtime_backend::grammar::conditions::BattlefieldChangeThisTurnConditionAst::PermanentLeftBattlefieldUnderYourControl => {
             Some(PredicateAst::PermanentLeftBattlefieldUnderYourControlThisTurn)
         }
+        crate::runtime_backend::grammar::conditions::BattlefieldChangeThisTurnConditionAst::ObjectLeftBattlefield {
+            filter,
+        } => Some(PredicateAst::ObjectLeftBattlefieldThisTurn(filter)),
         crate::runtime_backend::grammar::conditions::BattlefieldChangeThisTurnConditionAst::ObjectPutIntoGraveyardFromBattlefield {
             filter,
         } => Some(PredicateAst::ObjectPutIntoGraveyardFromBattlefieldThisTurn(filter)),
@@ -3956,6 +3959,15 @@ fn parse_source_did_not_attack_or_enter_control_this_turn_shape(
 }
 
 fn parse_spell_lifecycle_predicate(words: &[&str]) -> Option<PredicateAst> {
+    if matches!(
+        words,
+        ["spell", "was", "warped", "this", "turn"]
+            | ["spells", "were", "warped", "this", "turn"]
+    )
+    {
+        return Some(PredicateAst::SpellWasWarpedThisTurn);
+    }
+
     let tokens = crate::runtime_backend::lexer::synthetic_word_tokens(words);
     parse_you_cast_source_shape(&tokens)
         .or_else(|| parse_tagged_was_cast_shape(&tokens))
@@ -8089,6 +8101,8 @@ mod tests {
     #[test]
     fn parse_predicate_battlefield_change_this_turn_uses_shared_capture_parser()
     -> Result<(), CardTextError> {
+        let mut nonland_permanent = ObjectFilter::permanent_card().in_zone(Zone::Battlefield);
+        nonland_permanent.excluded_card_types.push(CardType::Land);
         let cases = [
             (
                 "If no permanents left battlefield this turn",
@@ -8097,6 +8111,10 @@ mod tests {
             (
                 "If a permanent left battlefield this turn",
                 PredicateAst::PermanentLeftBattlefieldThisTurn,
+            ),
+            (
+                "If a nonland permanent left battlefield this turn",
+                PredicateAst::ObjectLeftBattlefieldThisTurn(nonland_permanent.clone()),
             ),
             (
                 "If creatures left battlefield under your control this turn",
@@ -8118,6 +8136,29 @@ mod tests {
 
             assert_eq!(parsed, expected, "{text}");
         }
+        Ok(())
+    }
+
+    #[test]
+    fn parse_predicate_void_nonland_left_or_spell_warped_this_turn()
+    -> Result<(), CardTextError> {
+        let mut nonland_permanent = ObjectFilter::permanent_card().in_zone(Zone::Battlefield);
+        nonland_permanent.excluded_card_types.push(CardType::Land);
+        let tokens = lex_line(
+            "If a nonland permanent left the battlefield this turn or a spell was warped this turn",
+            0,
+        )?;
+        let parsed = parse_predicate(&predicate_tokens_after_if(&tokens))?;
+
+        assert_eq!(
+            parsed,
+            PredicateAst::Or(
+                Box::new(PredicateAst::ObjectLeftBattlefieldThisTurn(
+                    nonland_permanent,
+                )),
+                Box::new(PredicateAst::SpellWasWarpedThisTurn),
+            )
+        );
         Ok(())
     }
 

--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support.rs
@@ -561,6 +561,10 @@ pub(crate) fn compile_condition_from_predicate_ast(
         PredicateAst::PermanentLeftBattlefieldUnderYourControlThisTurn => {
             Condition::PermanentLeftBattlefieldUnderYourControlThisTurn
         }
+        PredicateAst::ObjectLeftBattlefieldThisTurn(filter) => {
+            Condition::ObjectLeftBattlefieldThisTurn(filter.clone())
+        }
+        PredicateAst::SpellWasWarpedThisTurn => Condition::SpellWasWarpedThisTurn,
         PredicateAst::ObjectEnteredBattlefieldThisTurn(filter) => {
             Condition::ObjectEnteredBattlefieldThisTurn(filter.clone())
         }

--- a/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/model/ast.rs
@@ -610,6 +610,8 @@ pub(crate) enum PredicateAst {
     CreatureCardPutIntoYourGraveyardThisTurn,
     PermanentLeftBattlefieldThisTurn,
     PermanentLeftBattlefieldUnderYourControlThisTurn,
+    ObjectLeftBattlefieldThisTurn(ObjectFilter),
+    SpellWasWarpedThisTurn,
     ObjectEnteredBattlefieldThisTurn(ObjectFilter),
     ObjectEnteredBattlefieldLastTurn(ObjectFilter),
     ObjectPutIntoGraveyardFromBattlefieldThisTurn(ObjectFilter),

--- a/crates/ironsmith-core/src/value_model.rs
+++ b/crates/ironsmith-core/src/value_model.rs
@@ -752,6 +752,8 @@ pub enum Condition {
     OpponentLostLifeThisTurn,
     PermanentLeftBattlefieldThisTurn,
     PermanentLeftBattlefieldUnderYourControlThisTurn,
+    ObjectLeftBattlefieldThisTurn(ObjectFilter),
+    SpellWasWarpedThisTurn,
     ObjectEnteredBattlefieldThisTurn(ObjectFilter),
     ObjectEnteredBattlefieldLastTurn(ObjectFilter),
     ObjectPutIntoGraveyardFromBattlefieldThisTurn(ObjectFilter),

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -63128,8 +63128,38 @@ fn parse_void_pump_upgrade_as_self_replacement() {
     let debug = format!("{:#?}", def.spell_effect);
     assert!(
         debug.contains("SelfReplacementBranch")
-            && debug.contains("PermanentLeftBattlefieldThisTurn"),
+            && debug.contains("ObjectLeftBattlefieldThisTurn")
+            && debug.contains("SpellWasWarpedThisTurn"),
         "expected void pump upgrade to lower as self-replacement, got {debug}"
+    );
+}
+
+#[test]
+fn parse_oracle_decode_transmissions_void_replacement_regression() {
+    let def = parse_oracle_card_definition("Decode Transmissions");
+
+    let spell_debug = format!("{:#?}", def.spell_effect);
+    assert!(
+        spell_debug.contains("SelfReplacementBranch")
+            && spell_debug.contains("ObjectLeftBattlefieldThisTurn")
+            && spell_debug.contains("excluded_card_types")
+            && spell_debug.contains("Land")
+            && spell_debug.contains("SpellWasWarpedThisTurn"),
+        "Decode Transmissions should structurally lower its Void condition as nonland-left OR warped-spell, got {spell_debug}"
+    );
+
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+    assert!(
+        rendered.contains("Draw two cards and lose 2 life")
+            && rendered.contains("a nonland permanent left the battlefield this turn")
+            && rendered.contains("a spell was warped this turn")
+            && rendered.contains("instead draw two cards")
+            && rendered.contains("each opponent loses 2 life"),
+        "Decode Transmissions compiled text should preserve the Void replacement clause, got {rendered}"
+    );
+    assert!(
+        !rendered.contains("unsupported predicate") && !rendered.contains("unsupported effect"),
+        "Decode Transmissions should compile without unsupported markers, got {rendered}"
     );
 }
 

--- a/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/ast_render.rs
@@ -617,6 +617,13 @@ fn describe_single_self_replacement_segment(
     ) {
         return Some(count_override_text);
     }
+    if let Some(draw_life_text) = describe_draw_life_to_opponent_loss_self_replacement(
+        &segment.default_effects,
+        &branch.replacement_effects,
+        &condition_text,
+    ) {
+        return Some(draw_life_text);
+    }
     if let Some(draw_discard_text) = describe_target_player_draw_discard_self_replacement(
         &segment.default_effects,
         &branch.replacement_effects,
@@ -1016,6 +1023,56 @@ fn card_count_text(count: &Value) -> String {
         Value::Fixed(n) => number_word(*n).unwrap_or_else(|| n.to_string()),
         _ => describe_value(count),
     }
+}
+
+fn describe_draw_life_to_opponent_loss_self_replacement(
+    default_effects: &[Effect],
+    replacement_effects: &[Effect],
+    condition_text: &str,
+) -> Option<String> {
+    let [default_draw_effect, default_life_effect] = default_effects else {
+        return None;
+    };
+    let [replacement_draw_effect, replacement_life_effect] = replacement_effects else {
+        return None;
+    };
+
+    let default_draw = default_draw_effect.downcast_ref::<crate::effects::DrawCardsEffect>()?;
+    let default_life = default_life_effect.downcast_ref::<crate::effects::LoseLifeEffect>()?;
+    if default_draw.player != PlayerFilter::You
+        || !matches!(default_life.player, ChooseSpec::Player(PlayerFilter::You))
+    {
+        return None;
+    }
+
+    let replacement_draw =
+        replacement_draw_effect.downcast_ref::<crate::effects::DrawCardsEffect>()?;
+    let replacement_for_players =
+        replacement_life_effect.downcast_ref::<crate::effects::ForPlayersEffect>()?;
+    let [replacement_life_effect] = replacement_for_players.effects.as_slice() else {
+        return None;
+    };
+    let replacement_life =
+        replacement_life_effect.downcast_ref::<crate::effects::LoseLifeEffect>()?;
+    if replacement_draw.player != PlayerFilter::You
+        || replacement_draw.count != default_draw.count
+        || replacement_for_players.filter != PlayerFilter::Opponent
+        || replacement_for_players.starting_with_controller
+        || !matches!(
+            replacement_life.player,
+            ChooseSpec::Player(PlayerFilter::IteratedPlayer)
+        )
+    {
+        return None;
+    }
+
+    let draw_count = card_count_text(&default_draw.count);
+    let draw_noun = card_count_noun(&default_draw.count);
+    let default_loss = describe_value(&default_life.amount);
+    let opponent_loss = describe_value(&replacement_life.amount);
+    Some(format!(
+        "You draw {draw_count} {draw_noun} and lose {default_loss} life. If {condition_text}, instead you draw {draw_count} {draw_noun} and each opponent loses {opponent_loss} life"
+    ))
 }
 
 fn describe_target_player_draw_discard_self_replacement(

--- a/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/normalize_common.rs
@@ -11791,6 +11791,13 @@ pub(super) fn describe_condition(condition: &Condition) -> String {
         Condition::PermanentLeftBattlefieldUnderYourControlThisTurn => {
             "a permanent left the battlefield under your control this turn".to_string()
         }
+        Condition::ObjectLeftBattlefieldThisTurn(filter) => {
+            let mut object_filter = filter.clone();
+            object_filter.zone = None;
+            let object = with_indefinite_article(strip_leading_article(&object_filter.description()));
+            format!("{object} left the battlefield this turn")
+        }
+        Condition::SpellWasWarpedThisTurn => "a spell was warped this turn".to_string(),
         Condition::ObjectEnteredBattlefieldThisTurn(filter) => {
             let mut object_filter = filter.clone();
             object_filter.zone = None;

--- a/crates/ironsmith-runtime/src/condition_eval.rs
+++ b/crates/ironsmith-runtime/src/condition_eval.rs
@@ -1019,6 +1019,18 @@ fn evaluate_condition_shared_core(
                 .permanents_left_battlefield_under_controller(ctx.controller)
                 > 0,
         ),
+        Condition::ObjectLeftBattlefieldThisTurn(filter) => Some(
+            game.turn_store.turn_history.object_left_battlefield_this_turn(
+                game,
+                filter,
+                &game.filter_context_for(ctx.controller, ctx.filter_source),
+            ) > 0,
+        ),
+        Condition::SpellWasWarpedThisTurn => Some(
+            game.turn_store
+                .turn_history
+                .spell_was_warped_this_turn(),
+        ),
         Condition::ObjectEnteredBattlefieldThisTurn(filter) => Some(
             object_matching_entered_battlefield_this_turn(game, ctx, filter),
         ),
@@ -1214,6 +1226,8 @@ fn assert_condition_variant_coverage(condition: &Condition) {
         Condition::OpponentLostLifeThisTurn => {}
         Condition::PermanentLeftBattlefieldThisTurn => {}
         Condition::PermanentLeftBattlefieldUnderYourControlThisTurn => {}
+        Condition::ObjectLeftBattlefieldThisTurn(..) => {}
+        Condition::SpellWasWarpedThisTurn => {}
         Condition::ObjectEnteredBattlefieldThisTurn(..) => {}
         Condition::ObjectEnteredBattlefieldLastTurn(..) => {}
         Condition::ObjectPutIntoGraveyardFromBattlefieldThisTurn(..) => {}
@@ -2146,6 +2160,8 @@ pub fn evaluate_condition_external(
         | Condition::OpponentLostLifeThisTurn
         | Condition::PermanentLeftBattlefieldThisTurn
         | Condition::PermanentLeftBattlefieldUnderYourControlThisTurn
+        | Condition::ObjectLeftBattlefieldThisTurn(_)
+        | Condition::SpellWasWarpedThisTurn
         | Condition::ObjectEnteredBattlefieldThisTurn(_)
         | Condition::ObjectEnteredBattlefieldLastTurn(_)
         | Condition::ObjectPutIntoGraveyardFromBattlefieldThisTurn(_)
@@ -2882,6 +2898,8 @@ fn evaluate_condition_simple(
         | Condition::OpponentLostLifeThisTurn
         | Condition::PermanentLeftBattlefieldThisTurn
         | Condition::PermanentLeftBattlefieldUnderYourControlThisTurn
+        | Condition::ObjectLeftBattlefieldThisTurn(_)
+        | Condition::SpellWasWarpedThisTurn
         | Condition::ObjectEnteredBattlefieldThisTurn(_)
         | Condition::ObjectEnteredBattlefieldLastTurn(_)
         | Condition::ObjectPutIntoGraveyardFromBattlefieldThisTurn(_)
@@ -4019,6 +4037,8 @@ fn evaluate_condition(
         | Condition::OpponentLostLifeThisTurn
         | Condition::PermanentLeftBattlefieldThisTurn
         | Condition::PermanentLeftBattlefieldUnderYourControlThisTurn
+        | Condition::ObjectLeftBattlefieldThisTurn(_)
+        | Condition::SpellWasWarpedThisTurn
         | Condition::ObjectEnteredBattlefieldThisTurn(_)
         | Condition::ObjectEnteredBattlefieldLastTurn(_)
         | Condition::ObjectPutIntoGraveyardFromBattlefieldThisTurn(_)

--- a/crates/ironsmith-runtime/src/events/spells/spell_cast.rs
+++ b/crates/ironsmith-runtime/src/events/spells/spell_cast.rs
@@ -22,6 +22,8 @@ pub struct SpellCastEvent {
     pub from_zone: Zone,
     /// Snapshot of the spell on the stack at cast time.
     pub snapshot: Option<ObjectSnapshot>,
+    /// Whether the spell was cast using a Warp alternative cost.
+    pub was_warped: bool,
 }
 
 impl SpellCastEvent {
@@ -32,6 +34,7 @@ impl SpellCastEvent {
             caster,
             from_zone,
             snapshot: None,
+            was_warped: false,
         }
     }
 
@@ -46,7 +49,13 @@ impl SpellCastEvent {
             caster,
             from_zone,
             snapshot: Some(snapshot),
+            was_warped: false,
         }
+    }
+
+    pub fn with_warped(mut self) -> Self {
+        self.was_warped = true;
+        self
     }
 }
 

--- a/crates/ironsmith-runtime/src/game_loop/priority_cast.rs
+++ b/crates/ironsmith-runtime/src/game_loop/priority_cast.rs
@@ -1389,18 +1389,26 @@ pub(super) fn finalize_pending_spell_cast(
 
     let event = if let Some(obj) = game.object(result.new_id) {
         let snapshot = crate::snapshot::ObjectSnapshot::from_object(obj, game);
+        let mut spell_cast = SpellCastEvent::new_with_snapshot(
+            result.new_id,
+            result.caster,
+            result.from_zone,
+            snapshot,
+        );
+        if result.was_warped {
+            spell_cast = spell_cast.with_warped();
+        }
         TriggerEvent::new_with_provenance(
-            SpellCastEvent::new_with_snapshot(
-                result.new_id,
-                result.caster,
-                result.from_zone,
-                snapshot,
-            ),
+            spell_cast,
             spell_cast_provenance,
         )
     } else {
+        let mut spell_cast = SpellCastEvent::new(result.new_id, result.caster, result.from_zone);
+        if result.was_warped {
+            spell_cast = spell_cast.with_warped();
+        }
         TriggerEvent::new_with_provenance(
-            SpellCastEvent::new(result.new_id, result.caster, result.from_zone),
+            spell_cast,
             spell_cast_provenance,
         )
     };

--- a/crates/ironsmith-runtime/src/game_loop/priority_mana.rs
+++ b/crates/ironsmith-runtime/src/game_loop/priority_mana.rs
@@ -3491,6 +3491,8 @@ pub(super) struct SpellCastResult {
     pub(super) caster: PlayerId,
     /// Which zone the spell was cast from.
     pub(super) from_zone: Zone,
+    /// Whether the spell was cast using its Warp alternative.
+    pub(super) was_warped: bool,
 }
 
 fn parse_simple_mana_marker_cost(text: &str) -> Option<crate::mana::ManaCost> {
@@ -3858,6 +3860,9 @@ pub(super) fn finalize_spell_cast(
         }
     }
     let selected_alternative_label = alternative_cast_label(game, caster, new_id, &casting_method);
+    let was_warped = selected_alternative_label
+        .as_deref()
+        .is_some_and(|label| label.eq_ignore_ascii_case("Warp"));
     if let Some(label) = selected_alternative_label.as_deref()
         && !label.eq_ignore_ascii_case("Parsed alternative cost")
         && !matches!(
@@ -4023,6 +4028,7 @@ pub(super) fn finalize_spell_cast(
         new_id,
         caster,
         from_zone,
+        was_warped,
     })
 }
 

--- a/crates/ironsmith-runtime/src/game_loop/tests.rs
+++ b/crates/ironsmith-runtime/src/game_loop/tests.rs
@@ -9,7 +9,6 @@ use crate::decision::{AutoPassDecisionMaker, DecisionMaker, SelectFirstDecisionM
 use crate::effect::RestrictionExt as _;
 use crate::effect::{Effect, EventValueSpec, Until, Value};
 use crate::events::EventKind;
-use crate::events::spells::SpellCastEvent;
 use crate::events::zones::EnterBattlefieldEvent;
 use crate::execute_cleanup_step;
 use crate::filter::ObjectFilterExt as _;
@@ -24722,6 +24721,216 @@ fn test_resolve_stack_entry_uses_default_effect_when_self_replacement_condition_
         game.player(alice).expect("alice exists").library.len(),
         library_before - 1,
         "the default segment should draw exactly one card"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn decode_transmissions_definition() -> crate::cards::CardDefinition {
+    CardDefinitionBuilder::new(CardId::new(), "Decode Transmissions")
+        .card_types(vec![CardType::Sorcery])
+        .parse_text(
+            "You draw two cards and lose 2 life.\n\
+             Void — If a nonland permanent left the battlefield this turn or a spell was warped \
+             this turn, instead you draw two cards and each opponent loses 2 life.",
+        )
+        .expect("Decode Transmissions should parse")
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn add_decode_transmissions_draw_cards(game: &mut GameState, player: PlayerId) {
+    for idx in 0..2 {
+        let card = CardBuilder::new(CardId::new(), format!("Decode Draw Card {idx}"))
+            .card_types(vec![CardType::Artifact])
+            .build();
+        game.create_object_from_card(&card, player, Zone::Library);
+    }
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn resolve_decode_transmissions(game: &mut GameState, controller: PlayerId) {
+    let spell_def = decode_transmissions_definition();
+    let spell_id = game.create_object_from_definition(&spell_def, controller, Zone::Stack);
+    game.push_to_stack(StackEntry::new(spell_id, controller));
+    resolve_stack_entry(game).expect("Decode Transmissions should resolve");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+fn cast_decode_setup_spell(
+    game: &mut GameState,
+    controller: PlayerId,
+    definition: &crate::cards::CardDefinition,
+    casting_method: CastingMethod,
+) {
+    let spell_id = game.create_object_from_definition(definition, controller, Zone::Hand);
+    let mut state = PriorityLoopState::new(2);
+    let mut trigger_queue = TriggerQueue::new();
+    let cast_response = PriorityResponse::PriorityAction(LegalAction::CastSpell {
+        spell_id,
+        from_zone: Zone::Hand,
+        casting_method,
+    });
+    apply_priority_response(game, &mut trigger_queue, &mut state, &cast_response)
+        .expect("setup spell cast should succeed");
+    resolve_stack_entry(game).expect("setup spell should resolve");
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn decode_transmissions_default_branch_draws_and_loses_life_without_void() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    add_decode_transmissions_draw_cards(&mut game, alice);
+
+    let hand_before = game.player(alice).expect("alice exists").hand.len();
+
+    resolve_decode_transmissions(&mut game, alice);
+
+    assert_eq!(
+        game.player(alice).expect("alice exists").hand.len(),
+        hand_before + 2,
+        "Decode Transmissions should draw two cards on its default branch"
+    );
+    assert_eq!(
+        game.player(alice).expect("alice exists").life,
+        18,
+        "Decode Transmissions default branch should make its controller lose 2 life"
+    );
+    assert_eq!(
+        game.player(bob).expect("bob exists").life,
+        20,
+        "Decode Transmissions default branch should not make opponents lose life"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn decode_transmissions_land_leaving_does_not_enable_void() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    add_decode_transmissions_draw_cards(&mut game, alice);
+
+    let land = CardBuilder::new(CardId::new(), "Void Test Land")
+        .card_types(vec![CardType::Land])
+        .build();
+    let land_id = game.create_object_from_card(&land, alice, Zone::Battlefield);
+    game.move_object_by_effect(land_id, Zone::Graveyard);
+
+    resolve_decode_transmissions(&mut game, alice);
+
+    assert_eq!(
+        game.player(alice).expect("alice exists").life,
+        18,
+        "a land leaving the battlefield should not satisfy Decode Transmissions' nonland Void condition"
+    );
+    assert_eq!(
+        game.player(bob).expect("bob exists").life,
+        20,
+        "opponents should not lose life when only a land left the battlefield"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn decode_transmissions_nonland_permanent_leaving_enables_void() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    add_decode_transmissions_draw_cards(&mut game, alice);
+
+    let artifact = CardBuilder::new(CardId::new(), "Void Test Artifact")
+        .card_types(vec![CardType::Artifact])
+        .build();
+    let artifact_id = game.create_object_from_card(&artifact, alice, Zone::Battlefield);
+    game.move_object_by_effect(artifact_id, Zone::Graveyard);
+
+    resolve_decode_transmissions(&mut game, alice);
+
+    assert_eq!(
+        game.player(alice).expect("alice exists").life,
+        20,
+        "Decode Transmissions Void branch should replace the controller life loss"
+    );
+    assert_eq!(
+        game.player(bob).expect("bob exists").life,
+        18,
+        "Decode Transmissions Void branch should make each opponent lose 2 life"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn decode_transmissions_nonwarped_spell_does_not_enable_void() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+    add_decode_transmissions_draw_cards(&mut game, alice);
+
+    game.player_mut(alice)
+        .expect("alice exists")
+        .mana_pool
+        .add(ManaSymbol::Blue, 1);
+    let setup_spell = CardDefinitionBuilder::new(CardId::new(), "Nonwarped Setup Spell")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Blue]]))
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .build();
+    cast_decode_setup_spell(&mut game, alice, &setup_spell, CastingMethod::Normal);
+
+    resolve_decode_transmissions(&mut game, alice);
+
+    assert_eq!(
+        game.player(alice).expect("alice exists").life,
+        18,
+        "a normally cast spell should not enable Decode Transmissions' Void replacement branch"
+    );
+    assert_eq!(
+        game.player(bob).expect("bob exists").life,
+        20,
+        "opponents should not lose life when only a nonwarped spell was cast"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn decode_transmissions_warped_spell_enables_void() {
+    let mut game = setup_game();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    game.turn.phase = Phase::FirstMain;
+    game.turn.step = None;
+    game.turn.active_player = alice;
+    game.turn.priority_player = Some(alice);
+    add_decode_transmissions_draw_cards(&mut game, alice);
+
+    game.player_mut(alice)
+        .expect("alice exists")
+        .mana_pool
+        .add(ManaSymbol::Blue, 1);
+    let warped_spell = CardDefinitionBuilder::new(CardId::new(), "Warped Setup Spell")
+        .mana_cost(ManaCost::from_pips(vec![vec![ManaSymbol::Generic(2)]]))
+        .card_types(vec![CardType::Creature])
+        .power_toughness(PowerToughness::fixed(1, 1))
+        .warp(ManaCost::from_pips(vec![vec![ManaSymbol::Blue]]))
+        .build();
+    cast_decode_setup_spell(&mut game, alice, &warped_spell, CastingMethod::Alternative(0));
+
+    resolve_decode_transmissions(&mut game, alice);
+
+    assert_eq!(
+        game.player(alice).expect("alice exists").life,
+        20,
+        "a warped spell should enable Decode Transmissions' Void replacement branch"
+    );
+    assert_eq!(
+        game.player(bob).expect("bob exists").life,
+        18,
+        "the warped-spell Void branch should make each opponent lose 2 life"
     );
 }
 

--- a/crates/ironsmith-runtime/src/turn_history.rs
+++ b/crates/ironsmith-runtime/src/turn_history.rs
@@ -11,10 +11,12 @@ use crate::events::permanents::SacrificeEvent;
 use crate::events::spells::SpellCastEvent;
 use crate::events::zones::ZoneChangeEvent;
 use crate::events::{DamageEvent, EventKind, LifeGainEvent, LifeLossEvent};
+use crate::filter::{FilterContext, ObjectFilterExt as _};
 use crate::game_state::TurnCounterTracker;
 use crate::ids::{ObjectId, PlayerId, StableId};
 use crate::provenance::{ProvNodeId, ProvenanceGraph};
 use crate::snapshot::ObjectSnapshot;
+use crate::target::ObjectFilter;
 use crate::triggers::TriggerEvent;
 use crate::triggers::TriggerIdentity;
 use crate::types::{CardType, Subtype};
@@ -216,6 +218,33 @@ impl TurnHistory {
     pub fn any_spell_was_cast_this_turn(&self) -> bool {
         self.projected_records()
             .any(|record| record.event.downcast::<SpellCastEvent>().is_some())
+    }
+
+    pub fn spell_was_warped_this_turn(&self) -> bool {
+        self.projected_records().any(|record| {
+            record
+                .event
+                .downcast::<SpellCastEvent>()
+                .is_some_and(|event| event.was_warped)
+        })
+    }
+
+    pub fn object_left_battlefield_this_turn(
+        &self,
+        game: &crate::game_state::GameState,
+        filter: &ObjectFilter,
+        ctx: &FilterContext,
+    ) -> u32 {
+        self.projected_records()
+            .filter_map(|record| record.event.downcast::<ZoneChangeEvent>())
+            .filter(|event| event.from == Zone::Battlefield)
+            .filter(|event| {
+                event
+                    .snapshot
+                    .as_ref()
+                    .is_some_and(|snapshot| filter.matches_snapshot(snapshot, ctx, game))
+            })
+            .count() as u32
     }
 
     pub fn total_life_gained_for_players(&self, players: &[PlayerId]) -> u32 {


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Decode Transmissions
Initial parse error:
```
unsupported predicate (predicate: 'nonland permanent left battlefield this turn or spell was warped this turn'); oracle-only fallback also failed: unsupported predicate (predicate: 'nonland permanent left battlefield this turn or spell was warped this turn')
```

Current worker: i-03e9cdecfa3e99922
Branch: codex/aws-card-fix-decode-transmissions
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260604T121212Z-controller-dev-loop-wave0029
