### PR TITLE
Fix Ironsmith parse failure: Defensive Formation

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/families/keyword_static/mod.rs
@@ -47,7 +47,7 @@ use super::grammar::abilities::{
     is_shuffle_into_library_from_graveyard_line_lexed, is_skulk_rules_text_line_lexed,
     is_this_creature_cant_attack_alone_line_lexed,
     is_this_creature_cant_attack_its_owner_line_lexed, is_this_subject_reference_lexed,
-    is_you_have_shroud_line_lexed,
+    is_you_assign_combat_damage_of_creatures_attacking_you_line_lexed, is_you_have_shroud_line_lexed,
     is_you_may_look_face_down_creatures_you_dont_control_any_time_line_lexed,
     is_you_may_look_top_card_any_time_line_lexed,
     is_your_opponents_play_with_hands_revealed_line_lexed,
@@ -2816,6 +2816,9 @@ fn static_ability_ast_line_rules() -> &'static [StaticAbilityLineRuleDef] {
         ),
         single_static_ability_ast_passthrough_rule!(parse_trigger_suppression_line_ast),
         single_static_ability_ast_rule!(parse_creatures_assign_combat_damage_using_toughness_line),
+        single_static_ability_ast_rule!(
+            parse_you_assign_combat_damage_of_creatures_attacking_you_line
+        ),
         single_static_ability_ast_rule!(
             parse_lethal_damage_to_creatures_you_control_uses_power_line
         ),
@@ -6347,6 +6350,17 @@ pub(crate) fn parse_creatures_assign_combat_damage_using_toughness_line(
             ));
         }
         None => {}
+    }
+    Ok(None)
+}
+
+pub(crate) fn parse_you_assign_combat_damage_of_creatures_attacking_you_line(
+    tokens: &[OwnedLexToken],
+) -> Result<Option<StaticAbility>, CardTextError> {
+    if is_you_assign_combat_damage_of_creatures_attacking_you_line_lexed(tokens) {
+        return Ok(Some(
+            StaticAbility::you_assign_combat_damage_of_creatures_attacking_you(),
+        ));
     }
     Ok(None)
 }

--- a/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/abilities.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/front_end/grammar/abilities.rs
@@ -2485,6 +2485,51 @@ pub(crate) fn parse_creatures_assign_combat_damage_using_toughness_line_lexed(
     None
 }
 
+pub(crate) fn is_you_assign_combat_damage_of_creatures_attacking_you_line_lexed(
+    tokens: &[OwnedLexToken],
+) -> bool {
+    let words = crate::runtime_backend::token_word_refs(tokens);
+    const EXPECTED: &[&str] = &[
+        "rather",
+        "than",
+        "the",
+        "attacking",
+        "player",
+        "you",
+        "assign",
+        "the",
+        "combat",
+        "damage",
+        "of",
+        "each",
+        "creature",
+        "attacking",
+        "you",
+        "you",
+        "can",
+        "divide",
+        "that",
+        "creature's",
+        "combat",
+        "damage",
+        "as",
+        "you",
+        "choose",
+        "among",
+        "any",
+        "of",
+        "the",
+        "creatures",
+        "blocking",
+        "it",
+    ];
+    words.len() == EXPECTED.len()
+        && words
+            .iter()
+            .zip(EXPECTED.iter())
+            .all(|(actual, expected)| actual.eq_ignore_ascii_case(expected))
+}
+
 pub(crate) fn is_lethal_damage_to_creatures_you_control_uses_power_line_lexed(
     tokens: &[OwnedLexToken],
 ) -> bool {

--- a/crates/ironsmith-compiler/src/runtime_backend/tests.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/tests.rs
@@ -8935,6 +8935,35 @@ fn rewrite_grammar_combat_damage_using_toughness_probe_tracks_subject_variant() 
 }
 
 #[test]
+fn rewrite_grammar_defending_player_combat_damage_assignment_probe_matches_static_line() {
+    let tokens = lex_line(
+        "Rather than the attacking player, you assign the combat damage of each creature attacking you. You can divide that creature's combat damage as you choose among any of the creatures blocking it.",
+        0,
+    )
+    .expect("rewrite lexer should classify defending-player combat-damage assignment static line");
+
+    assert!(
+        super::grammar::abilities::is_you_assign_combat_damage_of_creatures_attacking_you_line_lexed(
+            &tokens
+        ),
+        "grammar-owned defending-player combat-damage assignment probe should match Defensive Formation's static line"
+    );
+
+    let parsed =
+        super::keyword_static::parse_you_assign_combat_damage_of_creatures_attacking_you_line(
+            &tokens,
+        )
+        .expect("defending-player combat-damage assignment static line should parse");
+
+    assert!(matches!(
+        parsed,
+        Some(ability)
+            if ability.id()
+                == crate::static_abilities::StaticAbilityId::YouAssignCombatDamageOfCreaturesAttackingYou
+    ));
+}
+
+#[test]
 fn rewrite_grammar_zilortha_lethal_damage_power_static_line() {
     let tokens = lex_line(
         "Lethal damage dealt to creatures you control is determined by their power rather than their toughness.",

--- a/crates/ironsmith-core/src/static_ability_id.rs
+++ b/crates/ironsmith-core/src/static_ability_id.rs
@@ -92,6 +92,7 @@ pub enum StaticAbilityId {
     CantAttackYouUnlessControllerPaysPerAttackerBasicLandTypesAmongLandsYouControl,
     CantBlock,
     MayAssignDamageAsUnblocked,
+    YouAssignCombatDamageOfCreaturesAttackingYou,
     ThisCreatureAssignsCombatDamageUsingToughness,
     CreaturesAssignCombatDamageUsingToughness,
     CreaturesYouControlAssignCombatDamageUsingToughness,
@@ -362,6 +363,7 @@ impl StaticAbilityId {
             | CantAttackYouUnlessControllerPaysPerAttackerBasicLandTypesAmongLandsYouControl
             | CantBlock
             | MayAssignDamageAsUnblocked
+            | YouAssignCombatDamageOfCreaturesAttackingYou
             | ThisCreatureAssignsCombatDamageUsingToughness
             | CreaturesAssignCombatDamageUsingToughness
             | CreaturesYouControlAssignCombatDamageUsingToughness
@@ -671,6 +673,7 @@ impl StaticAbilityId {
                 | CantAttackYouUnlessControllerPaysPerAttackerBasicLandTypesAmongLandsYouControl
                 | CantBlock
                 | MayAssignDamageAsUnblocked
+                | YouAssignCombatDamageOfCreaturesAttackingYou
                 | ThisCreatureAssignsCombatDamageUsingToughness
                 | CreaturesAssignCombatDamageUsingToughness
                 | CreaturesYouControlAssignCombatDamageUsingToughness

--- a/crates/ironsmith-core/src/static_ability_model.rs
+++ b/crates/ironsmith-core/src/static_ability_model.rs
@@ -3588,6 +3588,13 @@ impl<
             payload: StaticAbilityPayload::None,
         }
     }
+    pub fn you_assign_combat_damage_of_creatures_attacking_you() -> Self {
+        Self {
+            id: Some(StaticAbilityId::YouAssignCombatDamageOfCreaturesAttackingYou),
+            label: "you assign combat damage of creatures attacking you".into(),
+            payload: StaticAbilityPayload::None,
+        }
+    }
     pub fn remove_ability(filter: ObjectFilter, ability: StaticAbility<T, E, C, Cond>) -> Self {
         Self {
             id: Some(StaticAbilityId::RemoveAbilityForFilter),

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -44349,6 +44349,210 @@ fn parse_this_creature_assigns_combat_damage_with_toughness_static_line() {
 
 #[cfg(ironsmith_runtime_parser_tests)]
 #[test]
+fn parse_oracle_defensive_formation_strict_and_renders_combat_assignment_clause() {
+    assert_oracle_card_parses_strict("Defensive Formation");
+    let def = parse_oracle_card_definition("Defensive Formation");
+    let rendered = unprocessed_compiled_lines(&def).join(" ");
+    let static_ids: Vec<_> = def
+        .abilities
+        .iter()
+        .filter_map(|ability| match &ability.kind {
+            AbilityKind::Static(static_ability) => Some(static_ability.id()),
+            _ => None,
+        })
+        .collect();
+
+    assert!(
+        static_ids.contains(
+            &crate::static_abilities::StaticAbilityId::YouAssignCombatDamageOfCreaturesAttackingYou
+        ),
+        "expected Defensive Formation to lower to defending-player combat-damage assignment static ability, got {static_ids:?}"
+    );
+    assert!(
+        rendered.contains(
+            "Rather than the attacking player, you assign the combat damage of each creature attacking you"
+        ) && rendered.contains(
+            "You can divide that creature's combat damage as you choose among any of the creatures blocking it"
+        ),
+        "Defensive Formation should render both combat-damage assignment clauses, got {rendered}"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
+fn defensive_formation_defending_player_orders_damage_assignment_for_creatures_attacking_them() {
+    let mut game = crate::game_state::GameState::new(
+        vec!["Alice".to_string(), "Bob".to_string(), "Charlie".to_string()],
+        20,
+    );
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let charlie = PlayerId::from_index(2);
+    let formation = parse_oracle_card_definition("Defensive Formation");
+    game.create_object_from_definition(&formation, alice, Zone::Battlefield);
+
+    let attacker = create_winds_test_creature(&mut game, "Bob Attacker", bob, 4, 4);
+    let alice_blocker_a = create_winds_test_creature(&mut game, "Alice Blocker A", alice, 1, 4);
+    let alice_blocker_b = create_winds_test_creature(&mut game, "Alice Blocker B", alice, 1, 4);
+    let charlie_blocker_a =
+        create_winds_test_creature(&mut game, "Charlie Blocker A", charlie, 1, 4);
+    let charlie_blocker_b =
+        create_winds_test_creature(&mut game, "Charlie Blocker B", charlie, 1, 4);
+    let planeswalker = {
+        let card = crate::card::CardBuilder::new(CardId::new(), "Alice Planeswalker")
+            .card_types(vec![CardType::Planeswalker])
+            .loyalty(3)
+            .build();
+        game.create_object_from_card(&card, alice, Zone::Battlefield)
+    };
+
+    let mut attacking_alice = crate::combat_state::CombatState::default();
+    attacking_alice.attackers.push(crate::combat_state::AttackerInfo {
+        creature: attacker,
+        target: crate::combat_state::AttackTarget::Player(alice),
+    });
+    attacking_alice
+        .blockers
+        .insert(attacker, vec![alice_blocker_a, alice_blocker_b]);
+
+    assert_eq!(
+        crate::game_loop::combat_damage_assignment_player_for_attacker(
+            &game,
+            &attacking_alice,
+            attacker
+        ),
+        Some(alice),
+        "Defensive Formation's controller should assign damage for creatures attacking them"
+    );
+    let order_context =
+        crate::game_loop::get_blocker_order_decision(&game, &attacking_alice, attacker)
+            .expect("multiple blockers should need an order decision");
+    let crate::decisions::context::DecisionContext::Order(order_context) = order_context else {
+        panic!("expected order decision context");
+    };
+    assert_eq!(
+        order_context.player, alice,
+        "Defensive Formation should move the combat damage assignment decision to the defending player"
+    );
+
+    let mut attacking_charlie = crate::combat_state::CombatState::default();
+    attacking_charlie.attackers.push(crate::combat_state::AttackerInfo {
+        creature: attacker,
+        target: crate::combat_state::AttackTarget::Player(charlie),
+    });
+    attacking_charlie
+        .blockers
+        .insert(attacker, vec![charlie_blocker_a, charlie_blocker_b]);
+
+    assert_eq!(
+        crate::game_loop::combat_damage_assignment_player_for_attacker(
+            &game,
+            &attacking_charlie,
+            attacker
+        ),
+        Some(bob),
+        "Defensive Formation should not affect creatures attacking another player"
+    );
+
+    let mut attacking_planeswalker = crate::combat_state::CombatState::default();
+    attacking_planeswalker
+        .attackers
+        .push(crate::combat_state::AttackerInfo {
+            creature: attacker,
+            target: crate::combat_state::AttackTarget::Planeswalker(planeswalker),
+        });
+    attacking_planeswalker
+        .blockers
+        .insert(attacker, vec![alice_blocker_a, alice_blocker_b]);
+
+    assert_eq!(
+        crate::game_loop::combat_damage_assignment_player_for_attacker(
+            &game,
+            &attacking_planeswalker,
+            attacker
+        ),
+        Some(bob),
+        "Defensive Formation should not affect creatures attacking a planeswalker its controller controls"
+    );
+
+    let alice_trampler = create_winds_test_creature(&mut game, "Bob Trampler", bob, 5, 5);
+    if let Some(object) = game.object_mut(alice_trampler) {
+        object.abilities.push(Ability::static_ability(
+            crate::static_abilities::StaticAbility::trample(),
+        ));
+    }
+    let alice_tough_blocker_a =
+        create_winds_test_creature(&mut game, "Alice Tough Blocker A", alice, 0, 6);
+    let alice_tough_blocker_b =
+        create_winds_test_creature(&mut game, "Alice Tough Blocker B", alice, 0, 6);
+    let mut formation_combat = crate::combat_state::CombatState::default();
+    formation_combat
+        .attackers
+        .push(crate::combat_state::AttackerInfo {
+            creature: alice_trampler,
+            target: crate::combat_state::AttackTarget::Player(alice),
+        });
+    formation_combat.blockers.insert(
+        alice_trampler,
+        vec![alice_tough_blocker_a, alice_tough_blocker_b],
+    );
+    game.set_combat_damage_assignment(alice_trampler, alice_tough_blocker_a, 1);
+    game.set_combat_damage_assignment(alice_trampler, alice_tough_blocker_b, 1);
+
+    let alice_life_before = game.player(alice).expect("Alice exists").life;
+    let formation_damage_events =
+        crate::game_loop::execute_combat_damage_step(&mut game, &formation_combat, false);
+    assert_eq!(
+        game.damage_on(alice_tough_blocker_a),
+        1,
+        "Defensive Formation should honor the defending player's chosen damage to the first blocker"
+    );
+    assert_eq!(
+        game.damage_on(alice_tough_blocker_b),
+        4,
+        "Defensive Formation should keep any remaining assigned damage among blockers"
+    );
+    assert_eq!(
+        game.player(alice).expect("Alice exists").life,
+        alice_life_before,
+        "Defensive Formation should keep unassigned trample damage from being assigned to the attacked player, got {formation_damage_events:?}"
+    );
+
+    let charlie_trampler = create_winds_test_creature(&mut game, "Bob Other Trampler", bob, 5, 5);
+    if let Some(object) = game.object_mut(charlie_trampler) {
+        object.abilities.push(Ability::static_ability(
+            crate::static_abilities::StaticAbility::trample(),
+        ));
+    }
+    let charlie_tough_blocker_a =
+        create_winds_test_creature(&mut game, "Charlie Tough Blocker A", charlie, 0, 6);
+    let charlie_tough_blocker_b =
+        create_winds_test_creature(&mut game, "Charlie Tough Blocker B", charlie, 0, 6);
+    let mut normal_combat = crate::combat_state::CombatState::default();
+    normal_combat
+        .attackers
+        .push(crate::combat_state::AttackerInfo {
+            creature: charlie_trampler,
+            target: crate::combat_state::AttackTarget::Player(charlie),
+        });
+    normal_combat.blockers.insert(
+        charlie_trampler,
+        vec![charlie_tough_blocker_a, charlie_tough_blocker_b],
+    );
+    game.set_combat_damage_assignment(charlie_trampler, charlie_tough_blocker_a, 1);
+    game.set_combat_damage_assignment(charlie_trampler, charlie_tough_blocker_b, 1);
+
+    let charlie_life_before = game.player(charlie).expect("Charlie exists").life;
+    crate::game_loop::execute_combat_damage_step(&mut game, &normal_combat, false);
+    assert_eq!(
+        game.player(charlie).expect("Charlie exists").life,
+        charlie_life_before - 3,
+        "Defensive Formation controlled by Alice should not change trample assignment for creatures attacking Charlie"
+    );
+}
+
+#[cfg(ironsmith_runtime_parser_tests)]
+#[test]
 fn parse_return_up_to_one_subtype_list_target_stays_single_clause() {
     let def = CardDefinitionBuilder::new(CardId::from_raw(1), "Thwart Return Variant")
         .card_types(vec![CardType::Sorcery])

--- a/crates/ironsmith-runtime/src/game_loop/combat_damage.rs
+++ b/crates/ironsmith-runtime/src/game_loop/combat_damage.rs
@@ -383,6 +383,31 @@ fn distribute_explicit_damage_to_creatures(
     distribution
 }
 
+fn distribute_explicit_damage_among_blockers_as_chosen(
+    blocker_ids: &[ObjectId],
+    blockers_len: usize,
+    total_damage: u32,
+    explicit_assignments: &std::collections::HashMap<ObjectId, u32>,
+) -> Vec<(u32, bool)> {
+    let mut distribution = Vec::with_capacity(blockers_len);
+    let mut remaining_damage = total_damage;
+
+    for blocker_id in blocker_ids.iter().take(blockers_len) {
+        let requested = explicit_assignments.get(blocker_id).copied().unwrap_or(0);
+        let damage = requested.min(remaining_damage);
+        distribution.push((damage, false));
+        remaining_damage = remaining_damage.saturating_sub(damage);
+    }
+
+    if remaining_damage > 0
+        && let Some((damage, _)) = distribution.last_mut()
+    {
+        *damage = damage.saturating_add(remaining_damage);
+    }
+
+    distribution
+}
+
 fn combat_damage_amount_to_player(result: &DamageResult) -> u32 {
     result.damage_dealt.max(result.poison_counters)
 }
@@ -415,8 +440,20 @@ pub(super) fn deal_damage_to_blockers(
     };
 
     // Calculate damage distribution (handles trample and explicit assignment choices)
+    let defender_assigns_damage =
+        defender_assigns_combat_damage_for_attacker(game, combat, attacker_id);
     let (distribution, excess) = if explicit_assignments.is_empty() {
         distribute_trample_damage(attacker, &blockers, total_damage, game)
+    } else if defender_assigns_damage {
+        (
+            distribute_explicit_damage_among_blockers_as_chosen(
+                &blocker_ids,
+                blockers.len(),
+                total_damage,
+                &explicit_assignments,
+            ),
+            0,
+        )
     } else {
         distribute_explicit_trample_damage(
             game,

--- a/crates/ironsmith-runtime/src/game_loop/combat_decisions.rs
+++ b/crates/ironsmith-runtime/src/game_loop/combat_decisions.rs
@@ -80,6 +80,61 @@ pub(super) fn static_abilities_for_object_with_effects(
         .unwrap_or_default()
 }
 
+pub(super) fn player_assigns_combat_damage_of_creatures_attacking_them(
+    game: &GameState,
+    player: PlayerId,
+) -> bool {
+    let all_effects = game.all_continuous_effects();
+    for &source_id in &game.battlefield {
+        let Some(source) = game.object(source_id) else {
+            continue;
+        };
+        if game.controller_of(source) != player {
+            continue;
+        }
+        for ability in static_abilities_for_object_with_effects(game, source_id, &all_effects) {
+            if ability.id()
+                == crate::static_abilities::StaticAbilityId::YouAssignCombatDamageOfCreaturesAttackingYou
+            {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+pub(super) fn defender_assigns_combat_damage_for_attacker(
+    game: &GameState,
+    combat: &CombatState,
+    attacker: ObjectId,
+) -> bool {
+    if let Some(crate::combat_state::AttackTarget::Player(defender)) =
+        crate::combat_state::get_attack_target(combat, attacker)
+    {
+        return player_assigns_combat_damage_of_creatures_attacking_them(game, *defender);
+    }
+
+    false
+}
+
+pub fn combat_damage_assignment_player_for_attacker(
+    game: &GameState,
+    combat: &CombatState,
+    attacker: ObjectId,
+) -> Option<PlayerId> {
+    let attacker_obj = game.object(attacker)?;
+    let attacking_player = game.controller_of(attacker_obj);
+    if defender_assigns_combat_damage_for_attacker(game, combat, attacker) {
+        if let crate::combat_state::AttackTarget::Player(defender) =
+            crate::combat_state::get_attack_target(combat, attacker)?
+        {
+            return Some(*defender);
+        }
+    }
+
+    Some(attacking_player)
+}
+
 pub(super) fn generic_attack_tax_per_attacker_against_player(
     game: &GameState,
     defending_player: PlayerId,
@@ -740,9 +795,8 @@ pub fn get_blocker_order_decision(
         return None;
     }
 
-    // The attacking creature's controller orders the blockers
     let attacker_obj = game.object(attacker)?;
-    let attacking_player = game.controller_of(attacker_obj);
+    let assignment_player = combat_damage_assignment_player_for_attacker(game, combat, attacker)?;
 
     // Convert blockers to items with names
     let items: Vec<(ObjectId, String)> = blockers
@@ -758,7 +812,7 @@ pub fn get_blocker_order_decision(
 
     let attacker_name = attacker_obj.name.clone();
     let ctx = crate::decisions::context::OrderContext::new(
-        attacking_player,
+        assignment_player,
         Some(attacker),
         format!("Order blockers for {}", attacker_name),
         items,

--- a/crates/ironsmith-runtime/src/static_abilities/combat.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/combat.rs
@@ -1940,6 +1940,12 @@ define_combat_ability!(
 );
 
 define_combat_ability!(
+    YouAssignCombatDamageOfCreaturesAttackingYou,
+    YouAssignCombatDamageOfCreaturesAttackingYou,
+    "Rather than the attacking player, you assign the combat damage of each creature attacking you. You can divide that creature's combat damage as you choose among any of the creatures blocking it"
+);
+
+define_combat_ability!(
     ThisCreatureAssignsCombatDamageUsingToughness,
     ThisCreatureAssignsCombatDamageUsingToughness,
     "This creature assigns combat damage equal to its toughness rather than its power"

--- a/crates/ironsmith-runtime/src/static_abilities/compiler_model.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/compiler_model.rs
@@ -109,6 +109,9 @@ impl StaticAbility {
             Some(StaticAbilityId::MayAssignDamageAsUnblocked) => {
                 Self::may_assign_damage_as_unblocked()
             }
+            Some(StaticAbilityId::YouAssignCombatDamageOfCreaturesAttackingYou) => {
+                Self::you_assign_combat_damage_of_creatures_attacking_you()
+            }
             Some(StaticAbilityId::AttachedGoadedBySourceController) => {
                 Self::attached_goaded_by_source_controller(label)
             }

--- a/crates/ironsmith-runtime/src/static_abilities/mod.rs
+++ b/crates/ironsmith-runtime/src/static_abilities/mod.rs
@@ -2449,6 +2449,10 @@ impl StaticAbility {
         Self::new(MayAssignDamageAsUnblocked)
     }
 
+    pub fn you_assign_combat_damage_of_creatures_attacking_you() -> Self {
+        Self::new(YouAssignCombatDamageOfCreaturesAttackingYou)
+    }
+
     pub fn creatures_assign_combat_damage_using_toughness() -> Self {
         Self::new(CreaturesAssignCombatDamageUsingToughness)
     }


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Defensive Formation
Initial parse error:
```
parser does not yet support line family: 'Rather than the attacking player, you assign the combat damage of each creature attacking you. You can divide that creature's combat damage as you choose among any of the creatures blocking it.'; oracle-only fallback also failed: parser does not yet support line family: 'Rather than the attacking player, you assign the combat damage of each creature attacking you. You can divide that creature's combat damage as you choose among any of the creatures blocking it.'
```

Current worker: i-0a9e129cf3a647304
Branch: codex/aws-card-fix-defensive-formation
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260604T121212Z-controller-dev-loop-wave0029
