### PR TITLE
Fix Ironsmith parse failure: Stolen Strategy

### DIFF
--- a/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/lowering/compile_support/effect_dispatch.rs
@@ -1385,7 +1385,7 @@ fn compile_subject_verb_effect(
                 let resolved_tag = resolve_it_tag_key(tag, &current_reference_env(ctx))?;
                 effect = effect.append_tagged(resolved_tag);
             }
-            if let Some(tag) = tags.first() {
+            if let Some(tag) = tags.first().or_else(|| accumulated_tags.first()) {
                 let resolved_tag = resolve_it_tag_key(tag, &current_reference_env(ctx))?;
                 ctx.last_object_tag = Some(resolved_tag.as_str().to_string());
             }

--- a/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/references/reference_resolution.rs
@@ -834,8 +834,12 @@ fn advance_reference_frame_for_effect(
                 SubjectVerbActionAst::RevealTop => {
                     frame.last_object_tag = Some(next_reference_tag(id_gen, "revealed"));
                 }
-                SubjectVerbActionAst::ExileTopOfLibrary { tags, .. } => {
-                    if let Some(tag) = tags.first() {
+                SubjectVerbActionAst::ExileTopOfLibrary {
+                    tags,
+                    accumulated_tags,
+                    ..
+                } => {
+                    if let Some(tag) = tags.first().or_else(|| accumulated_tags.first()) {
                         frame.last_object_tag = Some(if tag.as_str() == IT_TAG {
                             next_reference_tag(id_gen, "exiled")
                         } else {

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_inner/generic_subject_verb_programs.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/dispatch_inner/generic_subject_verb_programs.rs
@@ -1141,6 +1141,9 @@ fn parse_generic_top_cards_exile_counted_face_down_rest_bottom_subject_verb(
 
     let look_clause = sentence_clause.before(exile_token_idx).trimmed();
     let exile_clause = sentence_clause.from(exile_token_idx).trimmed();
+    if look_clause.is_empty() {
+        return Ok(None);
+    }
     let look_effect = super::verb_handlers::parse_look(look_clause.tokens(), None)?;
     let EffectAst::SubjectVerb(SubjectVerbEffectAst {
         subject: SubjectVerbSubjectAst { player, .. },

--- a/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/exile_actions.rs
+++ b/crates/ironsmith-compiler/src/runtime_backend/sentences/effect_sentences/exile_actions.rs
@@ -551,7 +551,16 @@ pub(crate) fn parse_exile_top_library_clause(
     }
 
     let count_start = token_index_for_word_index(&tokens, start + 1)?;
-    let (count, used_after_top) = parse_value(&tokens[count_start..])?;
+    let count_start_words =
+        crate::runtime_backend::token_word_refs(&tokens[count_start..=count_start]);
+    let (count, used_after_top) = if count_start_words
+        .first()
+        .is_some_and(|word| EXILE_CARD_OR_CARDS_WORD_PATTERN.matches_word(word))
+    {
+        (Value::Fixed(1), 0)
+    } else {
+        parse_value(&tokens[count_start..])?
+    };
     let after_count = trim_commas(&tokens[count_start + used_after_top..]);
     let after_count_words = crate::runtime_backend::token_word_refs(&after_count);
     if !after_count_words
@@ -578,8 +587,8 @@ pub(crate) fn parse_exile_top_library_clause(
             effects: vec![EffectAst::subject_verb_exile_top_of_library(
                 PlayerAst::That,
                 count,
-                vec![helper_tag_for_tokens(&tokens, "exiled")],
                 Vec::new(),
+                vec![helper_tag_for_tokens(&tokens, "exiled")],
             )],
         });
     }

--- a/crates/ironsmith-runtime/src/cards/builders/tests.rs
+++ b/crates/ironsmith-runtime/src/cards/builders/tests.rs
@@ -1233,6 +1233,158 @@ fn arvinox_the_mind_flail_exiles_bottom_cards_and_grants_only_permanent_spell_pe
 }
 
 #[test]
+fn stolen_strategy_strict_parser_compiled_text_and_model_regression() {
+    assert_oracle_card_parses_strict("Stolen Strategy");
+
+    let def = parse_oracle_card_definition("Stolen Strategy");
+    let rendered = compiled_text_lines(&def).join(" ");
+    let ability_debug = format!("{:#?}", def.abilities);
+
+    assert_eq!(def.name(), "Stolen Strategy");
+    assert_eq!(def.card.card_types, vec![CardType::Enchantment]);
+    assert!(
+        rendered.contains("At the beginning of your upkeep, exile the top card of each opponent's library. Until end of turn, you may cast spells from among those exiled cards, and you may spend mana as though it were mana of any color to cast those spells"),
+        "expected Stolen Strategy compiled text to preserve the per-opponent exile and tagged cast permission, got {rendered}"
+    );
+    assert!(
+        ability_debug.contains("BeginningOfUpkeepTrigger")
+            && ability_debug.contains("ForPlayersEffect")
+            && ability_debug.contains("filter: Opponent")
+            && ability_debug.contains("ExileTopOfLibraryEffect")
+            && ability_debug.contains("player: IteratedPlayer")
+            && ability_debug.contains("GrantPlayTaggedEffect")
+            && ability_debug.contains("duration: UntilEndOfTurn")
+            && ability_debug.contains("allow_any_color_for_cast: true"),
+        "expected Stolen Strategy to lower to upkeep-triggered per-opponent top exile plus tagged cast permission, got {ability_debug}"
+    );
+}
+
+#[test]
+fn stolen_strategy_runtime_exiles_each_opponents_top_card_and_grants_cast_permission() {
+    let def = parse_oracle_card_definition("Stolen Strategy");
+    let spell = CardDefinitionBuilder::new(CardId::new(), "Opponent Library Spell")
+        .card_types(vec![CardType::Instant])
+        .with_spell_effect(vec![Effect::draw(1)])
+        .build();
+    let filler = CardDefinitionBuilder::new(CardId::new(), "Library Filler")
+        .card_types(vec![CardType::Sorcery])
+        .with_spell_effect(vec![Effect::draw(1)])
+        .build();
+    let alice = PlayerId::from_index(0);
+    let bob = PlayerId::from_index(1);
+    let charlie = PlayerId::from_index(2);
+    let mut game = crate::game_state::GameState::new(
+        vec!["Alice".to_string(), "Bob".to_string(), "Charlie".to_string()],
+        20,
+    );
+    let stolen_strategy = game.create_object_from_definition(&def, alice, Zone::Battlefield);
+    let alice_top = game.create_object_from_definition(&spell, alice, Zone::Library);
+    let bob_bottom = game.create_object_from_definition(&filler, bob, Zone::Library);
+    let bob_top = game.create_object_from_definition(&spell, bob, Zone::Library);
+    let charlie_bottom = game.create_object_from_definition(&filler, charlie, Zone::Library);
+    let charlie_top = game.create_object_from_definition(&spell, charlie, Zone::Library);
+    let bob_top_stable = game.object(bob_top).expect("bob top setup").stable_id;
+    let charlie_top_stable = game
+        .object(charlie_top)
+        .expect("charlie top setup")
+        .stable_id;
+    assert!(game.set_player_library_order_with_audit(
+        bob,
+        vec![bob_bottom, bob_top],
+        "Stolen Strategy top-card regression setup",
+    ));
+    assert!(game.set_player_library_order_with_audit(
+        charlie,
+        vec![charlie_bottom, charlie_top],
+        "Stolen Strategy top-card regression setup",
+    ));
+
+    let bob_upkeep = crate::triggers::TriggerEvent::new_with_provenance(
+        crate::events::phase::BeginningOfUpkeepEvent::new(bob),
+        crate::provenance::ProvNodeId::default(),
+    );
+    assert_eq!(
+        resolve_triggers_for_source(&mut game, stolen_strategy, &bob_upkeep),
+        0,
+        "Stolen Strategy should not trigger on an opponent's upkeep"
+    );
+    assert_eq!(
+        game.object(bob_top).expect("bob top before upkeep").zone,
+        Zone::Library
+    );
+    assert_eq!(
+        game.object(charlie_top)
+            .expect("charlie top before upkeep")
+            .zone,
+        Zone::Library
+    );
+
+    let alice_upkeep = crate::triggers::TriggerEvent::new_with_provenance(
+        crate::events::phase::BeginningOfUpkeepEvent::new(alice),
+        crate::provenance::ProvNodeId::default(),
+    );
+    assert_eq!(
+        resolve_triggers_for_source(&mut game, stolen_strategy, &alice_upkeep),
+        1,
+        "Stolen Strategy should trigger at the beginning of its controller's upkeep"
+    );
+
+    let bob_exiled = game
+        .find_object_by_stable_id(bob_top_stable)
+        .expect("bob top card should still exist after exile");
+    let charlie_exiled = game
+        .find_object_by_stable_id(charlie_top_stable)
+        .expect("charlie top card should still exist after exile");
+    assert_eq!(
+        game.object(alice_top).expect("alice top").zone,
+        Zone::Library
+    );
+    assert_eq!(
+        game.object(bob_bottom).expect("bob bottom").zone,
+        Zone::Library
+    );
+    assert_eq!(
+        game.object(charlie_bottom).expect("charlie bottom").zone,
+        Zone::Library
+    );
+    assert_eq!(
+        game.object(bob_exiled).expect("bob exiled").zone,
+        Zone::Exile
+    );
+    assert_eq!(
+        game.object(charlie_exiled)
+            .expect("charlie exiled")
+            .zone,
+        Zone::Exile
+    );
+
+    for exiled in [bob_exiled, charlie_exiled] {
+        assert!(
+            game.effect_store.grant_registry.card_can_play_from_zone(
+                &game,
+                exiled,
+                Zone::Exile,
+                alice,
+            ),
+            "Alice should be able to cast each card exiled by Stolen Strategy"
+        );
+        assert!(
+            game.can_spend_mana_as_any_color(alice, Some(exiled)),
+            "Alice should be able to spend mana as any color to cast each Stolen Strategy card"
+        );
+        assert!(
+            !game.effect_store.grant_registry.card_can_play_from_zone(
+                &game,
+                exiled,
+                Zone::Exile,
+                bob,
+            ),
+            "Stolen Strategy should grant the cast permission only to its controller"
+        );
+    }
+}
+
+#[test]
 fn clockspinning_strict_parser_and_compiled_text_regression() {
     assert_oracle_card_parses_strict("Clockspinning");
 

--- a/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
+++ b/crates/ironsmith-runtime/src/compiled_text/render_effects.rs
@@ -3943,6 +3943,10 @@ fn describe_structural_multisentence_effect_list(effects: &[Effect]) -> Option<S
         return describe_structural_multisentence_effect_list(rest);
     }
 
+    if let Some(compact) = describe_each_opponent_exile_top_then_cast_until_eot_any_color(effects) {
+        return Some(compact);
+    }
+
     let refs = effects.iter().collect::<Vec<_>>();
     if let Some(compact) = describe_player_protection_from_everything_pair(&refs) {
         return Some(compact);
@@ -5653,6 +5657,44 @@ fn describe_roll_die_then_scry_result(effects: &[Effect]) -> Option<String> {
     ))
 }
 
+fn describe_each_opponent_exile_top_then_cast_until_eot_any_color(
+    effects: &[Effect],
+) -> Option<String> {
+    let [for_players_effect, grant_effect] = effects else {
+        return None;
+    };
+    let for_players = for_players_effect.downcast_ref::<crate::effects::ForPlayersEffect>()?;
+    if for_players.filter != PlayerFilter::Opponent || for_players.effects.len() != 1 {
+        return None;
+    }
+    let exile_top = for_players.effects[0]
+        .downcast_ref::<crate::effects::ExileTopOfLibraryEffect>()?;
+    if exile_top.player != PlayerFilter::IteratedPlayer
+        || exile_top.count != Value::Fixed(1)
+        || !exile_top.moved_tags.is_empty()
+        || exile_top.accumulated_tags.len() != 1
+    {
+        return None;
+    }
+
+    let grant = grant_effect.downcast_ref::<crate::effects::GrantPlayTaggedEffect>()?;
+    if grant.tag != exile_top.accumulated_tags[0]
+        || grant.player != PlayerFilter::You
+        || grant.duration != crate::effects::GrantPlayTaggedDuration::UntilEndOfTurn
+        || grant.allow_land
+        || !grant.allow_any_color_for_cast
+        || grant.while_on_top_of_library
+        || grant.filter.is_some()
+    {
+        return None;
+    }
+
+    Some(
+        "Exile the top card of each opponent's library. Until end of turn, you may cast spells from among those exiled cards, and you may spend mana as though it were mana of any color to cast those spells"
+            .to_string(),
+    )
+}
+
 fn describe_group_pump_then_conditional_untap(effects: &[Effect]) -> Option<String> {
     let [pump_effect, conditional_effect] = effects else {
         return None;
@@ -5732,6 +5774,9 @@ pub(super) fn describe_effect_list(effects: &[Effect]) -> String {
         && let Some(compact) =
             describe_for_players_bottom_library_exile_then_look_cast(for_players, look, grant)
     {
+        return compact;
+    }
+    if let Some(compact) = describe_each_opponent_exile_top_then_cast_until_eot_any_color(effects) {
         return compact;
     }
     if let Some(compact) = describe_structural_multisentence_effect_list(effects) {


### PR DESCRIPTION
Automated Ironsmith card-fixer worker.

Card: Stolen Strategy
Initial parse error:
```
unsupported look clause (clause: ''); oracle-only fallback also failed: unsupported look clause (clause: '')
```

Current worker: i-0070d85f85e5c254c
Branch: codex/aws-card-fix-stolen-strategy
Status/artifacts prefix: s3://ironsmith-card-fixers-843750990226-us-east-2/sessions/20260604T121212Z-controller-dev-loop-wave0029
