### PR TITLE
fix(wasm): return Manabrew bridge views as plain JS objects

### DIFF
--- a/crates/ironsmith-wasm/src/wasm_game_impl/manabrew_compat.rs
+++ b/crates/ironsmith-wasm/src/wasm_game_impl/manabrew_compat.rs
@@ -695,6 +695,17 @@ fn state_from_snapshot(
     json!({ "gameView": game_view_from_snapshot(snapshot, seat, overlay_cache) })
 }
 
+// A `serde_json::Value::Object` serializes to a JS `Map` under the default
+// serde-wasm-bindgen serializer, so the Manabrew side (which reads these by
+// property, e.g. `view.state.gameView`) sees `undefined`. `json_compatible`
+// emits plain objects/arrays, matching what the typed-struct returns already do.
+fn manabrew_value_to_js(value: &Value, label: &str) -> Result<JsValue, JsValue> {
+    use serde::Serialize;
+    value
+        .serialize(&serde_wasm_bindgen::Serializer::json_compatible())
+        .map_err(|error| JsValue::from_str(&format!("failed to encode {label}: {error}")))
+}
+
 fn redact_private_state(state: &Value) -> Value {
     let mut state = state.clone();
     let Some(players) = state
@@ -1764,8 +1775,7 @@ impl WasmGame {
             "state": state,
             "promptResult": manabrew_prompt_from_snapshot(&snapshot, &prompt_id),
         });
-        serde_wasm_bindgen::to_value(&view)
-            .map_err(|error| JsValue::from_str(&format!("failed to encode Manabrew view: {error}")))
+        manabrew_value_to_js(&view, "Manabrew view")
     }
 
     #[wasm_bindgen(js_name = manabrewPublicState)]
@@ -1778,8 +1788,7 @@ impl WasmGame {
             self.perspective,
             &mut self.manabrew_overlay_cache,
         );
-        serde_wasm_bindgen::to_value(&redact_private_state(&state))
-            .map_err(|error| JsValue::from_str(&format!("failed to encode Manabrew public state: {error}")))
+        manabrew_value_to_js(&redact_private_state(&state), "Manabrew public state")
     }
 
     #[wasm_bindgen(js_name = manabrewPrompt)]
@@ -1787,8 +1796,10 @@ impl WasmGame {
         let snapshot_js = self.ui_state()?;
         let snapshot: Value = serde_wasm_bindgen::from_value(snapshot_js)
             .map_err(|error| JsValue::from_str(&format!("failed to decode Ironsmith UI state: {error}")))?;
-        serde_wasm_bindgen::to_value(&manabrew_prompt_from_snapshot(&snapshot, &prompt_id))
-            .map_err(|error| JsValue::from_str(&format!("failed to encode Manabrew prompt: {error}")))
+        manabrew_value_to_js(
+            &manabrew_prompt_from_snapshot(&snapshot, &prompt_id),
+            "Manabrew prompt",
+        )
     }
 
     #[wasm_bindgen(js_name = manabrewCommandFromPromptOutput)]


### PR DESCRIPTION
## Summary

The Manabrew compat bridge's view/state/prompt getters return their payload built from a `serde_json::Value`, which the **default** serde-wasm-bindgen serializer encodes as a JS **`Map`**, not a plain object. The Manabrew side reads these by property (`view.state.gameView`, `state.gameView`), which is `undefined` on a `Map` — so every match start fails there with *"Ironsmith WASM did not return a Manabrew game view"*, even for a deck that `validateManabrewMatchConfig` accepts. (Validation works precisely because it returns a typed struct, which serializes as a plain object.)

Fix: serialize those three `Value` returns with `serde_wasm_bindgen::Serializer::json_compatible()` (plain objects/arrays), via a small `manabrew_value_to_js` helper. `manabrewView`, `manabrewPublicState`, and `manabrewPrompt` are affected; `manabrewCommandFromPromptOutput` is left as-is (its return is fed straight back into `dispatch`, i.e. read by wasm via `from_value`, never by JS property access).

## Why it matters

Without this, the Manabrew ⇄ Ironsmith trusted runtime cannot start a game at all — it renders a board only after the bridge return is normalized. Manabrew currently ships a defensive `Map`→object normalize on its side to work around it; this is the clean upstream fix so that workaround can be dropped.

## Test plan

- `cargo check -p ironsmith-wasm --target wasm32-unknown-unknown --no-default-features --features wasm-lean` — clean.
- `./rebuild-wasm.sh` — builds `pkg/`.
- Synced the rebuilt `pkg` into Manabrew and drove a full multiplayer game (Playwright, real relay) **with Manabrew's own `Map` workaround removed**: `manabrewView` now returns a plain object, the board renders, and the game reaches mulligan → priority in both single-client+bot and two-human (encrypted relay) flows.
