### PR TITLE
fix: tolerate browser stalls in peer heartbeat

### DIFF
--- a/web/ui/src/hooks/peer-lobby/connections.js
+++ b/web/ui/src/hooks/peer-lobby/connections.js
@@ -137,6 +137,7 @@ export function usePeerLobbyConnections(base, servicesRef) {
 
     const heartbeat = {
       lastSeen: Date.now(),
+      lastCheck: Date.now(),
       timer: window.setInterval(() => {
         if (!conn || conn.open === false) {
           clearConnectionHeartbeat(key);
@@ -145,10 +146,29 @@ export function usePeerLobbyConnections(base, servicesRef) {
         }
 
         const nowMs = Date.now();
+        const localSchedulerDelayMs = nowMs - heartbeat.lastCheck;
+        heartbeat.lastCheck = nowMs;
+        // Do not condemn the remote peer immediately after this tab's own
+        // event loop was suspended or heavily throttled.  Give the queued
+        // heartbeat/data events one full timeout window to arrive.
+        if (localSchedulerDelayMs > timeoutMs) {
+          recordPeerSyncPerf("peer_heartbeat:local_scheduler_stall", {
+            connection: key,
+            scheduler_delay_ms: localSchedulerDelayMs,
+            timeout_ms: timeoutMs,
+          });
+          heartbeat.lastSeen = nowMs;
+        }
         if (
           nowMs - heartbeat.lastSeen > timeoutMs
           && !pendingActionIntentSuppressesHeartbeatStale(nowMs)
         ) {
+          recordPeerSyncPerf("peer_heartbeat:timeout", {
+            connection: key,
+            silent_ms: nowMs - heartbeat.lastSeen,
+            timeout_ms: timeoutMs,
+            connection_open: conn.open !== false,
+          });
           clearConnectionHeartbeat(key);
           try {
             conn.close();

--- a/web/ui/src/hooks/peer-lobby/shared.js
+++ b/web/ui/src/hooks/peer-lobby/shared.js
@@ -109,7 +109,10 @@ export const INITIAL_MATCH_CLOCK_HASH = "0".repeat(64);
 export const PEER_OPEN_TIMEOUT_MS = 10000;
 export const PEER_CONNECT_TIMEOUT_MS = 15000;
 export const PEER_HEARTBEAT_INTERVAL_MS = 3000;
-export const PEER_HEARTBEAT_TIMEOUT_MS = 10000;
+// A busy or backgrounded browser can easily miss a few application-level
+// heartbeats while its WebRTC connection is still healthy.  Ten seconds was
+// short enough to turn ordinary event-loop stalls into destructive reconnects.
+export const PEER_HEARTBEAT_TIMEOUT_MS = 45000;
 export const DEFAULT_PLAYER_CLOCK_MS = 40 * 60 * 1000;
 export const MATCH_CLOCK_TICK_MS = 1000;
 export const MATCH_CLOCK_CLAIM_SKEW_MS = 2000;


### PR DESCRIPTION
## Summary
- increase the application heartbeat timeout from 10s to 45s so ordinary browser throttling and short network stalls do not tear down a healthy WebRTC session
- detect a delayed local heartbeat scheduler and grant a fresh timeout window instead of blaming the remote peer
- record scheduler-stall and real-timeout diagnostics in the existing bounded peer performance log

This intentionally leaves the wire protocol, action sequencing, resync, audit state, cryptography, and WASM engine untouched.

## Diagnosis
The previous 10-second liveness threshold could expire when a tab was backgrounded, the main event loop was suspended, or a busy client delayed heartbeat processing. Closing the DataConnection then triggered the much heavier reconnect/host-takeover path, which explains abrupt peer loss after an otherwise healthy period of play.

## Tests
- `pnpm test:p2p-browser` — 14 P2P audit/disconnect/resync scenarios passed
- focused PeerJS reconnect/resync/host-takeover E2E — passed
- targeted ESLint — 0 errors (pre-existing hook dependency warnings remain)
- `git diff --check` — passed

The full UI + real WASM test cannot start from a clean upstream checkout because generated `web/wasm_demo/pkg/engine.js`, `compiler.js`, and `verifier.js` artifacts are not committed. The failure occurs before lobby creation and is unrelated to this JavaScript-only networking change.