### PR TITLE
Make PeerJS recovery tolerant and survive browser refresh

### DIFF
--- a/web/ui/.env.example
+++ b/web/ui/.env.example
@@ -21,8 +21,11 @@
 # Optional websocket ping interval for the signaling connection, in milliseconds.
 # VITE_PEER_PING_INTERVAL=5000
 
-# Optional ICE/TURN config passed directly to RTCPeerConnection.
+# Optional ICE/STUN/TURN config passed directly to RTCPeerConnection.
 # This should be a JSON array of RTCIceServer objects.
+# STUN helps peers discover routable paths; TURN is required when both peers
+# are behind restrictive NATs. Use credentials from a TURN server you control
+# (for example, a small self-hosted coturn instance); never commit credentials.
 # Example:
 # VITE_PEER_ICE_SERVERS=[{"urls":["stun:stun.l.google.com:19302","stun:stun1.l.google.com:19302"]},{"urls":"turn:turn.example.com:3478","username":"user","credential":"pass"}]
 

--- a/web/ui/README.md
+++ b/web/ui/README.md
@@ -35,3 +35,18 @@ VITE_PEER_SECURE=false
 ```
 
 Use the host machine's LAN IP for `VITE_PEER_HOST`, not `0.0.0.0`. If you are serving the Vite dev app across machines, start it with `pnpm dev --host 0.0.0.0`.
+
+### ICE/TURN for restrictive networks
+
+The client accepts an optional `VITE_PEER_ICE_SERVERS` JSON array and passes it
+to WebRTC. Public STUN servers can improve address discovery, but they do not
+relay traffic. For peers that cannot connect directly, configure a TURN relay
+you control (for example coturn) in both clients' `.env.local` files:
+
+```bash
+VITE_PEER_ICE_SERVERS=[{"urls":["stun:stun.l.google.com:19302"]},{"urls":"turn:turn.example.com:3478","username":"user","credential":"pass"}]
+```
+
+Keep TURN credentials out of git and inject them at deployment time. No
+browser-only P2P setup can guarantee connectivity when a device is offline or
+the browser is suspended; TURN removes the common NAT traversal failure mode.

--- a/web/ui/src/components/layout/Shell.jsx
+++ b/web/ui/src/components/layout/Shell.jsx
@@ -41,9 +41,30 @@ export default function Shell() {
   } = useGame();
   useTabAttention();
   const initialPuzzleQueryRef = useRef(readPuzzleQueryParams());
+  const syncedLobbyUrlRef = useRef("");
   const [playerNames, setPlayerNames] = useState(
     () => initialPuzzlePlayerNames(initialPuzzleQueryRef.current) || "Alice,Bob,Charlie,Diana"
   );
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const lobbyId = String(multiplayer?.lobbyId || multiplayer?.hostPeerId || "").trim();
+    const active = multiplayer?.mode && multiplayer.mode !== "idle";
+    const currentUrl = new URL(window.location.href);
+    if (active && lobbyId) {
+      if (currentUrl.searchParams.get("lobby") !== lobbyId) {
+        currentUrl.searchParams.set("lobby", lobbyId);
+        window.history.replaceState({}, "", currentUrl.toString());
+      }
+      syncedLobbyUrlRef.current = lobbyId;
+      return;
+    }
+    if (syncedLobbyUrlRef.current && currentUrl.searchParams.get("lobby") === syncedLobbyUrlRef.current) {
+      currentUrl.searchParams.delete("lobby");
+      window.history.replaceState({}, "", currentUrl.toString());
+    }
+    syncedLobbyUrlRef.current = "";
+  }, [multiplayer?.hostPeerId, multiplayer?.lobbyId, multiplayer?.mode]);
   const [startingLife, setStartingLife] = useState(
     () => initialPuzzleStartingLife(initialPuzzleQueryRef.current) ?? 20
   );

--- a/web/ui/src/hooks/peer-lobby/connections.js
+++ b/web/ui/src/hooks/peer-lobby/connections.js
@@ -111,6 +111,7 @@ export function usePeerLobbyConnections(base, servicesRef) {
     const heartbeat = connectionHeartbeatsRef.current.get(key);
     if (heartbeat) {
       heartbeat.lastSeen = Date.now();
+      heartbeat.missedTimeouts = 0;
     }
   }, []);
 
@@ -134,12 +135,23 @@ export function usePeerLobbyConnections(base, servicesRef) {
     clearConnectionHeartbeat(key);
     const { intervalMs, timeoutMs } = peerHeartbeatConfigRef.current;
     if (!intervalMs || !timeoutMs) return;
+    const maxMissedTimeouts = 3;
 
     const heartbeat = {
       lastSeen: Date.now(),
       lastCheck: Date.now(),
+      missedTimeouts: 0,
+      lastTimeoutLogAt: 0,
       timer: window.setInterval(() => {
-        if (!conn || conn.open === false) {
+        const dataChannelState = String(conn?.dataChannel?.readyState || "").toLowerCase();
+        const iceState = String(conn?.peerConnection?.iceConnectionState || "").toLowerCase();
+        if (
+          !conn
+          || conn.open === false
+          || dataChannelState === "closed"
+          || iceState === "failed"
+          || iceState === "closed"
+        ) {
           clearConnectionHeartbeat(key);
           onStale?.("Connection closed");
           return;
@@ -163,12 +175,28 @@ export function usePeerLobbyConnections(base, servicesRef) {
           nowMs - heartbeat.lastSeen > timeoutMs
           && !pendingActionIntentSuppressesHeartbeatStale(nowMs)
         ) {
-          recordPeerSyncPerf("peer_heartbeat:timeout", {
-            connection: key,
-            silent_ms: nowMs - heartbeat.lastSeen,
-            timeout_ms: timeoutMs,
-            connection_open: conn.open !== false,
-          });
+          if (nowMs - heartbeat.lastTimeoutLogAt >= timeoutMs) {
+            recordPeerSyncPerf("peer_heartbeat:timeout", {
+              connection: key,
+              silent_ms: nowMs - heartbeat.lastSeen,
+              timeout_ms: timeoutMs,
+              missed_windows: heartbeat.missedTimeouts + 1,
+              connection_open: conn.open !== false,
+            });
+            heartbeat.lastTimeoutLogAt = nowMs;
+          }
+          heartbeat.missedTimeouts += 1;
+          if (heartbeat.missedTimeouts < maxMissedTimeouts) {
+            // Application-level silence is not proof that WebRTC is dead: the
+            // browser may be backgrounded or the event loop may be suspended.
+            // Require several consecutive windows before recovery is started.
+            safeSend(conn, {
+              type: "peer_heartbeat",
+              protocolVersion: PROTOCOL_VERSION,
+              at: nowMs,
+            });
+            return;
+          }
           clearConnectionHeartbeat(key);
           try {
             conn.close();


### PR DESCRIPTION
## Problem
Transient browser/event-loop stalls were treated as a dead WebRTC peer, causing the game to end early. Refreshing a host or guest also lost the lobby entry point.

## Fix
- Treat native DataChannel/ICE failure as immediately actionable, but require 3 consecutive heartbeat windows before declaring application-level failure.
- Reset missed windows on any valid inbound traffic and record scheduler stalls separately.
- Persist the active lobby id in the URL and remove it on an explicit idle/leave, allowing the existing reconnect/takeover/resync flow to resume after refresh.

## Validation
- `pnpm test:p2p-browser` (14/14 scenarios passed)
- PeerJS reconnect/resync E2E: guest reconnect and host-takeover reconnect passed
- Targeted ESLint: no errors (only existing React hook dependency warnings)
- `git diff --check`

This deliberately keeps the existing protocol, state-resync, reconnect-proof, and takeover architecture intact. It cannot guarantee connectivity through broken NAT or an offline browser; those cases require deployable TURN credentials via `VITE_PEER_ICE_SERVERS`.