### PR TITLE
WIP: add authoritative Cloudflare Durable Object lobby transport

### DIFF
--- a/.github/workflows/deploy-realtime.yml
+++ b/.github/workflows/deploy-realtime.yml
@@ -1,0 +1,31 @@
+name: Deploy realtime Worker
+
+on:
+  push:
+    branches: [main, codex/websocket-authoritative-migration]
+    paths:
+      - "web/realtime-worker/**"
+      - ".github/workflows/deploy-realtime.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test-and-deploy:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: web/realtime-worker
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - run: npm install --ignore-scripts
+      - run: npm test
+      - if: ${{ github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch' }}
+        run: npx wrangler deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/web/realtime-worker/README.md
+++ b/web/realtime-worker/README.md
@@ -1,0 +1,16 @@
+# Ironsmith realtime worker
+
+This Worker provides one authoritative Durable Object per lobby. Clients join
+over WebSocket, submit idempotent actions, and resume from their last sequence
+after a refresh or network interruption.
+
+## Deploy
+
+```bash
+npm install
+npx wrangler deploy
+```
+
+The CI workflow should provide `CLOUDFLARE_API_TOKEN` and
+`CLOUDFLARE_ACCOUNT_ID` as secrets. The frontend endpoint is:
+`wss://<worker-domain>/lobby?id=<lobby-id>`.

--- a/web/realtime-worker/src/index.js
+++ b/web/realtime-worker/src/index.js
@@ -1,0 +1,116 @@
+const MAX_MESSAGE_BYTES = 256 * 1024;
+const MAX_ACTION_BYTES = 128 * 1024;
+const MAX_REPLAY = 500;
+
+function json(data) {
+  return JSON.stringify(data);
+}
+
+function response(status, body) {
+  return new Response(json(body), {
+    status,
+    headers: { "content-type": "application/json; charset=utf-8" },
+  });
+}
+
+export default {
+  async fetch(request, env) {
+    const url = new URL(request.url);
+    if (url.pathname === "/health") return response(200, { ok: true });
+    if (url.pathname !== "/lobby") return response(404, { error: "not_found" });
+    const lobbyId = url.searchParams.get("id")?.trim();
+    if (!lobbyId || lobbyId.length > 128) return response(400, { error: "invalid_lobby" });
+    const id = env.LOBBIES.idFromName(lobbyId);
+    return env.LOBBIES.get(id).fetch(request);
+  },
+};
+
+export class LobbyRoom {
+  constructor(state) {
+    this.state = state;
+    this.sessions = new Map();
+  }
+
+  async fetch(request) {
+    if (request.headers.get("Upgrade")?.toLowerCase() !== "websocket") {
+      return response(426, { error: "websocket_required" });
+    }
+    const pair = new WebSocketPair();
+    const [client, server] = Object.values(pair);
+    server.accept();
+    const session = { socket: server, playerId: "", lastSequence: 0 };
+    this.sessions.set(server, session);
+    server.addEventListener("message", (event) => {
+      this.handleMessage(session, event.data).catch((error) => {
+        this.send(session, { type: "error", code: "server_error", message: String(error?.message || error) });
+      });
+    });
+    server.addEventListener("close", () => this.sessions.delete(server));
+    server.addEventListener("error", () => this.sessions.delete(server));
+    return new Response(null, { status: 101, webSocket: client });
+  }
+
+  async handleMessage(session, raw) {
+    if (typeof raw !== "string" || new TextEncoder().encode(raw).byteLength > MAX_MESSAGE_BYTES) {
+      this.send(session, { type: "error", code: "message_too_large" });
+      return;
+    }
+    let message;
+    try { message = JSON.parse(raw); } catch { this.send(session, { type: "error", code: "invalid_json" }); return; }
+    if (message?.type === "join") return this.join(session, message);
+    if (message?.type === "ping") return this.send(session, { type: "pong", at: message.at ?? Date.now() });
+    if (message?.type === "action") return this.action(session, message);
+    if (message?.type === "resume") return this.resume(session, message);
+    this.send(session, { type: "error", code: "unknown_message" });
+  }
+
+  async join(session, message) {
+    const playerId = String(message.playerId || "").trim();
+    if (!playerId || playerId.length > 128) return this.send(session, { type: "error", code: "invalid_player" });
+    session.playerId = playerId;
+    const sequence = await this.sequence();
+    this.send(session, { type: "joined", playerId, sequence });
+    await this.replay(session, Number(message.lastSequence ?? 0));
+  }
+
+  async resume(session, message) {
+    if (!session.playerId) return this.send(session, { type: "error", code: "join_required" });
+    await this.replay(session, Number(message.lastSequence ?? 0));
+  }
+
+  async action(session, message) {
+    if (!session.playerId) return this.send(session, { type: "error", code: "join_required" });
+    const actionId = String(message.actionId || "").trim();
+    if (!actionId || actionId.length > 256) return this.send(session, { type: "error", code: "invalid_action_id" });
+    const payload = message.payload;
+    const encoded = json(payload);
+    if (new TextEncoder().encode(encoded).byteLength > MAX_ACTION_BYTES) return this.send(session, { type: "error", code: "action_too_large" });
+    const key = `action:${actionId}`;
+    const existing = await this.state.storage.get(key);
+    if (existing) return this.send(session, { type: "action_ack", actionId, sequence: existing.sequence, duplicate: true });
+    const sequence = (await this.sequence()) + 1;
+    const record = { actionId, playerId: session.playerId, payload, sequence, at: Date.now() };
+    await this.state.storage.put(key, record);
+    await this.state.storage.put(`sequence:${sequence}`, record);
+    await this.state.storage.put("meta:sequence", sequence);
+    this.broadcast({ type: "action", ...record });
+    this.send(session, { type: "action_ack", actionId, sequence, duplicate: false });
+  }
+
+  async sequence() { return Number((await this.state.storage.get("meta:sequence")) || 0); }
+
+  async replay(session, lastSequence) {
+    const current = await this.sequence();
+    const from = Math.max(0, Number.isFinite(lastSequence) ? lastSequence : 0);
+    const records = [];
+    for (let sequence = from + 1; sequence <= current && records.length < MAX_REPLAY; sequence += 1) {
+      const record = await this.state.storage.get(`sequence:${sequence}`);
+      if (record) records.push(record);
+    }
+    this.send(session, { type: "replay", from: from + 1, to: current, actions: records });
+    session.lastSequence = current;
+  }
+
+  send(session, message) { try { session.socket.send(json(message)); } catch { this.sessions.delete(session.socket); } }
+  broadcast(message) { for (const session of this.sessions.values()) this.send(session, message); }
+}

--- a/web/realtime-worker/src/index.js
+++ b/web/realtime-worker/src/index.js
@@ -61,6 +61,7 @@ export class LobbyRoom {
     if (message?.type === "ping") return this.send(session, { type: "pong", at: message.at ?? Date.now() });
     if (message?.type === "action") return this.action(session, message);
     if (message?.type === "resume") return this.resume(session, message);
+    if (message?.type === "snapshot") return this.snapshot(session, message);
     this.send(session, { type: "error", code: "unknown_message" });
   }
 
@@ -76,6 +77,19 @@ export class LobbyRoom {
   async resume(session, message) {
     if (!session.playerId) return this.send(session, { type: "error", code: "join_required" });
     await this.replay(session, Number(message.lastSequence ?? 0));
+  }
+
+  async snapshot(session, message) {
+    if (!session.playerId) return this.send(session, { type: "error", code: "join_required" });
+    const snapshot = message.state;
+    if (snapshot === undefined) return this.send(session, { type: "error", code: "invalid_snapshot" });
+    const encoded = json(snapshot);
+    if (new TextEncoder().encode(encoded).byteLength > MAX_ACTION_BYTES) {
+      return this.send(session, { type: "error", code: "snapshot_too_large" });
+    }
+    const sequence = await this.sequence();
+    await this.state.storage.put("snapshot", { sequence, state: snapshot, at: Date.now() });
+    this.send(session, { type: "snapshot_ack", sequence });
   }
 
   async action(session, message) {
@@ -102,13 +116,20 @@ export class LobbyRoom {
   async replay(session, lastSequence) {
     const current = await this.sequence();
     const from = Math.max(0, Number.isFinite(lastSequence) ? lastSequence : 0);
+    const snapshot = await this.state.storage.get("snapshot");
+    if (snapshot && from < snapshot.sequence && current - from > MAX_REPLAY) {
+      this.send(session, { type: "snapshot_required", sequence: snapshot.sequence, snapshot: snapshot.state });
+      session.lastSequence = snapshot.sequence;
+      return;
+    }
     const records = [];
     for (let sequence = from + 1; sequence <= current && records.length < MAX_REPLAY; sequence += 1) {
       const record = await this.state.storage.get(`sequence:${sequence}`);
       if (record) records.push(record);
     }
-    this.send(session, { type: "replay", from: from + 1, to: current, actions: records });
-    session.lastSequence = current;
+    const complete = records.length === current - from;
+    this.send(session, { type: "replay", from: from + 1, to: current, actions: records, complete });
+    session.lastSequence = complete ? current : from + records.length;
   }
 
   send(session, message) { try { session.socket.send(json(message)); } catch { this.sessions.delete(session.socket); } }

--- a/web/realtime-worker/test/lobby.test.mjs
+++ b/web/realtime-worker/test/lobby.test.mjs
@@ -1,0 +1,9 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { LobbyRoom } from "../src/index.js";
+
+test("worker source exposes an authoritative lobby object", async () => {
+  assert.equal(typeof LobbyRoom, "function");
+  assert.ok(LobbyRoom.prototype.handleMessage);
+  assert.ok(LobbyRoom.prototype.replay);
+});

--- a/web/realtime-worker/test/lobby.test.mjs
+++ b/web/realtime-worker/test/lobby.test.mjs
@@ -7,3 +7,43 @@ test("worker source exposes an authoritative lobby object", async () => {
   assert.ok(LobbyRoom.prototype.handleMessage);
   assert.ok(LobbyRoom.prototype.replay);
 });
+
+function roomHarness() {
+  const values = new Map();
+  const sent = [];
+  const state = { storage: {
+    async get(key) { return values.get(key); },
+    async put(key, value) { values.set(key, value); },
+  } };
+  const room = new LobbyRoom(state);
+  const socket = { send(value) { sent.push(JSON.parse(value)); } };
+  const session = { socket, playerId: "", lastSequence: 0 };
+  room.sessions.set(socket, session);
+  return { room, session, sent };
+}
+
+test("actions are sequenced, acknowledged, and idempotent", async () => {
+  const { room, session, sent } = roomHarness();
+  await room.handleMessage(session, JSON.stringify({ type: "join", playerId: "p1" }));
+  await room.handleMessage(session, JSON.stringify({
+    type: "action", actionId: "a1", payload: { command: "pass" },
+  }));
+  await room.handleMessage(session, JSON.stringify({
+    type: "action", actionId: "a1", payload: { command: "pass" },
+  }));
+  const acknowledgements = sent.filter((message) => message.type === "action_ack");
+  assert.deepEqual(acknowledgements.map((message) => message.sequence), [1, 1]);
+  assert.equal(acknowledgements[1].duplicate, true);
+});
+
+test("resume replays actions after a reconnect", async () => {
+  const { room, session } = roomHarness();
+  await room.handleMessage(session, JSON.stringify({ type: "join", playerId: "p1" }));
+  await room.handleMessage(session, JSON.stringify({ type: "action", actionId: "a1", payload: { n: 1 } }));
+  const resumed = { socket: { send(value) { resumed.messages.push(JSON.parse(value)); } }, playerId: "p1", messages: [] };
+  room.sessions.set(resumed.socket, resumed);
+  await room.handleMessage(resumed, JSON.stringify({ type: "resume", lastSequence: 0 }));
+  const replay = resumed.messages.find((message) => message.type === "replay");
+  assert.equal(replay.actions.length, 1);
+  assert.equal(replay.actions[0].actionId, "a1");
+});

--- a/web/realtime-worker/wrangler.toml
+++ b/web/realtime-worker/wrangler.toml
@@ -1,0 +1,11 @@
+name = "ironsmith-realtime"
+main = "src/index.js"
+compatibility_date = "2026-09-08"
+
+[[durable_objects.bindings]]
+name = "LOBBIES"
+class_name = "LobbyRoom"
+
+[[migrations]]
+tag = "v1"
+new_sqlite_classes = ["LobbyRoom"]

--- a/web/ui/src/hooks/peer-lobby/realtime-config.js
+++ b/web/ui/src/hooks/peer-lobby/realtime-config.js
@@ -1,0 +1,15 @@
+export function realtimeLobbyUrl(lobbyId, baseUrl = import.meta.env?.VITE_REALTIME_WS_URL) {
+  const lobby = String(lobbyId || "").trim();
+  const base = String(baseUrl || "").trim();
+  if (!lobby || !base) return "";
+  let url;
+  try {
+    url = new URL(base, globalThis.location?.origin || "http://localhost");
+  } catch {
+    return "";
+  }
+  if (!["ws:", "wss:"].includes(url.protocol)) return "";
+  url.pathname = url.pathname.replace(/\/$/, "") + "/lobby";
+  url.searchParams.set("id", lobby);
+  return url.toString();
+}

--- a/web/ui/src/hooks/peer-lobby/websocket-connection.js
+++ b/web/ui/src/hooks/peer-lobby/websocket-connection.js
@@ -1,0 +1,62 @@
+// PeerJS-compatible connection facade for the authoritative lobby Worker.
+// Keeping this small adapter separate lets the existing validation/resync
+// pipeline consume WebSocket messages without depending on browser globals in
+// tests or leaking transport details into the game engine.
+
+export function createWebSocketConnection(url, { peer = "realtime", WebSocketImpl = globalThis.WebSocket } = {}) {
+  if (typeof WebSocketImpl !== "function") {
+    throw new Error("WebSocket is not available in this environment");
+  }
+  const listeners = new Map();
+  const socket = new WebSocketImpl(url);
+  const connection = {
+    peer,
+    open: false,
+    reliable: true,
+    serialization: "json",
+    socket,
+    on(event, handler) {
+      if (typeof handler !== "function") return connection;
+      const handlers = listeners.get(event) || new Set();
+      handlers.add(handler);
+      listeners.set(event, handlers);
+      return connection;
+    },
+    off(event, handler) {
+      listeners.get(event)?.delete(handler);
+      return connection;
+    },
+    send(message) {
+      if (socket.readyState !== WebSocketImpl.OPEN) {
+        throw new Error("WebSocket connection is not open");
+      }
+      socket.send(JSON.stringify(message));
+    },
+    close() {
+      socket.close();
+    },
+  };
+  const emit = (event, ...args) => {
+    for (const handler of listeners.get(event) || []) handler(...args);
+  };
+  socket.addEventListener("open", () => {
+    connection.open = true;
+    emit("open");
+  });
+  socket.addEventListener("message", (event) => {
+    let message;
+    try {
+      message = typeof event.data === "string" ? JSON.parse(event.data) : event.data;
+    } catch {
+      emit("error", new Error("Invalid JSON from realtime lobby"));
+      return;
+    }
+    emit("data", message);
+  });
+  socket.addEventListener("error", (event) => emit("error", event));
+  socket.addEventListener("close", (event) => {
+    connection.open = false;
+    emit("close", event);
+  });
+  return connection;
+}

--- a/web/ui/src/hooks/peer-lobby/websocket-connection.js
+++ b/web/ui/src/hooks/peer-lobby/websocket-connection.js
@@ -2,6 +2,9 @@
 // Keeping this small adapter separate lets the existing validation/resync
 // pipeline consume WebSocket messages without depending on browser globals in
 // tests or leaking transport details into the game engine.
+import { realtimeLobbyUrl } from "./realtime-config.js";
+
+export { realtimeLobbyUrl };
 
 export function createWebSocketConnection(url, { peer = "realtime", WebSocketImpl = globalThis.WebSocket } = {}) {
   if (typeof WebSocketImpl !== "function") {

--- a/web/ui/tests/realtime-config.test.js
+++ b/web/ui/tests/realtime-config.test.js
@@ -1,0 +1,14 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { realtimeLobbyUrl } from "../src/hooks/peer-lobby/realtime-config.js";
+
+test("builds a scoped WebSocket lobby URL", () => {
+  assert.equal(
+    realtimeLobbyUrl("abc 123", "wss://realtime.example.com"),
+    "wss://realtime.example.com/lobby?id=abc+123"
+  );
+});
+
+test("rejects non-WebSocket endpoints", () => {
+  assert.equal(realtimeLobbyUrl("abc", "https://example.com"), "");
+});

--- a/web/ui/tests/websocket-connection.test.js
+++ b/web/ui/tests/websocket-connection.test.js
@@ -1,0 +1,31 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createWebSocketConnection } from "../src/hooks/peer-lobby/websocket-connection.js";
+
+class FakeWebSocket {
+  static OPEN = 1;
+  constructor() { this.readyState = 0; this.handlers = new Map(); this.sent = []; }
+  addEventListener(event, handler) { this.handlers.set(event, handler); }
+  open() { this.readyState = FakeWebSocket.OPEN; this.handlers.get("open")?.(); }
+  receive(data) { this.handlers.get("message")?.({ data }); }
+  send(value) { this.sent.push(value); }
+  close() { this.readyState = 3; this.handlers.get("close")?.({ code: 1000 }); }
+}
+
+test("WebSocket facade exposes PeerJS-like open, data, send and close events", () => {
+  let socket;
+  const connection = createWebSocketConnection("wss://example.test/lobby?id=x", {
+    WebSocketImpl: class extends FakeWebSocket { constructor(url) { super(); socket = this; this.url = url; } },
+    peer: "p1",
+  });
+  const received = [];
+  connection.on("data", (message) => received.push(message));
+  socket.open();
+  assert.equal(connection.open, true);
+  connection.send({ type: "ping" });
+  socket.receive('{"type":"pong"}');
+  assert.deepEqual(received, [{ type: "pong" }]);
+  assert.deepEqual(JSON.parse(socket.sent[0]), { type: "ping" });
+  connection.close();
+  assert.equal(connection.open, false);
+});


### PR DESCRIPTION
## Status: foundational transport (WIP)

This draft adds the Cloudflare Durable Object transport core for review. It is intentionally not wired into the existing PeerJS UI yet.

## Included
- one Durable Object per lobby;
- WebSocket join/ping/resume protocol;
- durable, sequenced and idempotent action log;
- replay from the client's last sequence after reconnect;
- message and replay bounds;
- Wrangler configuration and CI deployment notes.

## Verification
- `node --test web/realtime-worker/test/lobby.test.mjs`
- `git diff --check`

## Next integration step
Adapt `usePeerLobby` behind a transport interface, preserve the current signed action validation and WASM engine, then add deployed WebSocket E2E tests for guest reconnect, host refresh, simultaneous refresh, duplicates and out-of-order delivery. This draft is not a claim that the full migration is complete.