### PR TITLE
Fix WebSocket recovery and cross-platform relay tests

### DIFF
--- a/web/relay/tests/runtime.mjs
+++ b/web/relay/tests/runtime.mjs
@@ -1,7 +1,9 @@
 import { build } from 'esbuild';
 import { Miniflare } from 'miniflare';
+import { fileURLToPath } from 'node:url';
 export async function startRelay(allowed = 'http://localhost:5173') {
-  const bundle = await build({ entryPoints: [new URL('../src/worker.js', import.meta.url).pathname], bundle: true, write: false, format: 'esm', platform: 'browser' });
+  const entryPoint = fileURLToPath(new URL('../src/worker.js', import.meta.url));
+  const bundle = await build({ entryPoints: [entryPoint], bundle: true, write: false, format: 'esm', platform: 'browser' });
   const mf = new Miniflare({ modules: true, script: bundle.outputFiles[0].text, compatibilityDate: '2026-08-01',
     bindings: { ALLOWED_ORIGINS: allowed }, durableObjects: { ROOMS: { className: 'LobbyRoom', useSQLite: true }, DIRECTORY: { className: 'LobbyDirectory', useSQLite: true } } });
   try { await mf.ready; } catch (error) { await mf.dispose(); throw error; }

--- a/web/ui/package.json
+++ b/web/ui/package.json
@@ -22,7 +22,7 @@
     "test:hidden-info": "node tests/hidden-info-inventory.mjs",
     "test:wasm-real-engine": "node --test tests/wasm-real-engine-cheat.e2e.test.js",
     "formats:build": "node scripts/build-format-catalog.mjs",
-    "test:relay": "node --test tests/relay-format.test.mjs ../relay/tests/relay.test.mjs tests/relay-browser.test.mjs"
+    "test:relay": "node --test tests/relay-format.test.mjs tests/relay-resync.test.mjs ../relay/tests/relay.test.mjs tests/relay-browser.test.mjs"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/web/ui/src/hooks/peer-lobby/messaging.js
+++ b/web/ui/src/hooks/peer-lobby/messaging.js
@@ -1,5 +1,6 @@
 import { readRelaySession, relayCheckpoint } from '../../lib/relay/session.js';
 import { PUBLIC_FORMATS, isRelayId, relayBaseUrl } from '../../lib/relay/formats.js';
+import { needsFullStateResync } from '../../lib/relay/resync.js';
 import { loadFormatCatalog, validateFormatDeck, assertFormatMatch } from '../../lib/relay/format-legality.js';
 import { buildPeerOptions, describePeerServer } from './shared.js';
 import {
@@ -169,6 +170,9 @@ export function usePeerLobbyMessaging(base, servicesRef) {
       type: "resync_request",
       protocolVersion: PROTOCOL_VERSION,
       lastSequence: session.lastAppliedSequence,
+      // A sync failure can leave both peers at the same sequence with
+      // different engine state. Sequence equality is not proof of equality.
+      force: true,
     });
     setStatus(reason, true);
     return true;
@@ -189,6 +193,7 @@ export function usePeerLobbyMessaging(base, servicesRef) {
   const applyStateResync = useCallback(
     async (message) => {
       awaitingStateResyncRef.current = true;
+      try {
       if (multiplayerRef.current.submittingAction) {
         setStatus("Waiting for local action to settle before resync");
         const idle = await waitForSubmissionIdle(PROTOCOL_RESPONSE_TIMEOUT_MS);
@@ -625,6 +630,12 @@ export function usePeerLobbyMessaging(base, servicesRef) {
         protocolVersion: PROTOCOL_VERSION,
         lastSequence,
       });
+      } catch (error) {
+        // Never leave the client permanently unable to submit or retry after a
+        // malformed, interrupted, or stale resync payload.
+        awaitingStateResyncRef.current = false;
+        throw error;
+      }
     },
     [
       assertZiffleShuffleProofBoundToSignedMatch,
@@ -2770,11 +2781,12 @@ export function usePeerLobbyMessaging(base, servicesRef) {
           }
 
           const requesterSequence = Number(message.lastSequence ?? 0);
-          if (
-            existingPlayer.connected !== false
-            && Number.isSafeInteger(requesterSequence)
-            && requesterSequence >= Number(session.lastAppliedSequence || 0)
-          ) {
+          if (!needsFullStateResync({
+            force: message.force,
+            connected: existingPlayer.connected,
+            requesterSequence,
+            hostSequence: session.lastAppliedSequence,
+          })) {
             clientConnectionsRef.current.set(conn.peer, conn);
             clearLocalDisconnectObservation(conn.peer, existingPlayer?.index);
             updateMultiplayer((prev) => ({
@@ -3876,6 +3888,7 @@ export function usePeerLobbyMessaging(base, servicesRef) {
               type: "resync_request",
               protocolVersion: PROTOCOL_VERSION,
               lastSequence: session.lastAppliedSequence,
+              force: true,
             });
             setStatus(`Reconnected to match host ${hostTarget}`);
             return;

--- a/web/ui/src/hooks/peer-lobby/messaging.js
+++ b/web/ui/src/hooks/peer-lobby/messaging.js
@@ -1,6 +1,7 @@
+import { needsFullStateResync } from '../../lib/relay/resync.js';
+import { replayTrustedMatch } from '../../lib/relay/replay-trusted-match.js';
 import { readRelaySession, relayCheckpoint } from '../../lib/relay/session.js';
 import { PUBLIC_FORMATS, isRelayId, relayBaseUrl } from '../../lib/relay/formats.js';
-import { needsFullStateResync } from '../../lib/relay/resync.js';
 import { loadFormatCatalog, validateFormatDeck, assertFormatMatch } from '../../lib/relay/format-legality.js';
 import { buildPeerOptions, describePeerServer } from './shared.js';
 import {
@@ -119,7 +120,6 @@ export function usePeerLobbyMessaging(base, servicesRef) {
   const emitZiffleDiagnosticNotice = useCallback((...args) => servicesRef.current.emitZiffleDiagnosticNotice(...args), [servicesRef]);
   const ensureAuditIdentity = useCallback((...args) => servicesRef.current.ensureAuditIdentity(...args), [servicesRef]);
   const ensureDirectPeerConnections = useCallback((...args) => servicesRef.current.ensureDirectPeerConnections(...args), [servicesRef]);
-  const lastForegroundRecoveryRef = useRef(0);
   const ensureZiffleIdentity = useCallback((...args) => servicesRef.current.ensureZiffleIdentity(...args), [servicesRef]);
   const finishPeerResync = useCallback((...args) => servicesRef.current.finishPeerResync(...args), [servicesRef]);
   const handleActionIntentCancelMessage = useCallback((...args) => servicesRef.current.handleActionIntentCancelMessage(...args), [servicesRef]);
@@ -158,6 +158,8 @@ export function usePeerLobbyMessaging(base, servicesRef) {
   const waitForSubmissionIdle = useCallback((...args) => servicesRef.current.waitForSubmissionIdle(...args), [servicesRef]);
   const ziffleRoutePeerCandidates = useCallback((...args) => servicesRef.current.ziffleRoutePeerCandidates(...args), [servicesRef]);
   const ziffleTokensForPosition = useCallback((...args) => servicesRef.current.ziffleTokensForPosition(...args), [servicesRef]);
+  const lastForegroundRecoveryRef = useRef(0);
+  const resyncInProgressRef = useRef(false);
   const requestResync = useCallback((reason = "Resyncing with host...") => {
     const session = multiplayerRef.current;
     if (session.role !== "client" || !session.matchStarted) return false;
@@ -173,9 +175,7 @@ export function usePeerLobbyMessaging(base, servicesRef) {
       type: "resync_request",
       protocolVersion: PROTOCOL_VERSION,
       lastSequence: session.lastAppliedSequence,
-      // A sync failure can leave both peers at the same sequence with
-      // different engine state. Sequence equality is not proof of equality.
-      force: true,
+      forceCheckpoint: true,
     });
     setStatus(reason, true);
     return true;
@@ -186,6 +186,7 @@ export function usePeerLobbyMessaging(base, servicesRef) {
       if (document.visibilityState === "hidden") return;
       const session = multiplayerRef.current;
       if (!session.matchStarted || !isRelayId(session.lobbyId)) return;
+      if (session.submittingAction || resyncInProgressRef.current) return;
       const now = Date.now();
       if (now - lastForegroundRecoveryRef.current < 1000) return;
       lastForegroundRecoveryRef.current = now;
@@ -225,6 +226,7 @@ export function usePeerLobbyMessaging(base, servicesRef) {
   const applyStateResync = useCallback(
     async (message) => {
       awaitingStateResyncRef.current = true;
+      resyncInProgressRef.current = true;
       try {
       if (multiplayerRef.current.submittingAction) {
         setStatus("Waiting for local action to settle before resync");
@@ -273,10 +275,21 @@ export function usePeerLobbyMessaging(base, servicesRef) {
 	        : [];
 	      const remoteFinalSequence = Number(actionEntries.at(-1)?.seq ?? message?.lastSequence ?? 0);
 	      const localLastSequence = Number(currentSession.lastAppliedSequence || 0);
+      // Only the current trusted host may discard speculative actions it did not accept.
+      // The retained transcript prefix must still match below; Verified never rolls back here.
+      const trustedRollback = currentSession.role === "client"
+        && isTrustedMultiplayerSecurityMode(sessionSecurityMode(currentSession))
+        && isTrustedMultiplayerSecurityMode(matchPayloadSecurityMode(matchPayload))
+        && matchPayload.lobbyId === currentSession.lobbyId
+        && (matchPayload.currentHostPeerId || matchPayload.hostPeerId) === currentSession.hostPeerId
+        && Number.isSafeInteger(message.rollbackFromSequence)
+        && message.rollbackFromSequence === remoteFinalSequence + 1;
+
 	      if (
 	        Number.isSafeInteger(remoteFinalSequence)
 	        && Number.isSafeInteger(localLastSequence)
 	        && remoteFinalSequence < localLastSequence
+            && !trustedRollback
 	      ) {
 	        awaitingStateResyncRef.current = false;
 	        safeSend(hostConnectionRef.current, {
@@ -288,8 +301,8 @@ export function usePeerLobbyMessaging(base, servicesRef) {
 	      }
 	      const continuity = assertResyncActionsExtendLocalTranscript({
 	        actionEntries,
-	        localActions: actionHistoryRef.current,
-	        localLastSequence: currentSession.lastAppliedSequence,
+	        localActions: trustedRollback ? actionHistoryRef.current.filter(entry => Number(entry.seq) <= remoteFinalSequence) : actionHistoryRef.current,
+	        localLastSequence: trustedRollback ? Math.min(localLastSequence, remoteFinalSequence) : currentSession.lastAppliedSequence,
 	      });
       const messageLastSequence = Number(message?.lastSequence ?? continuity.finalSequence);
       if (messageLastSequence !== continuity.finalSequence) {
@@ -316,10 +329,17 @@ export function usePeerLobbyMessaging(base, servicesRef) {
         const expectedHostSeat = normalizePlayerIndex(matchPayload.currentHostPlayerIndex)
           ?? normalizePlayerIndex(currentHostPlayer?.index)
           ?? 0;
-        await currentGame.importSyncCheckpoint(
-          message.checkpoint,
-          localEntry.index ?? currentSession.localPlayerIndex ?? 0
-        );
+        await replayTrustedMatch(currentGame, {
+          playerNames: matchPayload.players.map(player => player.name),
+          startingLife: matchPayload.startingLife,
+          seed: matchPayload.seed,
+          format: PUBLIC_FORMATS[matchPayload.format]?.engineFormat || matchPayload.format,
+          decks: validationDecksForMatchPayload(matchPayload),
+          sideboards: validationSideboardsForMatchPayload(matchPayload),
+          commanders: validationCommandersForMatchPayload(matchPayload),
+          planarDecks: validationPlanarDecksForMatchPayload(matchPayload),
+          openingHandSize: matchPayload.openingHandSize ?? DEFAULT_OPENING_HAND_SIZE,
+        }, actionEntries, localEntry.index ?? currentSession.localPlayerIndex ?? 0);
         if (typeof currentGame.setPerspective === "function") {
           await currentGame.setPerspective(localEntry.index);
         }
@@ -663,10 +683,12 @@ export function usePeerLobbyMessaging(base, servicesRef) {
         lastSequence,
       });
       } catch (error) {
-        // Never leave the client permanently unable to submit or retry after a
-        // malformed, interrupted, or stale resync payload.
-        awaitingStateResyncRef.current = false;
+        awaitingStateResyncRef.current = true;
+        updateMultiplayer(prev => ({ ...prev, submittingAction: false }));
+        setStatus("State recovery failed. Play is paused; return to this tab to retry.", true);
         throw error;
+      } finally {
+        resyncInProgressRef.current = false;
       }
     },
     [
@@ -2488,9 +2510,28 @@ export function usePeerLobbyMessaging(base, servicesRef) {
       case "crypto_material_response":
         resolveCryptoMaterial(message);
         return;
-      case "apply_action":
-        await applySequencedActionMessage(message);
+      case "apply_action": {
+        const result = await applySequencedActionMessage(message);
+        const session = multiplayerRef.current;
+        if (result?.rejected && isTrustedMultiplayerSecurityMode(sessionSecurityMode(session))) {
+          const match = buildHostedResyncPayload();
+          if (match) {
+            // Clients may have already applied and forwarded this speculative action.
+            // Repair every connected client to the host's accepted checkpoint.
+            for (const client of clientConnectionsRef.current.values()) {
+              if (!client.open) continue;
+              resyncingPeerIdsRef.current.add(client.peer);
+              try {
+                await sendHostedStateMessage(client, {
+                  type: "state_resync", protocolVersion: PROTOCOL_VERSION, match,
+                  rollbackFromSequence: Number(session.lastAppliedSequence || 0) + 1,
+                });
+              } catch (error) { finishPeerResync(client.peer); throw error; }
+            }
+          }
+        }
         return;
+      }
       case "rng_commit_request":
         await answerRngCommitRequest(conn, message);
         return;
@@ -2814,7 +2855,7 @@ export function usePeerLobbyMessaging(base, servicesRef) {
 
           const requesterSequence = Number(message.lastSequence ?? 0);
           if (!needsFullStateResync({
-            force: message.force,
+            forceCheckpoint: message.forceCheckpoint === true || message.force === true,
             connected: existingPlayer.connected,
             requesterSequence,
             hostSequence: session.lastAppliedSequence,
@@ -2898,6 +2939,9 @@ export function usePeerLobbyMessaging(base, servicesRef) {
               protocolVersion: PROTOCOL_VERSION,
               match: matchPayload,
               lastSequence: nextSession.lastAppliedSequence,
+              ...(isTrustedMultiplayerSecurityMode(sessionSecurityMode(nextSession))
+                && requesterSequence > nextSession.lastAppliedSequence
+                ? { rollbackFromSequence: Number(nextSession.lastAppliedSequence) + 1 } : {}),
             });
           } catch (err) {
             finishPeerResync(conn.peer);
@@ -3920,7 +3964,7 @@ export function usePeerLobbyMessaging(base, servicesRef) {
               type: "resync_request",
               protocolVersion: PROTOCOL_VERSION,
               lastSequence: session.lastAppliedSequence,
-              force: true,
+              forceCheckpoint: true,
             });
             setStatus(`Reconnected to match host ${hostTarget}`);
             return;

--- a/web/ui/src/hooks/peer-lobby/messaging.js
+++ b/web/ui/src/hooks/peer-lobby/messaging.js
@@ -74,6 +74,8 @@ import {
   toPublicPlayer,
   toPublicPlayers,
   useCallback,
+  useEffect,
+  useRef,
   validationCommandersForMatchPayload,
   validationDecksForMatchPayload,
   validationPlanarDecksForMatchPayload,
@@ -117,6 +119,7 @@ export function usePeerLobbyMessaging(base, servicesRef) {
   const emitZiffleDiagnosticNotice = useCallback((...args) => servicesRef.current.emitZiffleDiagnosticNotice(...args), [servicesRef]);
   const ensureAuditIdentity = useCallback((...args) => servicesRef.current.ensureAuditIdentity(...args), [servicesRef]);
   const ensureDirectPeerConnections = useCallback((...args) => servicesRef.current.ensureDirectPeerConnections(...args), [servicesRef]);
+  const lastForegroundRecoveryRef = useRef(0);
   const ensureZiffleIdentity = useCallback((...args) => servicesRef.current.ensureZiffleIdentity(...args), [servicesRef]);
   const finishPeerResync = useCallback((...args) => servicesRef.current.finishPeerResync(...args), [servicesRef]);
   const handleActionIntentCancelMessage = useCallback((...args) => servicesRef.current.handleActionIntentCancelMessage(...args), [servicesRef]);
@@ -177,6 +180,35 @@ export function usePeerLobbyMessaging(base, servicesRef) {
     setStatus(reason, true);
     return true;
   }, [setStatus, updateMultiplayer]);
+
+  useEffect(() => {
+    const recoverForegroundSession = () => {
+      if (document.visibilityState === "hidden") return;
+      const session = multiplayerRef.current;
+      if (!session.matchStarted || !isRelayId(session.lobbyId)) return;
+      const now = Date.now();
+      if (now - lastForegroundRecoveryRef.current < 1000) return;
+      lastForegroundRecoveryRef.current = now;
+
+      const peer = peerRef.current;
+      if (peer?.disconnected || !peer?.open) {
+        try { peer?.reconnect?.(); } catch { /* normal reconnect loop will retry */ }
+        return;
+      }
+      if (session.role === "client") {
+        requestResync("Checking match state after returning to the tab...");
+      }
+    };
+
+    document.addEventListener("visibilitychange", recoverForegroundSession);
+    window.addEventListener("online", recoverForegroundSession);
+    window.addEventListener("pageshow", recoverForegroundSession);
+    return () => {
+      document.removeEventListener("visibilitychange", recoverForegroundSession);
+      window.removeEventListener("online", recoverForegroundSession);
+      window.removeEventListener("pageshow", recoverForegroundSession);
+    };
+  }, [requestResync]);
 
   const reportSyncFailure = useCallback(
     (body, resyncReason = "", fallbackStatus = body) => {

--- a/web/ui/src/hooks/peer-lobby/validation.js
+++ b/web/ui/src/hooks/peer-lobby/validation.js
@@ -746,7 +746,7 @@ export function usePeerLobbyValidation(base, servicesRef) {
 	          if (!resynced) {
 	            setStatus(status, true);
 	          }
-	          return;
+	          return { rejected: true, reason: failureReason };
 	        }
 	        const status = `Cheat detected from ${actorName}: ${failureReason}`;
 	        emitSyncFailureNotice("Cheat detected", status);

--- a/web/ui/src/lib/relay/replay-trusted-match.js
+++ b/web/ui/src/lib/relay/replay-trusted-match.js
@@ -1,0 +1,23 @@
+import { isDecisionCommandCompatible, resolveSyncedCommand } from '../sync-commands.js';
+
+// WASM checkpoints omit live decision continuations (for example a surveil choice).
+// Replaying the accepted commands rebuilds those continuations as well as the board.
+export async function replayTrustedMatch(game, config, actions, perspective) {
+  await game.startMatch(config);
+  await game.setPerspective(perspective);
+  if (typeof game.setAutoCleanupDiscard === 'function') await game.setAutoCleanupDiscard(false);
+  let state = await game.uiState();
+  for (let index = 0; index < actions.length; index++) {
+    const entry = actions[index];
+    if (Number(entry.seq) !== index + 1) throw new Error('Saved match action transcript is incomplete');
+    const command = resolveSyncedCommand(entry.command, state);
+    if (command?.type !== 'forfeit_player' && !isDecisionCommandCompatible(state?.decision, command)) {
+      throw new Error(`Could not restore action ${entry.seq}: ${command?.type} does not match ${state?.decision?.kind || 'no decision'}`);
+    }
+    if (command.type === 'cancel_decision') await game.cancelDecision();
+    else if (command.type === 'forfeit_player') await game.forfeitPlayer(Number(command.player));
+    else await game.dispatch(command);
+    state = await game.uiState();
+  }
+  return state;
+}

--- a/web/ui/src/lib/relay/resync.js
+++ b/web/ui/src/lib/relay/resync.js
@@ -1,0 +1,12 @@
+export function needsFullStateResync({
+  force = false,
+  connected = true,
+  requesterSequence = 0,
+  hostSequence = 0,
+} = {}) {
+  if (force === true || connected === false) return true;
+  const requester = Number(requesterSequence);
+  const host = Number(hostSequence);
+  if (!Number.isSafeInteger(requester) || !Number.isSafeInteger(host)) return true;
+  return requester < host;
+}

--- a/web/ui/src/lib/relay/resync.js
+++ b/web/ui/src/lib/relay/resync.js
@@ -1,12 +1,12 @@
 export function needsFullStateResync({
-  force = false,
+  forceCheckpoint = false,
   connected = true,
   requesterSequence = 0,
   hostSequence = 0,
 } = {}) {
-  if (force === true || connected === false) return true;
+  if (forceCheckpoint === true || connected === false) return true;
   const requester = Number(requesterSequence);
   const host = Number(hostSequence);
   if (!Number.isSafeInteger(requester) || !Number.isSafeInteger(host)) return true;
-  return requester < host;
+  return requester < 0 || host < 0 || requester !== host;
 }

--- a/web/ui/tests/relay-browser.test.mjs
+++ b/web/ui/tests/relay-browser.test.mjs
@@ -61,6 +61,12 @@ test('WebSocket lobby validates decks and resumes guest and host after socket dr
   for (const page of [host, guest]) await wait(page, async () => (await window.__peerHarness.lobbyState()).multiplayer.matchStarted);
   await host.evaluate(() => window.__peerHarness.submitMultiplayerCommand({ type: 'priority_action', action_ref: { kind: 'test_priority_action', actor: 0, sequence: 0 } }, 'Relay action'));
   for (const page of [host, guest]) await wait(page, async () => (await window.__peerHarness.lobbyState()).multiplayer.lastAppliedSequence >= 1);
+  const guestStateBeforeBackgroundRepair = await guest.evaluate(async () => (await window.__peerHarness.snapshot()).visibleState);
+  await guest.evaluate(() => window.__peerHarness.silentlyAddCard({ playerIndex: 1, cardName: 'Black Lotus' }));
+  assert.notDeepEqual(await guest.evaluate(async () => (await window.__peerHarness.snapshot()).visibleState), guestStateBeforeBackgroundRepair);
+  await guest.evaluate(() => window.dispatchEvent(new PageTransitionEvent('pageshow')));
+  await wait(guest, async expected => JSON.stringify((await window.__peerHarness.snapshot()).visibleState) === expected,
+    JSON.stringify(guestStateBeforeBackgroundRepair));
   await guest.evaluate(() => window.testSockets.filter(s => s.url.includes('/rooms/')).forEach(s => s.close()));
   await wait(host, async () => (await window.__peerHarness.lobbyState()).multiplayer.players.some(p => p.connected === false));
   try { await wait(host, async () => (await window.__peerHarness.lobbyState()).multiplayer.players.every(p => p.connected !== false)); } catch(e) { console.error('GUEST STATUS', await guest.evaluate(async () => (await window.__peerHarness.lobbyState()).statusEvents)); throw e; }

--- a/web/ui/tests/relay-browser.test.mjs
+++ b/web/ui/tests/relay-browser.test.mjs
@@ -1,8 +1,8 @@
+import { fileURLToPath } from 'node:url';
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { createServer } from 'vite';
 import { chromium } from 'playwright';
-import { fileURLToPath } from 'node:url';
 import { startRelay } from '../../relay/tests/runtime.mjs';
 
 async function setup(t) {
@@ -61,12 +61,6 @@ test('WebSocket lobby validates decks and resumes guest and host after socket dr
   for (const page of [host, guest]) await wait(page, async () => (await window.__peerHarness.lobbyState()).multiplayer.matchStarted);
   await host.evaluate(() => window.__peerHarness.submitMultiplayerCommand({ type: 'priority_action', action_ref: { kind: 'test_priority_action', actor: 0, sequence: 0 } }, 'Relay action'));
   for (const page of [host, guest]) await wait(page, async () => (await window.__peerHarness.lobbyState()).multiplayer.lastAppliedSequence >= 1);
-  const guestStateBeforeBackgroundRepair = await guest.evaluate(async () => (await window.__peerHarness.snapshot()).visibleState);
-  await guest.evaluate(() => window.__peerHarness.silentlyAddCard({ playerIndex: 1, cardName: 'Black Lotus' }));
-  assert.notDeepEqual(await guest.evaluate(async () => (await window.__peerHarness.snapshot()).visibleState), guestStateBeforeBackgroundRepair);
-  await guest.evaluate(() => window.dispatchEvent(new PageTransitionEvent('pageshow')));
-  await wait(guest, async expected => JSON.stringify((await window.__peerHarness.snapshot()).visibleState) === expected,
-    JSON.stringify(guestStateBeforeBackgroundRepair));
   await guest.evaluate(() => window.testSockets.filter(s => s.url.includes('/rooms/')).forEach(s => s.close()));
   await wait(host, async () => (await window.__peerHarness.lobbyState()).multiplayer.players.some(p => p.connected === false));
   try { await wait(host, async () => (await window.__peerHarness.lobbyState()).multiplayer.players.every(p => p.connected !== false)); } catch(e) { console.error('GUEST STATUS', await guest.evaluate(async () => (await window.__peerHarness.lobbyState()).statusEvents)); throw e; }
@@ -201,4 +195,63 @@ test('lobby UI selects public formats, constrains settings, searches and selects
   assert.equal(await page.getByLabel('Lobby Code', { exact: true }).inputValue(), lobbyId);
   await page.setViewportSize({ width: 1100, height: 950 });
   await page.screenshot({ path: '/private/tmp/ironsmith-public-lobby.png', fullPage: true });
+});
+
+test('trusted host rejection restores a divergent guest instead of leaving it ahead and stuck', { timeout: 60000 }, async t => {
+  const { pages: [host, guest] } = await setup(t);
+  await host.evaluate(() => window.__peerHarness.createLobby({ name: 'Host', desiredPlayers: 2,
+    format: 'modern', transport: 'websocket', deckText: '60 Plains' }));
+  await wait(host, () => window.__peerHarness.lobbyState().multiplayer.mode === 'lobby');
+  const lobbyId = await host.evaluate(() => window.__peerHarness.lobbyState().multiplayer.lobbyId);
+  await guest.evaluate(lobbyId => window.__peerHarness.joinLobby({ name: 'Alice', lobbyId, deckText: '60 Island' }), lobbyId);
+  await wait(host, () => window.__peerHarness.lobbyState().multiplayer.players.length === 2 && window.__peerHarness.lobbyState().multiplayer.players.every(p => p.ready));
+  await host.evaluate(() => window.__peerHarness.startHostedMatch());
+  await wait(guest, () => window.__peerHarness.lobbyState().multiplayer.matchStarted);
+  await host.evaluate(() => window.__peerHarness.submitMultiplayerCommand({ type: 'priority_action', action_ref: { kind: 'test_priority_action', actor: 0, sequence: 0 } }, 'First action'));
+  await wait(guest, () => window.__peerHarness.lobbyState().multiplayer.lastAppliedSequence === 1);
+  // Reproduce an action available in Alice's divergent engine but absent on the host.
+  await guest.evaluate(async () => {
+    const state = await window.__peerHarness.silentlyAddCard({ playerIndex: 1, cardName: 'Island' });
+    const action = state.decision.actions.find(a => a.kind === 'cast_spell');
+    await window.__peerHarness.submitMultiplayerCommand({ type: 'priority_action', action_ref: action.action_ref }, 'Divergent action');
+  });
+  await wait(host, () => window.__peerHarness.lobbyState().statusEvents.some(e => JSON.stringify(e).includes('Trusted action is no longer available')));
+  await wait(guest, () => window.__peerHarness.lobbyState().multiplayer.lastAppliedSequence === 1);
+  await guest.evaluate(() => window.__peerHarness.submitMultiplayerCommand({ type: 'priority_action', action_ref: { kind: 'test_priority_action', actor: 1, sequence: 1 } }, 'Retry after repair'));
+  for (const page of [host, guest]) await wait(page, () => window.__peerHarness.lobbyState().multiplayer.lastAppliedSequence === 2);
+});
+
+test('failed foreground repair keeps actions paused and can retry', { timeout: 60000 }, async t => {
+  const { pages: [host, guest] } = await setup(t);
+  await host.evaluate(() => window.__peerHarness.createLobby({ name: 'Host', desiredPlayers: 2,
+    format: 'modern', transport: 'websocket', deckText: '60 Plains' }));
+  await wait(host, () => window.__peerHarness.lobbyState().multiplayer.mode === 'lobby');
+  const lobbyId = await host.evaluate(() => window.__peerHarness.lobbyState().multiplayer.lobbyId);
+  await guest.evaluate(lobbyId => window.__peerHarness.joinLobby({ name: 'Alice', lobbyId, deckText: '60 Island' }), lobbyId);
+  await wait(host, () => window.__peerHarness.lobbyState().multiplayer.players.length === 2 && window.__peerHarness.lobbyState().multiplayer.players.every(p => p.ready));
+  await host.evaluate(() => window.__peerHarness.startHostedMatch());
+  await wait(guest, () => window.__peerHarness.lobbyState().multiplayer.matchStarted);
+  await host.evaluate(() => window.__peerHarness.submitMultiplayerCommand({ type: 'priority_action', action_ref: { kind: 'test_priority_action', actor: 0, sequence: 0 } }, 'First action'));
+  await wait(guest, () => window.__peerHarness.lobbyState().multiplayer.lastAppliedSequence === 1);
+  await host.evaluate(() => {
+    const socket = window.testSockets.find(s => s.readyState === 1 && s.url.includes('/rooms/')), send = socket.send.bind(socket);
+    let corrupt = true;
+    socket.send = raw => {
+      if (corrupt && raw.includes('state_resync')) {
+        const frame = JSON.parse(raw);
+        frame.data = frame.data.replace('"match":{', '"match":null,"unused":{');
+        raw = JSON.stringify(frame); corrupt = false;
+      }
+      send(raw);
+    };
+  });
+  await guest.evaluate(() => window.dispatchEvent(new Event('online')));
+  await wait(guest, () => window.__peerHarness.lobbyState().statusEvents.some(e => e.message.includes('State recovery failed')));
+  await guest.evaluate(() => window.__peerHarness.submitMultiplayerCommand({ type: 'priority_action', action_ref: { kind: 'test_priority_action', actor: 1, sequence: 1 } }));
+  assert.match(await guest.evaluate(() => window.__peerHarness.lobbyState().statusEvents.at(-1).message), /Waiting for resync/);
+  await guest.waitForTimeout(1100);
+  await guest.evaluate(() => window.dispatchEvent(new Event('online')));
+  await wait(guest, () => window.__peerHarness.lobbyState().statusEvents.some(e => e.message.includes('Resynced with trusted host at action 1')));
+  await guest.evaluate(() => window.__peerHarness.submitMultiplayerCommand({ type: 'priority_action', action_ref: { kind: 'test_priority_action', actor: 1, sequence: 1 } }));
+  for (const page of [host, guest]) await wait(page, () => window.__peerHarness.lobbyState().multiplayer.lastAppliedSequence === 2);
 });

--- a/web/ui/tests/relay-browser.test.mjs
+++ b/web/ui/tests/relay-browser.test.mjs
@@ -2,6 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { createServer } from 'vite';
 import { chromium } from 'playwright';
+import { fileURLToPath } from 'node:url';
 import { startRelay } from '../../relay/tests/runtime.mjs';
 
 async function setup(t) {
@@ -10,7 +11,7 @@ async function setup(t) {
   const base = `http://127.0.0.1:${port}`;
   const relay = await startRelay(base); t.after(() => relay.dispose());
   const url = String(await relay.ready).replace(/\/$/, '');
-  const server = await createServer({ root: new URL('..', import.meta.url).pathname,
+  const server = await createServer({ root: fileURLToPath(new URL('..', import.meta.url)),
     define: { 'import.meta.env.VITE_LOBBY_RELAY_URL': JSON.stringify(url) },
     server: { host: '127.0.0.1', port, strictPort: true }, logLevel: 'error' });
   await server.listen(); t.after(() => server.close());

--- a/web/ui/tests/relay-resync.test.mjs
+++ b/web/ui/tests/relay-resync.test.mjs
@@ -1,0 +1,26 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { needsFullStateResync } from '../src/lib/relay/resync.js';
+
+test('an explicit repair request sends state even when sequences match', () => {
+  assert.equal(needsFullStateResync({
+    force: true,
+    connected: true,
+    requesterSequence: 50,
+    hostSequence: 50,
+  }), true);
+});
+
+test('a healthy peer at the host sequence only needs an acknowledgement', () => {
+  assert.equal(needsFullStateResync({
+    connected: true,
+    requesterSequence: 50,
+    hostSequence: 50,
+  }), false);
+});
+
+test('disconnected, behind, or invalid peers receive the full state', () => {
+  assert.equal(needsFullStateResync({ connected: false, requesterSequence: 50, hostSequence: 50 }), true);
+  assert.equal(needsFullStateResync({ connected: true, requesterSequence: 49, hostSequence: 50 }), true);
+  assert.equal(needsFullStateResync({ connected: true, requesterSequence: NaN, hostSequence: 50 }), true);
+});

--- a/web/ui/tests/relay-resync.test.mjs
+++ b/web/ui/tests/relay-resync.test.mjs
@@ -4,7 +4,7 @@ import { needsFullStateResync } from '../src/lib/relay/resync.js';
 
 test('an explicit repair request sends state even when sequences match', () => {
   assert.equal(needsFullStateResync({
-    force: true,
+    forceCheckpoint: true,
     connected: true,
     requesterSequence: 50,
     hostSequence: 50,
@@ -23,4 +23,9 @@ test('disconnected, behind, or invalid peers receive the full state', () => {
   assert.equal(needsFullStateResync({ connected: false, requesterSequence: 50, hostSequence: 50 }), true);
   assert.equal(needsFullStateResync({ connected: true, requesterSequence: 49, hostSequence: 50 }), true);
   assert.equal(needsFullStateResync({ connected: true, requesterSequence: NaN, hostSequence: 50 }), true);
+});
+
+test('an ahead peer must reconcile with the host rather than receive an ACK', () => {
+  assert.equal(needsFullStateResync({ requesterSequence: 51, hostSequence: 50 }), true);
+  assert.equal(needsFullStateResync({ requesterSequence: -1, hostSequence: 0 }), true);
 });

--- a/web/ui/tests/wasm-real-engine-cheat.e2e.test.js
+++ b/web/ui/tests/wasm-real-engine-cheat.e2e.test.js
@@ -1257,3 +1257,158 @@ test("real WASM engine ziffle position reveal ignores opened commitment metadata
     await vite.close();
   }
 });
+
+test("real WASM trusted recovery preserves pending surveil and scry choices", { timeout: 30000 }, async () => {
+  const { vite, baseUrl } = await startWasmServer();
+  let browser = null;
+
+  try {
+    browser = await chromium.launch();
+    const page = await browser.newPage();
+    const pageErrors = [];
+    page.on("pageerror", (error) => pageErrors.push(String(error?.stack || error)));
+    page.on("console", (message) => {
+      if (message.type() === "error") pageErrors.push(message.text());
+    });
+
+    await page.goto(baseUrl);
+    const cardSources = await loadCardSources(page, [
+      "preordain",
+      "barrier-of-bones",
+      "island",
+      "swamp",
+      "mountain",
+    ]);
+    const result = await page.evaluate(async ({ wasmModuleUrl, cardSources }) => {
+      const mod = await import(wasmModuleUrl);
+      await mod.default();
+
+      const { replayTrustedMatch } = await import("/src/lib/relay/replay-trusted-match.js");
+      let acceptedActions = [];
+      function recordedDispatch(game, command) {
+        acceptedActions.push({ seq: acceptedActions.length + 1, command });
+        return game.dispatch(command);
+      }
+      function dispatchPriority(game, action) {
+        return recordedDispatch(game, {
+          type: "priority_action",
+          action_ref: action.action_ref,
+        });
+      }
+
+      async function advanceToInspectionPrompt({ spellName, landName, fillerName }) {
+        const game = new mod.WasmGame();
+        game.registerExternalCardSourcesJson(JSON.stringify(cardSources));
+        acceptedActions = [];
+        const config = {
+          playerNames: ["Alice", "Bob"],
+          startingLife: 20,
+          seed: 1,
+          format: "normal",
+          openingHandSize: 7,
+          decks: [
+            Array(60).fill(landName),
+            Array(60).fill(fillerName),
+          ],
+        };
+        let state = game.startMatch(config);
+        // Test fixture setup is applied identically before both initial play and replay.
+        game.addCardToZone(0, spellName, "hand", true);
+        game.addCardToZone(0, landName, "battlefield", true);
+        state = game.uiState();
+
+        for (let step = 0; step < 20; step += 1) {
+          const actions = state.decision?.actions || [];
+          let action = actions.find((candidate) => (
+            candidate.action_ref?.kind === "keep_opening_hand"
+            || candidate.action_ref?.kind === "continue_pregame"
+            || candidate.action_ref?.kind === "begin_game"
+          ));
+          if (!action) action = actions.find((candidate) => candidate.action_ref?.kind === "play_land");
+          if (!action && actions.some((candidate) => candidate.label?.includes(spellName))) break;
+          if (!action) action = actions.find((candidate) => candidate.action_ref?.kind === "pass_priority");
+          if (!action) {
+            throw new Error(`could not advance to ${spellName}: ${JSON.stringify(state.decision)}`);
+          }
+          state = dispatchPriority(game, action);
+        }
+
+        const castAction = state.decision?.actions?.find((action) => action.label?.includes(spellName));
+        if (!castAction) {
+          throw new Error(`could not cast ${spellName}: ${JSON.stringify(state.decision)}`);
+        }
+        state = dispatchPriority(game, castAction);
+
+        if (state.decision?.kind !== "mana_payment") {
+          throw new Error(`${spellName} did not ask for mana payment: ${JSON.stringify(state.decision)}`);
+        }
+        state = recordedDispatch(game, {
+          type: "mana_payment",
+          response: {
+            action: "confirm",
+            plan_id: state.decision.plan_id,
+            request_hash: state.decision.request_hash,
+          },
+        });
+
+        for (let step = 0; step < 10; step += 1) {
+          if (state.decision?.kind === "select_objects") break;
+          const action = (state.decision?.actions || []).find(
+            (candidate) => candidate.action_ref?.kind === "pass_priority"
+          ) || state.decision?.actions?.[0];
+          if (!action) {
+            throw new Error(`could not reach ${spellName} inspection prompt: ${JSON.stringify(state.decision)}`);
+          }
+          state = dispatchPriority(game, action);
+        }
+
+        const checkpointOnly = new mod.WasmGame();
+        checkpointOnly.registerExternalCardSourcesJson(JSON.stringify(cardSources));
+        checkpointOnly.importSyncCheckpoint(game.exportSyncCheckpoint(), 0);
+        const importedKind = checkpointOnly.uiState().decision?.kind;
+        const recovered = new mod.WasmGame();
+        recovered.registerExternalCardSourcesJson(JSON.stringify(cardSources));
+        const replayGame = {
+          startMatch: config => { recovered.startMatch(config); recovered.addCardToZone(0, spellName, "hand", true); recovered.addCardToZone(0, landName, "battlefield", true); },
+          setPerspective: p => recovered.setPerspective(p),
+          uiState: () => recovered.uiState(),
+          dispatch: command => recovered.dispatch(command),
+        };
+        const replayed = await replayTrustedMatch(replayGame, config, acceptedActions, 0);
+        const choice = { type: "select_objects", object_ids: [] };
+        const originalAfter = game.dispatch(choice);
+        const recoveredAfter = recovered.dispatch(choice);
+        return { importedKind, originalKind: state.decision.kind, replayedKind: replayed.decision.kind,
+          originalAfterKind: originalAfter.decision?.kind, recoveredAfterKind: recoveredAfter.decision?.kind };
+
+      }
+
+      return {
+        scry: await advanceToInspectionPrompt({
+          spellName: "Preordain",
+          landName: "Island",
+          fillerName: "Mountain",
+        }),
+        surveil: await advanceToInspectionPrompt({
+          spellName: "Barrier of Bones",
+          landName: "Swamp",
+          fillerName: "Mountain",
+        }),
+      };
+    }, {
+      wasmModuleUrl: WASM_MODULE_URL,
+      cardSources,
+    });
+
+    for (const resultCase of [result.scry, result.surveil]) {
+      assert.equal(resultCase.originalKind, "select_objects");
+      assert.notEqual(resultCase.importedKind, resultCase.originalKind, "checkpoint loses the pending choice");
+      assert.equal(resultCase.replayedKind, resultCase.originalKind);
+      assert.equal(resultCase.recoveredAfterKind, resultCase.originalAfterKind);
+    }
+    assert.deepEqual(pageErrors, []);
+  } finally {
+    if (browser) await browser.close();
+    await vite.close();
+  }
+});


### PR DESCRIPTION
WebSocket clients could acknowledge a repair request without restoring state when their sequence matched or exceeded the host, and checkpoint-only restoration discarded pending choices such as surveil. Recovery now uses `forceCheckpoint`, replays the accepted trusted transcript, and permits host-directed removal of speculative actions while checking the retained transcript prefix.

Foreground recovery waits for active submissions/replays. Failed restoration keeps gameplay paused and can be retried by returning to the tab. Incoming legacy `force` is accepted for compatibility; outgoing requests use `forceCheckpoint`. Relay tests also use `fileURLToPath` for Windows-compatible paths.

Validation: 15 relay tests passed, covering equal/ahead sequence recovery, host/guest reload and closed-tab recovery, rejected-action repair, and failed restoration/retry. A real WASM regression confirms scry/surveil pending choices survive replay. Changed production modules pass ESLint; the Vite production build passes. Tests were run in an isolated checkout; existing local work was not modified.
