### PR TITLE
Improve card inspection and keyboard navigation

### DIFF
--- a/web/ui/src/components/board/BattlefieldRow.jsx
+++ b/web/ui/src/components/board/BattlefieldRow.jsx
@@ -61,6 +61,7 @@ const MOBILE_BATTLEFIELD_TOKEN_HIT_SLOP_X = 16;
 const MOBILE_BATTLEFIELD_TOKEN_HIT_SLOP_Y = 16;
 const BATTLEFIELD_MOVE_DRAG_DISTANCE_SQ = 6 * 6;
 const BATTLEFIELD_MOVE_CLICK_SUPPRESS_MS = 700;
+const BATTLEFIELD_KEYBOARD_EXIT_DELAY_MS = 80;
 
 function buildPaperRowGroups(battlefieldSide, buckets, options = {}) {
   const singleRow = options.singleRow === true;
@@ -885,6 +886,8 @@ export default function BattlefieldRow({
   enableReposition = enablePlacementPreview,
 }) {
   const rowRef = useRef(null);
+  const keyboardNavigationRef = useRef(false);
+  const keyboardExitTimerRef = useRef(null);
   const previousCardsRef = useRef(cards);
   const previousPaperLayoutRef = useRef(null);
   const stablePaperLayoutRef = useRef(null);
@@ -915,6 +918,7 @@ export default function BattlefieldRow({
     clearTimeout(manaCloseTimer.current);
     setManaPopover(null);
   }, []);
+  useEffect(() => () => clearTimeout(keyboardExitTimerRef.current), []);
   const leaveManaPopover = useCallback(() => {
     clearTimeout(manaCloseTimer.current);
     manaCloseTimer.current = setTimeout(() => setManaPopover(null), 180);
@@ -2172,6 +2176,11 @@ export default function BattlefieldRow({
   }, [loading, closeManaPopover, clearHover, clearAnchoredCardPreview, dispatch]);
 
   const handleCardSelectionClick = useCallback((event, card) => {
+    // A direct field click is also a navigation starting point. Preserve the
+    // focus so the next arrow key continues from this exact permanent.
+    keyboardNavigationRef.current = true;
+    clearTimeout(keyboardExitTimerRef.current);
+    event.currentTarget?.focus?.({ preventScroll: true });
     const manaActions = (paymentActionMap.get(Number(card?.id)) || []);
     if (manaActions.length) {
       event.preventDefault();
@@ -2397,10 +2406,37 @@ export default function BattlefieldRow({
     }
   }, [clearMobileCardPress]);
 
+  const handleFieldKeyboardNavigation = useCallback((_event, nextCardElement) => {
+    keyboardNavigationRef.current = true;
+    clearTimeout(keyboardExitTimerRef.current);
+    // If keyboard navigation begins from a hovered card, its stale hover state
+    // would otherwise keep owning the inspector while focus moves elsewhere.
+    // Release it once, then let the keyboard target become the sole detail.
+    clearHover();
+    clearAnchoredCardPreview();
+    const nextObjectId = nextCardElement?.dataset?.objectId;
+    if (nextObjectId != null) onInspect?.(nextObjectId);
+  }, [clearAnchoredCardPreview, clearHover, onInspect]);
+
+  const handleFieldPointerMove = useCallback((event, card) => {
+    if (!keyboardNavigationRef.current || event.pointerType === "touch") return;
+    if (event.movementX === 0 && event.movementY === 0) return;
+    clearTimeout(keyboardExitTimerRef.current);
+    const target = event.currentTarget;
+    keyboardExitTimerRef.current = window.setTimeout(() => {
+      keyboardNavigationRef.current = false;
+      keyboardExitTimerRef.current = null;
+      closeManaPopover();
+      hoverCard(card.id);
+      target?.focus?.({ preventScroll: true });
+    }, BATTLEFIELD_KEYBOARD_EXIT_DELAY_MS);
+  }, [closeManaPopover, hoverCard]);
+
   return (
     <div
       ref={rowRef}
       className={`battlefield-row ${displayCards.length === 0 ? "battlefield-row-empty" : ""} ${alignStart ? "battlefield-row--align-start" : ""} ${isMobileBattleBottomLayout ? "battlefield-row--mobile-bottom-inline-fit" : ""} ${shouldFreezePaperLayout ? "battlefield-row--layout-freeze" : ""} ${usesDensePaperLayout ? "battlefield-row--dense" : ""} relative grid gap-1.5 content-start justify-center min-h-0 h-full`}
+      data-card-navigation-scope="field"
       data-bf-side={battlefieldSide}
       data-placement-active={pointerInsideBattlefield ? "true" : "false"}
       data-battlefield-drop-grid={canPreviewHeldPlacement ? "true" : undefined}
@@ -2576,16 +2612,24 @@ export default function BattlefieldRow({
             suppressTooltip={suppressTooltip}
             onClick={isLayoutHold ? undefined : ((event) => handleCardSelectionClick(event, card))}
             onKeyboardActivate={isLayoutHold ? undefined : ((event) => handleCardKeyboardActivate(event, card))}
+            onKeyboardNavigation={isLayoutHold ? undefined : handleFieldKeyboardNavigation}
             onPointerDown={isLayoutHold ? undefined : ((event) => handleCardPointerPressStart(event, card, isCombatCandidate))}
-            onPointerMove={isLayoutHold ? undefined : handleCardPointerPressMove}
+            onPointerMove={isLayoutHold ? undefined : ((event) => { handleCardPointerPressMove(event); handleFieldPointerMove(event, card); })}
             onPointerUp={isLayoutHold ? undefined : handleCardPointerPressEnd}
             onPointerCancel={isLayoutHold ? undefined : handleCardPointerPressEnd}
             onPointerLeave={isLayoutHold ? undefined : handleCardPointerPressEnd}
             onMouseEnter={isLayoutHold ? undefined : ((event) => {
+              if (keyboardNavigationRef.current) return;
               if (!showManaPopover(event, card)) { closeManaPopover(); hoverCard(card.id); event.currentTarget.focus({ preventScroll: true }); }
             })}
             onMouseLeave={isLayoutHold ? undefined : (() => { clearHover(); leaveManaPopover(); })}
-            onFocus={isLayoutHold ? undefined : (() => { closeManaPopover(); hoverCard(card.id); })}
+            onFocus={isLayoutHold ? undefined : (() => {
+              closeManaPopover();
+              hoverCard(card.id);
+              // Mouse focus is only hover. Keyboard focus is the user's
+              // explicit navigation request, so it also advances the detail.
+              if (keyboardNavigationRef.current) onInspect?.(card.id);
+            })}
             centerOverlay={showsUndoOverlay ? (
               <Button
                 type="button"

--- a/web/ui/src/components/board/HandZone.jsx
+++ b/web/ui/src/components/board/HandZone.jsx
@@ -24,6 +24,8 @@ const DRAW_TO_HAND_REVEAL_DELAY_MS = 1080;
 // Keep in sync with the card-flight stagger in GameEffectAnimations.
 const DRAW_TO_HAND_REVEAL_STAGGER_MS = 150;
 const HAND_ACTION_HOVER_EVENT = "ironsmith:hand-action-hover";
+const HAND_KEYBOARD_EXIT_DELAY_MS = 260;
+const HAND_HOVER_ACTIVATION_DELAY_MS = 35;
 
 /** Map card_types array to a glow kind for hand display. */
 function handGlowFromTypes(cardTypes) {
@@ -339,12 +341,11 @@ function stableHandSlotObjectIdAtPoint(handList, hoverableHandObjectIds, selecte
 export default function HandZone({
   player,
   selectedObjectId,
-  onInspect,
   isExpanded = false,
   layout = "fan",
 }) {
   const { state, multiplayer } = useGame();
-  const { hoveredObjectId, hoveredLinkedObjectIds, hoverCard, clearHover } = useHover();
+  const { hoveredObjectId, hoveredLinkedObjectIds, clearHover, clearAnchoredCardPreview } = useHover();
   const { startDrag, updateDrag, endDrag } = useDragActions();
   const dragState = useDragState();
   const handScale = useManabrewHandScale(layout === "mobile-fullscreen");
@@ -353,6 +354,10 @@ export default function HandZone({
   const dragHandlersRef = useRef(null);
   const dragScrollLockRef = useRef(null);
   const hoverClearTimerRef = useRef(null);
+  const hoverActivateTimerRef = useRef(null);
+  const pointerHoverTargetRef = useRef(null);
+  const keyboardNavigationRef = useRef(false);
+  const keyboardExitTimerRef = useRef(null);
   const handListRef = useRef(null);
   const handScrollRef = useRef(null);
   const centerCycleRef = useRef(null);
@@ -368,6 +373,8 @@ export default function HandZone({
   const [handTransitionsHydrated, setHandTransitionsHydrated] = useState(false);
   const [menuHoveredHandObjectId, setMenuHoveredHandObjectId] = useState(null);
   const [hoveredHandObjectId, setHoveredHandObjectId] = useState(null);
+  const [keyboardSelectedObjectId, setKeyboardSelectedObjectId] = useState(null);
+  const [keyboardNavigationActive, setKeyboardNavigationActive] = useState(false);
   const rawHandCards = useMemo(
     () => (player?.can_view_hand && player?.hand_cards) || [],
     [player?.can_view_hand, player?.hand_cards]
@@ -686,11 +693,17 @@ export default function HandZone({
     () => computeManabrewHandDimensions(handScale),
     [handScale]
   );
-  const activeFanObjectId = dragState || isMobileFan
+  // Only one interaction source may drive the fan at a time. In particular,
+  // do not combine a stale keyboard selection with a newly hovered card while
+  // the pointer is taking control back from the arrow-key mode.
+  const interactionObjectId = keyboardNavigationActive
+    ? keyboardSelectedObjectId
+    : hoveredHandObjectId;
+  const activeFanObjectId = dragState
     ? null
     : activeMenuHoveredHandObjectId
-      || selectedObjectIdKey
-      || hoveredHandObjectId;
+      || interactionObjectId
+      || selectedObjectIdKey;
   const activeFanIndex = useMemo(() => {
     if (!activeFanObjectId) return null;
     const handIndex = handCards.findIndex((card) => String(card.id) === activeFanObjectId);
@@ -756,10 +769,15 @@ export default function HandZone({
     if (nextRects.size > 0) collapsedCardRectsRef.current = nextRects;
   }, [dragState, handLayoutSignature, isExpanded, isRoulette]);
 
-  const handleCardClick = useCallback((_e, card) => {
-    const candidateObjectIds = [Number(card?.id)].filter((id) => Number.isFinite(id));
-    onInspect?.(card.id, { candidateObjectIds, source: "hand" });
-  }, [onInspect]);
+  const handleCardClick = useCallback((event, card) => {
+    setKeyboardSelectedObjectId(String(card.id));
+    keyboardNavigationRef.current = true;
+    setKeyboardNavigationActive(true);
+    event.currentTarget?.focus?.({ preventScroll: true });
+    clearHover();
+    clearAnchoredCardPreview();
+    window.dispatchEvent(new CustomEvent("ironsmith:hand-inspection"));
+  }, [clearAnchoredCardPreview, clearHover]);
 
   const handleKeyboardCardActivate = useCallback((event, card, plays, glowKind) => {
     if (plays?.length) {
@@ -827,6 +845,14 @@ export default function HandZone({
         clearTimeout(hoverClearTimerRef.current);
         hoverClearTimerRef.current = null;
       }
+      if (hoverActivateTimerRef.current) {
+        clearTimeout(hoverActivateTimerRef.current);
+        hoverActivateTimerRef.current = null;
+      }
+      if (keyboardExitTimerRef.current) {
+        clearTimeout(keyboardExitTimerRef.current);
+        keyboardExitTimerRef.current = null;
+      }
       const handlers = dragHandlersRef.current;
       if (!handlers) return;
       document.removeEventListener("pointermove", handlers.onMove);
@@ -884,27 +910,90 @@ export default function HandZone({
   }, [isMobileFan, selectedObjectId]);
 
 
+  const scheduleHoverTarget = useCallback((objectId) => {
+    const normalizedObjectId = String(objectId);
+    pointerHoverTargetRef.current = normalizedObjectId;
+    if (hoverActivateTimerRef.current) clearTimeout(hoverActivateTimerRef.current);
+    hoverActivateTimerRef.current = window.setTimeout(() => {
+      hoverActivateTimerRef.current = null;
+      setHoveredHandObjectId(normalizedObjectId);
+      clearHover();
+      clearAnchoredCardPreview();
+    }, HAND_HOVER_ACTIVATION_DELAY_MS);
+  }, [clearAnchoredCardPreview, clearHover]);
+
   const handleHoverEnter = useCallback((objectId) => {
+    // Once arrow-key navigation starts, keep the keyboard selection stable
+    // until the pointer actually moves. Transformed cards can pass beneath a
+    // stationary cursor and fire synthetic mouse-enter events otherwise.
+    if (keyboardNavigationRef.current) return;
+    // Hand hover owns the only active inspection surface. Clear a field
+    // preview before the small hand-hover debounce starts, so two details
+    // never overlap during that transition.
+    clearHover();
+    clearAnchoredCardPreview();
+    window.dispatchEvent(new CustomEvent("ironsmith:hand-inspection"));
     if (hoverClearTimerRef.current) {
       clearTimeout(hoverClearTimerRef.current);
       hoverClearTimerRef.current = null;
     }
+    if (hoverActivateTimerRef.current) {
+      clearTimeout(hoverActivateTimerRef.current);
+      hoverActivateTimerRef.current = null;
+    }
     const normalizedObjectId = String(objectId);
-    setHoveredHandObjectId(normalizedObjectId);
-    hoverCard(normalizedObjectId);
-  }, [hoverCard]);
+    // Ignore synthetic enter events caused by the active card moving under a
+    // stationary cursor. Real pointer movement updates this ref first.
+    if (
+      hoveredHandObjectId != null
+      && pointerHoverTargetRef.current === String(hoveredHandObjectId)
+      && pointerHoverTargetRef.current !== normalizedObjectId
+    ) return;
+    scheduleHoverTarget(normalizedObjectId);
+  }, [clearAnchoredCardPreview, clearHover, hoveredHandObjectId, scheduleHoverTarget]);
 
+  const handleKeyboardNavigation = useCallback(() => {
+    keyboardNavigationRef.current = true;
+    setKeyboardNavigationActive(true);
+    if (keyboardExitTimerRef.current) {
+      clearTimeout(keyboardExitTimerRef.current);
+      keyboardExitTimerRef.current = null;
+    }
+    if (hoverClearTimerRef.current) {
+      clearTimeout(hoverClearTimerRef.current);
+      hoverClearTimerRef.current = null;
+    }
+    setHoveredHandObjectId(null);
+  }, []);
+
+  const handleCardFocus = useCallback((_event, card) => {
+    handleHoverEnter(card.id);
+    // Focus selects the same rendered card in the hand. It deliberately does
+    // not open the separate inspector rail.
+    setKeyboardSelectedObjectId(String(card.id));
+  }, [handleHoverEnter]);
   const handleHoverLeave = useCallback(() => {
+    if (hoverActivateTimerRef.current) {
+      clearTimeout(hoverActivateTimerRef.current);
+      hoverActivateTimerRef.current = null;
+    }
     if (hoverClearTimerRef.current) {
       clearTimeout(hoverClearTimerRef.current);
     }
     // Small delay smooths hover-out when moving across dense hand cards.
     hoverClearTimerRef.current = setTimeout(() => {
+      if (
+        hoveredHandObjectId != null
+        && pointerHoverTargetRef.current === String(hoveredHandObjectId)
+      ) {
+        hoverClearTimerRef.current = null;
+        return;
+      }
       setHoveredHandObjectId(null);
       clearHover();
       hoverClearTimerRef.current = null;
     }, 110);
-  }, [clearHover]);
+  }, [clearHover, hoveredHandObjectId]);
 
   useEffect(() => {
     const wasExpanded = previousExpandedRef.current;
@@ -949,8 +1038,37 @@ export default function HandZone({
 
   const handleHandPointerMove = useCallback((event) => {
     if (event.pointerType === "touch" || activePointerIdRef.current != null) return;
+    if (keyboardNavigationRef.current) {
+      const pointerOverHandCard = resolveHandHoverObjectId(event.clientX, event.clientY) != null;
+      // A stationary pointer, or one moving within the hand, must not steal
+      // selection from the keyboard. Leaving the hand is the explicit exit.
+      if (event.movementX === 0 && event.movementY === 0) return;
+      if (pointerOverHandCard) {
+        if (keyboardExitTimerRef.current) {
+          clearTimeout(keyboardExitTimerRef.current);
+          keyboardExitTimerRef.current = null;
+        }
+        // A real pointer movement over a card is an explicit request to
+        // return to mouse mode. Clear the keyboard selection first so the
+        // old centered card cannot remain raised alongside the hovered one.
+        keyboardNavigationRef.current = false;
+        setKeyboardNavigationActive(false);
+        setKeyboardSelectedObjectId(null);
+      } else {
+        if (!keyboardExitTimerRef.current) {
+          keyboardExitTimerRef.current = window.setTimeout(() => {
+            keyboardExitTimerRef.current = null;
+            keyboardNavigationRef.current = false;
+            setKeyboardNavigationActive(false);
+            setKeyboardSelectedObjectId(null);
+          }, HAND_KEYBOARD_EXIT_DELAY_MS);
+        }
+        return;
+      }
+    }
 
     const objectId = resolveHandHoverObjectId(event.clientX, event.clientY);
+    pointerHoverTargetRef.current = objectId;
     if (objectId == null) {
       if (hoveredHandObjectId != null) {
         handleHoverLeave();
@@ -963,12 +1081,21 @@ export default function HandZone({
       hoverClearTimerRef.current = null;
     }
     if (hoveredHandObjectId !== objectId) {
-      setHoveredHandObjectId(objectId);
+      scheduleHoverTarget(objectId);
     }
-  }, [handleHoverLeave, hoveredHandObjectId, resolveHandHoverObjectId]);
+  }, [handleHoverLeave, hoveredHandObjectId, resolveHandHoverObjectId, scheduleHoverTarget]);
 
   const handleHandPointerLeave = useCallback((event) => {
     if (event.pointerType === "touch") return;
+    pointerHoverTargetRef.current = null;
+    if (keyboardNavigationRef.current && !keyboardExitTimerRef.current) {
+      keyboardExitTimerRef.current = window.setTimeout(() => {
+        keyboardExitTimerRef.current = null;
+        keyboardNavigationRef.current = false;
+        setKeyboardNavigationActive(false);
+        setKeyboardSelectedObjectId(null);
+      }, HAND_KEYBOARD_EXIT_DELAY_MS);
+    }
     handleHoverLeave();
   }, [handleHoverLeave]);
 
@@ -1219,9 +1346,11 @@ export default function HandZone({
           ? baseGlowKind
           : isActionLinkedHover ? "action-link" : baseGlowKind;
         const cardObjectId = String(card.id);
-        const isHovered = hoveredHandObjectId === cardObjectId;
+        const isHovered = !keyboardNavigationActive && hoveredHandObjectId === cardObjectId;
+        const isKeyboardSelected = keyboardNavigationActive && keyboardSelectedObjectId === cardObjectId;
         const isInspected = !isMobileFan && (
-          (selectedObjectIdKey != null && cardObjectId === selectedObjectIdKey)
+          ((selectedObjectIdKey != null && cardObjectId === selectedObjectIdKey)
+            || cardObjectId === keyboardSelectedObjectId)
           || isMenuActionPreview
         );
         const isNew = newIds.has(card.id);
@@ -1247,11 +1376,12 @@ export default function HandZone({
             isInspected={isInspected}
             onClick={isPlayable ? undefined : (event) => handleCardClick(event, card)}
             onKeyboardActivate={(event) => handleKeyboardCardActivate(event, card, plays, glowKind)}
+            onKeyboardNavigation={handleKeyboardNavigation}
             onPointerDown={isPlayable ? (event) => handlePointerDown(event, card, plays, glowKind) : undefined}
-            onMouseEnter={(event) => { handleHoverEnter(card.id); event.currentTarget.focus({ preventScroll: true }); }}
+            onMouseEnter={(event) => { handleHoverEnter(card.id); if (!keyboardNavigationRef.current) event.currentTarget.focus({ preventScroll: true }); }}
             onMouseLeave={isMobileFan ? undefined : handleHoverLeave}
-            onFocus={() => handleHoverEnter(card.id)}
-            className={`mobile-hand-rail-card${isPlayable ? " mobile-hand-rail-card--draggable" : ""}${String(dragState?.objectId) === cardObjectId ? " hand-card--drag-source" : ""} !w-full !max-w-none !min-w-0 !basis-auto !flex-none self-stretch p-1`}
+            onFocus={(event) => handleCardFocus(event, card)}
+            className={`mobile-hand-rail-card${isPlayable ? " mobile-hand-rail-card--draggable" : ""}${isKeyboardSelected ? " keyboard-selected" : ""}${String(dragState?.objectId) === cardObjectId ? " hand-card--drag-source" : ""} !w-full !max-w-none !min-w-0 !basis-auto !flex-none self-stretch p-1`}
             style={{
               width: "100%",
               minWidth: "0px",
@@ -1281,9 +1411,11 @@ export default function HandZone({
         ? baseGlowKind
         : isActionLinkedHover ? "action-link" : baseGlowKind;
       const extraObjectId = String(extra.id);
-      const isHovered = hoveredHandObjectId === extraObjectId;
+      const isHovered = !keyboardNavigationActive && hoveredHandObjectId === extraObjectId;
+      const isKeyboardSelected = keyboardNavigationActive && keyboardSelectedObjectId === extraObjectId;
       const isInspected = !isMobileFan && (
-        (selectedObjectIdKey != null && extraObjectId === selectedObjectIdKey)
+        ((selectedObjectIdKey != null && extraObjectId === selectedObjectIdKey)
+          || extraObjectId === keyboardSelectedObjectId)
         || isMenuActionPreview
       );
       return (
@@ -1299,11 +1431,12 @@ export default function HandZone({
           isInspected={isInspected}
           onClick={isPlayable ? undefined : (event) => handleCardClick(event, card)}
           onKeyboardActivate={(event) => handleKeyboardCardActivate(event, card, plays, glowKind)}
+          onKeyboardNavigation={handleKeyboardNavigation}
           onPointerDown={plays.length > 0 ? (event) => handlePointerDown(event, card, plays, baseGlowKind || "extra") : undefined}
-        onMouseEnter={(event) => { handleHoverEnter(extra.id); event.currentTarget.focus({ preventScroll: true }); }}
+        onMouseEnter={(event) => { handleHoverEnter(extra.id); if (!keyboardNavigationRef.current) event.currentTarget.focus({ preventScroll: true }); }}
         onMouseLeave={isMobileFan ? undefined : handleHoverLeave}
-        onFocus={() => handleHoverEnter(extra.id)}
-          className={`mobile-hand-rail-card mobile-hand-rail-card--extra${plays.length > 0 ? " mobile-hand-rail-card--draggable" : ""}${String(dragState?.objectId) === extraObjectId ? " hand-card--drag-source" : ""} !w-full !max-w-none !min-w-0 !basis-auto !flex-none self-stretch p-1`}
+        onFocus={(event) => handleCardFocus(event, card)}
+          className={`mobile-hand-rail-card mobile-hand-rail-card--extra${plays.length > 0 ? " mobile-hand-rail-card--draggable" : ""}${isKeyboardSelected ? " keyboard-selected" : ""}${String(dragState?.objectId) === extraObjectId ? " hand-card--drag-source" : ""} !w-full !max-w-none !min-w-0 !basis-auto !flex-none self-stretch p-1`}
           style={{
             width: "100%",
             minWidth: "0px",
@@ -1345,9 +1478,11 @@ export default function HandZone({
           ? baseGlowKind
           : isActionLinkedHover ? "action-link" : baseGlowKind;
         const cardObjectId = String(card.id);
-        const isHovered = hoveredHandObjectId === cardObjectId;
+        const isHovered = !keyboardNavigationActive && hoveredHandObjectId === cardObjectId;
+        const isKeyboardSelected = keyboardNavigationActive && keyboardSelectedObjectId === cardObjectId;
         const isInspected = !isMobileFan && (
-          (selectedObjectIdKey != null && cardObjectId === selectedObjectIdKey)
+          ((selectedObjectIdKey != null && cardObjectId === selectedObjectIdKey)
+            || cardObjectId === keyboardSelectedObjectId)
           || isMenuActionPreview
         );
         const isDrawInFlight = reserveDrawSlots && hiddenDrawCardIds.has(cardObjectId);
@@ -1382,12 +1517,14 @@ export default function HandZone({
               isInspected={isInspected}
               onClick={isPlayable ? undefined : (e) => handleCardClick(e, card)}
               onKeyboardActivate={(event) => handleKeyboardCardActivate(event, card, plays, glowKind)}
+              onKeyboardNavigation={handleKeyboardNavigation}
               onPointerDown={isPlayable ? (e) => handlePointerDown(e, card, plays, glowKind) : undefined}
-              onMouseEnter={(event) => { handleHoverEnter(card.id); event.currentTarget.focus({ preventScroll: true }); }}
+              onMouseEnter={(event) => { handleHoverEnter(card.id); if (!keyboardNavigationRef.current) event.currentTarget.focus({ preventScroll: true }); }}
               onMouseLeave={isMobileFan ? undefined : handleHoverLeave}
               onFocus={() => handleHoverEnter(card.id)}
               className={[
                 isMobileFan && isPlayable ? "hand-card--mobile-draggable" : null,
+                isKeyboardSelected ? "keyboard-selected" : null,
                 String(dragState?.objectId) === cardObjectId ? "hand-card--drag-source" : null,
               ].filter(Boolean).join(" ") || undefined}
               style={cardStyle}
@@ -1414,9 +1551,11 @@ export default function HandZone({
         ? baseGlowKind
         : isActionLinkedHover ? "action-link" : baseGlowKind;
       const extraObjectId = String(extra.id);
-      const isHovered = hoveredHandObjectId === extraObjectId;
+      const isHovered = !keyboardNavigationActive && hoveredHandObjectId === extraObjectId;
+      const isKeyboardSelected = keyboardNavigationActive && keyboardSelectedObjectId === extraObjectId;
       const isInspected = !isMobileFan && (
-        (selectedObjectIdKey != null && extraObjectId === selectedObjectIdKey)
+        ((selectedObjectIdKey != null && extraObjectId === selectedObjectIdKey)
+          || extraObjectId === keyboardSelectedObjectId)
         || isMenuActionPreview
       );
       const { wrapperStyle: baseWrapperStyle, cardStyle } = splitHandCardRowStyle(
@@ -1446,12 +1585,14 @@ export default function HandZone({
             isInspected={isInspected}
             onClick={isPlayable ? undefined : (e) => handleCardClick(e, card)}
             onKeyboardActivate={(event) => handleKeyboardCardActivate(event, card, plays, glowKind)}
+            onKeyboardNavigation={handleKeyboardNavigation}
             onPointerDown={plays.length > 0 ? (e) => handlePointerDown(e, card, plays, baseGlowKind || "extra") : undefined}
-            onMouseEnter={(event) => { handleHoverEnter(extra.id); event.currentTarget.focus({ preventScroll: true }); }}
+            onMouseEnter={(event) => { handleHoverEnter(extra.id); if (!keyboardNavigationRef.current) event.currentTarget.focus({ preventScroll: true }); }}
             onMouseLeave={isMobileFan ? undefined : handleHoverLeave}
             onFocus={() => handleHoverEnter(extra.id)}
             className={[
               isMobileFan && isPlayable ? "hand-card--mobile-draggable" : null,
+              isKeyboardSelected ? "keyboard-selected" : null,
               String(dragState?.objectId) === extraObjectId ? "hand-card--drag-source" : null,
             ].filter(Boolean).join(" ") || undefined}
             style={cardStyle}
@@ -1462,7 +1603,7 @@ export default function HandZone({
 
     if (isVerticalRail) {
       return (
-        <section className="mobile-hand-rail-zone min-h-0 h-full overflow-hidden">
+        <section className="mobile-hand-rail-zone min-h-0 h-full overflow-hidden" data-card-navigation-scope="hand" data-hand-navigation-scope="hand" data-keyboard-navigation={keyboardNavigationActive ? "true" : undefined}>
           <div className="mobile-hand-rail-scroll min-h-0 h-full overflow-y-auto overflow-x-hidden pr-0.5">
             <div
               ref={handListRef}
@@ -1483,6 +1624,9 @@ export default function HandZone({
       return (
         <section
           className={`hand-zone-surface min-w-0 bg-transparent px-2 py-1 h-full min-h-0 overflow-visible ${isRoulette ? "hand-zone-surface-roulette" : "max-w-full"} ${isMobileFan ? "hand-zone-surface-mobile-fan" : ""}`}
+          data-card-navigation-scope="hand"
+          data-hand-navigation-scope="hand"
+          data-keyboard-navigation={keyboardNavigationActive ? "true" : undefined}
           style={{
             width: surfaceWidth,
             maxWidth: isRoulette ? surfaceWidth : "100%",

--- a/web/ui/src/components/board/MobileBattleScene.jsx
+++ b/web/ui/src/components/board/MobileBattleScene.jsx
@@ -724,6 +724,7 @@ export default function MobileBattleScene({
             cardWidth={layout.cardWidth}
             cardHeight={layout.cardHeight}
             selectedObjectId={selectedObjectId}
+            onInspect={requestInspectObject}
             onCardClick={handleCardInspect}
             onCardPointerDown={handleCardTargetPointerDown}
             onMobileCardActionMenu={openObjectActions}
@@ -753,6 +754,7 @@ export default function MobileBattleScene({
             cardHeight={layout.cardHeight}
             selfBackVisibleHeight={layout.selfBackVisibleHeight}
             selectedObjectId={selectedObjectId}
+            onInspect={requestInspectObject}
             onCardClick={handleCardInspect}
             onCardPointerDown={handleCardTargetPointerDown}
             onMobileCardActionMenu={openObjectActions}

--- a/web/ui/src/components/board/MobileBattlefieldLane.jsx
+++ b/web/ui/src/components/board/MobileBattlefieldLane.jsx
@@ -11,6 +11,7 @@ export default function MobileBattlefieldLane({
   clippedHeight = null,
   battlefieldSide,
   selectedObjectId,
+  onInspect,
   onCardClick,
   onCardPointerDown,
   onMobileCardActionMenu,
@@ -41,6 +42,7 @@ export default function MobileBattlefieldLane({
             overlapPx: 0,
           }}
           selectedObjectId={selectedObjectId}
+          onInspect={onInspect}
           onCardClick={onCardClick}
           onCardPointerDown={onCardPointerDown}
           onMobileCardActionMenu={onMobileCardActionMenu}

--- a/web/ui/src/components/board/MyZone.jsx
+++ b/web/ui/src/components/board/MyZone.jsx
@@ -599,6 +599,7 @@ export default function MyZone({
               paperLayoutMode="mobile-battle-bottom"
               paperMinSlotsPerRow={7}
               selectedObjectId={selectedObjectId}
+              onInspect={onInspect}
               onCardClick={handleCardClick}
               onCardPointerDown={handleCardPointerDown}
               onMobileCardActionMenu={onMobileCardActionMenu}
@@ -831,6 +832,7 @@ export default function MyZone({
                       compact
                       battlefieldSide="bottom"
                       selectedObjectId={selectedObjectId}
+                      onInspect={onInspect}
                       onCardClick={handleCardClick}
                       onCardPointerDown={handleCardPointerDown}
                       onMobileCardActionMenu={onMobileCardActionMenu}
@@ -960,6 +962,7 @@ export default function MyZone({
                   alignStart={mergedMobileHeader && entry.zone === "battlefield"}
                   bottomSafeInset={mergedMobileHeader && entry.zone === "battlefield" ? 0 : undefined}
                   selectedObjectId={selectedObjectId}
+                  onInspect={onInspect}
                   onCardClick={handleCardClick}
                   onCardPointerDown={handleCardPointerDown}
                   onMobileCardActionMenu={mobileBattleScene && entry.zone === "battlefield" ? onMobileCardActionMenu : null}

--- a/web/ui/src/components/board/OpponentZone.jsx
+++ b/web/ui/src/components/board/OpponentZone.jsx
@@ -655,6 +655,7 @@ function OpponentSlot({
                       compact
                       battlefieldSide="top"
                       selectedObjectId={selectedObjectId}
+                      onInspect={onInspect}
                       onCardClick={handleCardClick}
                       onCardPointerDown={handleCardPointerDown}
                       onMobileCardActionMenu={mobileBattleScene ? onMobileCardActionMenu : null}
@@ -754,6 +755,7 @@ function OpponentSlot({
                   paperMinSlotsPerRow={mobileBattleScene && entry.zone === "battlefield" ? 7 : null}
                   enableReposition={entry.zone === "battlefield"}
                   selectedObjectId={selectedObjectId}
+                  onInspect={onInspect}
                   onCardClick={handleCardClick}
                   onCardPointerDown={handleCardPointerDown}
                   onMobileCardActionMenu={mobileBattleScene && entry.zone === "battlefield" ? onMobileCardActionMenu : null}

--- a/web/ui/src/components/board/mobile/MobileBattlefieldBand.jsx
+++ b/web/ui/src/components/board/mobile/MobileBattlefieldBand.jsx
@@ -12,6 +12,7 @@ export default function MobileBattlefieldBand({
   cardHeight,
   selfBackVisibleHeight,
   selectedObjectId,
+  onInspect,
   onCardClick,
   onCardPointerDown,
   onMobileCardActionMenu,
@@ -91,6 +92,7 @@ export default function MobileBattlefieldBand({
           clippedHeight={clippedHeight}
           battlefieldSide={battlefieldSide}
           selectedObjectId={selectedObjectId}
+          onInspect={onInspect}
           onCardClick={onCardClick}
           onCardPointerDown={onCardPointerDown}
           onMobileCardActionMenu={onMobileCardActionMenu}

--- a/web/ui/src/components/cards/GameCard.jsx
+++ b/web/ui/src/components/cards/GameCard.jsx
@@ -10,6 +10,7 @@ import useScryfallImageUrl from "@/hooks/useScryfallImageUrl";
 import { useTranslatedCardName } from "@/i18n/useTranslatedCardName";
 
 const semanticScoreCache = new Map();
+const HAND_CORNER_REPAIR_VERSION = 2;
 
 function clamp(value, min, max) {
   return Math.min(Math.max(value, min), max);
@@ -18,6 +19,65 @@ function clamp(value, min, max) {
 function parseCssPixelValue(value) {
   const parsed = Number.parseFloat(value);
   return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function repairTransparentHandCorners(image) {
+  const width = image.naturalWidth;
+  const height = image.naturalHeight;
+  if (!width || !height) return null;
+  const canvas = document.createElement("canvas");
+  canvas.width = width;
+  canvas.height = height;
+  const context = canvas.getContext("2d", { willReadFrequently: true });
+  if (!context) return null;
+  context.drawImage(image, 0, 0);
+  const pixels = context.getImageData(0, 0, width, height);
+  const { data } = pixels;
+  const corners = {
+    tl: [0, 0, 1, 1], tr: [width - 1, 0, -1, 1],
+    bl: [0, height - 1, 1, -1], br: [width - 1, height - 1, -1, -1],
+  };
+  const scanSize = Math.max(10, Math.round(Math.min(width, height) * 0.026));
+  let repairedPixels = 0;
+
+  for (const [originX, originY, xDirection, yDirection] of Object.values(corners)) {
+    for (let y = 0; y < scanSize; y += 1) {
+      for (let x = 0; x < scanSize; x += 1) {
+        const targetX = originX + x * xDirection;
+        const targetY = originY + y * yDirection;
+        const targetOffset = (targetY * width + targetX) * 4;
+        const distanceFromCurveCenter = Math.hypot(x - scanSize, y - scanSize);
+        const outsideRoundedFrame = distanceFromCurveCenter > scanSize - 0.5;
+        const needsAlphaRepair = data[targetOffset + 3] < 250;
+        if (!outsideRoundedFrame && !needsAlphaRepair) continue;
+
+        // Project the broken pixel onto the curved frame. This preserves the
+        // exact local tone (including a dark, textured or white frame) rather
+        // than assigning one colour to every card corner.
+        const scale = Math.min(1, (scanSize - 1) / Math.max(distanceFromCurveCenter, 1));
+        const sourceX = Math.round(scanSize + (x - scanSize) * scale);
+        const sourceY = Math.round(scanSize + (y - scanSize) * scale);
+        const absoluteX = originX + sourceX * xDirection;
+        const absoluteY = originY + sourceY * yDirection;
+        const sourceOffset = (absoluteY * width + absoluteX) * 4;
+        if (data[sourceOffset + 3] < 250) continue;
+
+        const colourDistance = Math.abs(data[targetOffset] - data[sourceOffset])
+          + Math.abs(data[targetOffset + 1] - data[sourceOffset + 1])
+          + Math.abs(data[targetOffset + 2] - data[sourceOffset + 2]);
+        if (!needsAlphaRepair && colourDistance < 42) continue;
+
+        data[targetOffset] = data[sourceOffset];
+        data[targetOffset + 1] = data[sourceOffset + 1];
+        data[targetOffset + 2] = data[sourceOffset + 2];
+        data[targetOffset + 3] = 255;
+        repairedPixels += 1;
+      }
+    }
+  }
+  if (repairedPixels === 0) return { url: null, hasIrregularCorners: false };
+  context.putImageData(pixels, 0, 0);
+  return { url: canvas.toDataURL("image/webp", 0.98), hasIrregularCorners: true };
 }
 
 function normalizeSemanticScore(rawScore) {
@@ -771,6 +831,7 @@ export default function GameCard({
   variant = "battlefield",
   onClick,
   onKeyboardActivate,
+  onKeyboardNavigation,
   onContextMenu,
   onPointerDown,
   onPointerMove,
@@ -813,6 +874,10 @@ export default function GameCard({
   const artUrl = sourceImageUrl || resolvedArtUrl;
   const imageLoading = variant === "hand" ? "eager" : "lazy";
   const imageFetchPriority = variant === "hand" ? "high" : "auto";
+  const [repairedHandArt, setRepairedHandArt] = useState(null);
+  const displayedArtUrl = variant === "hand" && repairedHandArt?.source === artUrl
+    ? repairedHandArt.url || artUrl
+    : artUrl;
   const useTokenBattlefield = variant === "battlefield" && battlefieldVisualMode === "mobile-token";
   const count = Number(card.count);
   const groupSize = Number.isFinite(count) && count > 1 ? count : 1;
@@ -820,6 +885,17 @@ export default function GameCard({
     ? Math.max(0, Math.min(groupSize, 4) - 1)
     : 0;
   const [fetchedBattlefieldMeta, setFetchedBattlefieldMeta] = useState(null);
+
+  const handleHandArtLoad = (event) => {
+    if (variant !== "hand" || displayedArtUrl !== artUrl) return;
+    try {
+      const repair = repairTransparentHandCorners(event.currentTarget);
+      setRepairedHandArt({ source: artUrl, ...repair });
+    } catch {
+      setRepairedHandArt({ source: artUrl, url: null, hasIrregularCorners: false });
+    }
+  };
+
   const glowPhase = glowPhaseFromSeed(`${card.id}:${name}`);
   const auraDelay1 = `-${((glowPhase % 4200) / 1000).toFixed(3)}s`;
   const auraDelay2 = `-${(((glowPhase * 17) % 5600) / 1000).toFixed(3)}s`;
@@ -1403,6 +1479,7 @@ export default function GameCard({
       data-member-object-ids={(Array.isArray(card.member_ids) ? card.member_ids : []).join(",")}
       data-member-stable-ids={memberStableIds.join(",")}
       data-card-name={name}
+      data-hand-irregular-corners={variant === "hand" && repairedHandArt?.source === artUrl && repairedHandArt.hasIrregularCorners ? "true" : undefined}
       title={suppressTooltip || variant === "battlefield" ? undefined : (groupSize > 1 ? `${displayName} (${groupSize} grouped permanents)` : displayName)}
       role={keyboardInteractive ? "button" : undefined}
       tabIndex={keyboardInteractive ? 0 : undefined}
@@ -1412,8 +1489,18 @@ export default function GameCard({
       onKeyDown={(event) => {
         if (!keyboardInteractive) return;
         if (["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown"].includes(event.key)) {
-          const cards = Array.from(document.querySelectorAll('.game-card[role="button"]'))
-            .filter((candidate) => candidate.offsetParent !== null && !candidate.hasAttribute("aria-hidden"));
+          // Hand navigation must not jump into battlefield/decision cards that
+          // happen to be mounted elsewhere in the workspace. Keep the focus
+          // loop inside the nearest hand surface when one exists.
+          const navigationScope = event.currentTarget.closest("[data-card-navigation-scope]");
+          const cards = Array.from((navigationScope || document).querySelectorAll('.game-card[role="button"]'))
+            .filter((candidate) => {
+              if (candidate.offsetParent === null || candidate.hasAttribute("aria-hidden")) return false;
+              // Battlefield layout transitions keep temporary cards mounted but
+              // visually hidden. They must never consume an arrow-key stop.
+              const candidateStyle = window.getComputedStyle(candidate);
+              return candidateStyle.display !== "none" && candidateStyle.visibility !== "hidden";
+            });
           const targetMode = Boolean(targetDecision);
           const navigable = targetMode
             ? cards.filter((candidate) => candidate.classList.contains("target-legal"))
@@ -1422,10 +1509,45 @@ export default function GameCard({
           const currentIndex = pool.indexOf(event.currentTarget);
           if (pool.length === 0 || (pool.length < 2 && currentIndex >= 0)) return;
           const forward = event.key === "ArrowRight" || event.key === "ArrowDown";
+          const isFieldNavigation = navigationScope?.dataset.cardNavigationScope === "field";
+          if (isFieldNavigation && currentIndex >= 0) {
+            const currentRect = event.currentTarget.getBoundingClientRect();
+            const currentCenter = {
+              x: currentRect.left + currentRect.width / 2,
+              y: currentRect.top + currentRect.height / 2,
+            };
+            const isHorizontal = event.key === "ArrowLeft" || event.key === "ArrowRight";
+            const direction = forward ? 1 : -1;
+            const candidates = pool
+              .filter((candidate) => candidate !== event.currentTarget)
+              .map((candidate) => {
+                const rect = candidate.getBoundingClientRect();
+                const center = { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
+                const primaryDelta = isHorizontal ? center.x - currentCenter.x : center.y - currentCenter.y;
+                const secondaryDelta = isHorizontal ? center.y - currentCenter.y : center.x - currentCenter.x;
+                if (primaryDelta * direction <= 2) return null;
+                // Prefer the same row/column; only then consider a diagonal.
+                return { candidate, score: Math.abs(primaryDelta) + Math.abs(secondaryDelta) * 2.4 };
+              })
+              .filter(Boolean)
+              .sort((a, b) => a.score - b.score);
+            if (candidates.length === 0) return;
+            event.preventDefault();
+            onKeyboardNavigation?.(event, candidates[0].candidate);
+            candidates[0].candidate.focus();
+            return;
+          }
+          const proposedIndex = currentIndex + (forward ? 1 : -1);
+          // A battlefield is a spatial row/grid, not a carousel: stop at the
+          // visible edge instead of silently wrapping back to another card.
+          if (isFieldNavigation && currentIndex >= 0 && (proposedIndex < 0 || proposedIndex >= pool.length)) return;
           const nextIndex = currentIndex < 0
             ? (forward ? 0 : pool.length - 1)
-            : (currentIndex + (forward ? 1 : -1) + pool.length) % pool.length;
+            : isFieldNavigation
+              ? proposedIndex
+              : (proposedIndex + pool.length) % pool.length;
           event.preventDefault();
+          onKeyboardNavigation?.(event, pool[nextIndex]);
           pool[nextIndex]?.focus();
           return;
         }
@@ -1495,17 +1617,20 @@ export default function GameCard({
         )}
         {artUrl && (variant !== "battlefield" || !useTokenBattlefield) && (
           <img
+            key={variant === "hand" ? `${artUrl}-${HAND_CORNER_REPAIR_VERSION}` : artUrl}
             className={cn(
               "absolute inset-0 w-full h-full z-0 pointer-events-none",
               variant === "hand" || usePortraitBattlefield ? "object-cover object-top" : "object-fill",
               artTreatmentClass,
             )}
-            src={artUrl}
+            src={displayedArtUrl}
             alt=""
             loading={imageLoading}
             fetchPriority={imageFetchPriority}
             decoding="async"
             referrerPolicy="no-referrer"
+            crossOrigin={variant === "hand" ? "anonymous" : undefined}
+            onLoad={variant === "hand" ? handleHandArtLoad : undefined}
           />
         )}
         {variant === "battlefield" && !useTokenBattlefield && (

--- a/web/ui/src/components/layout/Workspace.jsx
+++ b/web/ui/src/components/layout/Workspace.jsx
@@ -772,6 +772,18 @@ export default function Workspace({
   const showTopDock = !nonDesktopViewport && !tabletCompactViewport;
   const showRematchSideboarding = multiplayer?.rematch?.phase === "sideboarding";
 
+  useEffect(() => {
+    const dismissFieldInspectorForHand = () => {
+      setSelectedObjectId(null);
+      setPinnedInspectorObjectId(null);
+      setSuppressFallbackInspector(true);
+      clearAnchoredCardPreview();
+      clearHover();
+    };
+    window.addEventListener("ironsmith:hand-inspection", dismissFieldInspectorForHand);
+    return () => window.removeEventListener("ironsmith:hand-inspection", dismissFieldInspectorForHand);
+  }, [clearAnchoredCardPreview, clearHover]);
+
   const players = useMemo(() => state?.players || [], [state?.players]);
   const perspective = state?.perspective;
   const me = players.find((p) => p.id === perspective) || players[0];

--- a/web/ui/src/components/right-rail/CardFrameStage.jsx
+++ b/web/ui/src/components/right-rail/CardFrameStage.jsx
@@ -49,8 +49,7 @@ export default function CardFrameStage({ preparation, assets = preparation, prev
   }, [preparation]);
 
   useLayoutEffect(() => { onReadyChange?.(ready || previewReady); }, [onReadyChange, ready, previewReady]);
-
-  return <>
+  return <div className="card-frame-preview-shell">
     {previewReady && <img className="card-frame-art-preview" src={previewUrl}
       alt={previewName || 'Card artwork'} referrerPolicy="no-referrer"
       data-frame-ready={ready ? 'true' : 'false'} aria-hidden={ready} />}
@@ -58,5 +57,5 @@ export default function CardFrameStage({ preparation, assets = preparation, prev
     aria-hidden={!ready} inert={!ready}
     style={{...style, opacity: ready ? 1 : 0, ...(presentation.reuse ? {transition: 'none'} : {}), ...(!ready ? {pointerEvents: 'none'} : {})}}>
     {children}
-  </div></>;
+  </div></div>;
 }

--- a/web/ui/src/components/right-rail/OriginalCardFallback.jsx
+++ b/web/ui/src/components/right-rail/OriginalCardFallback.jsx
@@ -1,12 +1,73 @@
 import { SymbolText } from '@/lib/mana-symbols';
+import { useState } from 'react';
 import GroupedManaAbility from './GroupedManaAbility';
 import './original-card-fallback.css';
+
+function repairPrintingCorners(image) {
+  const width = image.naturalWidth;
+  const height = image.naturalHeight;
+  if (!width || !height) return null;
+  const canvas = document.createElement('canvas');
+  canvas.width = width;
+  canvas.height = height;
+  const context = canvas.getContext('2d', { willReadFrequently: true });
+  if (!context) return null;
+  context.drawImage(image, 0, 0);
+  const pixels = context.getImageData(0, 0, width, height);
+  const { data } = pixels;
+  const radius = Math.max(10, Math.round(Math.min(width, height) * 0.026));
+  const corners = [[0, 0, 1, 1], [width - 1, 0, -1, 1], [0, height - 1, 1, -1], [width - 1, height - 1, -1, -1]];
+  let repaired = 0;
+
+  for (const [originX, originY, xDirection, yDirection] of corners) {
+    for (let y = 0; y < radius; y += 1) for (let x = 0; x < radius; x += 1) {
+      const distance = Math.hypot(x - radius, y - radius);
+      const targetX = originX + x * xDirection;
+      const targetY = originY + y * yDirection;
+      const target = (targetY * width + targetX) * 4;
+      const needsRepair = data[target + 3] < 250 || distance > radius - 0.5;
+      if (!needsRepair) continue;
+      const scale = Math.min(1, (radius - 1) / Math.max(distance, 1));
+      const sourceX = Math.round(radius + (x - radius) * scale);
+      const sourceY = Math.round(radius + (y - radius) * scale);
+      const sourceXAbsolute = originX + sourceX * xDirection;
+      const sourceYAbsolute = originY + sourceY * yDirection;
+      const source = (sourceYAbsolute * width + sourceXAbsolute) * 4;
+      if (data[source + 3] < 250) continue;
+      const difference = Math.abs(data[target] - data[source]) + Math.abs(data[target + 1] - data[source + 1]) + Math.abs(data[target + 2] - data[source + 2]);
+      if (data[target + 3] >= 250 && difference < 42) continue;
+      data[target] = data[source]; data[target + 1] = data[source + 1]; data[target + 2] = data[source + 2]; data[target + 3] = 255;
+      repaired += 1;
+    }
+  }
+  if (!repaired) return null;
+  context.putImageData(pixels, 0, 0);
+  return canvas.toDataURL('image/webp', 0.98);
+}
+
+function PrintingImage({ imageUrl, name }) {
+  const [repaired, setRepaired] = useState(null);
+  const displayedUrl = repaired?.source === imageUrl ? repaired.url || imageUrl : imageUrl;
+  return <img
+    key={`${imageUrl}-corner-repair-v1`}
+    src={displayedUrl}
+    alt={name || 'Card'}
+    crossOrigin="anonymous"
+    referrerPolicy="no-referrer"
+    decoding="async"
+    onLoad={(event) => {
+      if (displayedUrl !== imageUrl) return;
+      try { setRepaired({ source: imageUrl, url: repairPrintingCorners(event.currentTarget) }); }
+      catch { setRepaired({ source: imageUrl, url: null }); }
+    }}
+  />;
+}
 
 // When text regions cannot be masked, preserve the printing. Live rules and
 // actions remain available in an explicit details panel, not a fake card frame.
 export default function OriginalCardFallback({ imageUrl, name, rulesView, onActivate, highlighted, flavorText, stats, counters, detailsLabel }) {
   return <article className="original-card-fallback" aria-label={name || 'Card details'}>
-    {imageUrl && <img src={imageUrl} alt={name || 'Card'} referrerPolicy="no-referrer" decoding="async" />}
+    {imageUrl && <PrintingImage imageUrl={imageUrl} name={name} />}
     <details className="original-card-details" open={!imageUrl || undefined}>
       <summary>{detailsLabel}</summary>
       <div className="original-card-details__body">

--- a/web/ui/src/components/right-rail/RegisteredCardFrame.jsx
+++ b/web/ui/src/components/right-rail/RegisteredCardFrame.jsx
@@ -170,6 +170,10 @@ export default function RegisteredCardFrame({registration,imageUrl,typography,ru
   return <article className="registered-card-frame" aria-label={name} data-registration-id={registration.id} data-rules-scale={sharedScale} data-rules-shrink={columns?columns.shrink.toFixed(3):undefined}>
     <div className="registered-card-frame__surface" ref={surfaceRef}>
       <img className="registered-card-frame__scan" src={imageUrl} alt={name} referrerPolicy="no-referrer" />
+      <span className="registered-card-frame__corner-fill registered-card-frame__corner-fill--tl" aria-hidden="true" />
+      <span className="registered-card-frame__corner-fill registered-card-frame__corner-fill--tr" aria-hidden="true" />
+      <span className="registered-card-frame__corner-fill registered-card-frame__corner-fill--bl" aria-hidden="true" />
+      <span className="registered-card-frame__corner-fill registered-card-frame__corner-fill--br" aria-hidden="true" />
       {fields.map((field,index)=>{
         const entry=entries[index];
         if(!entry)return null;

--- a/web/ui/src/components/right-rail/card-frame-stage.css
+++ b/web/ui/src/components/right-rail/card-frame-stage.css
@@ -1,10 +1,19 @@
+.card-frame-preview-shell {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+}
+
 .card-frame-art-preview {
   position: absolute;
   inset: 0;
   width: 100%;
   height: 100%;
   object-fit: cover;
-  border-radius: inherit;
+  /* Full-card previews occasionally contain square light wedges outside the
+     physical rounded card. Keep the correction in the shared preview layer. */
+  border-radius: 0;
+  clip-path: polygon(0 10px, 10px 0, calc(100% - 10px) 0, 100% 10px, 100% calc(100% - 10px), calc(100% - 10px) 100%, 10px 100%, 0 calc(100% - 10px));
   pointer-events: none;
   opacity: 1;
   transition: opacity 240ms ease;

--- a/web/ui/src/components/right-rail/original-card-fallback.css
+++ b/web/ui/src/components/right-rail/original-card-fallback.css
@@ -1,11 +1,19 @@
 .original-card-fallback {
   position: absolute;
   inset: 0;
+  background-color: var(--card-frame-edge, #050505);
+  background-image: var(--source-frame-image, none);
+  background-size: calc(100% + 24px) calc(100% + 24px);
+  background-position: center;
 }
 .original-card-fallback > img {
   width: 100%;
   height: 100%;
   object-fit: contain;
+  /* Full-print scans occasionally include square white wedges beyond the
+     physical card's rounded edge. This only removes that exterior radius. */
+  border-radius: 0;
+  clip-path: polygon(0 10px, 10px 0, calc(100% - 10px) 0, 100% 10px, 100% calc(100% - 10px), calc(100% - 10px) 100%, 10px 100%, 0 calc(100% - 10px));
 }
 .original-card-details {
   position: absolute;

--- a/web/ui/src/components/right-rail/registered-card-frame.css
+++ b/web/ui/src/components/right-rail/registered-card-frame.css
@@ -1,6 +1,26 @@
 .registered-card-frame { position:absolute; inset:0; display:grid; place-items:center; }
-.registered-card-frame__surface { position:relative; width:100%; aspect-ratio:488/680; max-height:100%; container-type:size; }
-.registered-card-frame__scan { display:block; width:100%; height:100%; object-fit:fill; }
+.registered-card-frame__surface {
+  position:relative;
+  width:100%;
+  aspect-ratio:488/680;
+  max-height:100%;
+  container-type:size;
+  overflow:hidden;
+  border-radius:0;
+  /* The clipped tip shows a copy sampled inward from the same printing, so
+     texture and shade continue from the healthy side pixels, never from the
+     defective corner pixels. */
+  background-color:var(--card-frame-edge,#08090a);
+  background-image:var(--source-frame-image,none);
+  background-size:calc(100% + 24px) calc(100% + 24px);
+  background-position:center;
+}
+.registered-card-frame__scan { display:block; width:100%; height:100%; object-fit:fill; border-radius:8px; clip-path:inset(0 round 8px); }
+.registered-card-frame__corner-fill { position:absolute; inset:0; z-index:1; pointer-events:none; background:#050505; }
+.registered-card-frame__corner-fill--tl { clip-path:polygon(0 0, 14px 0, 0 14px); }
+.registered-card-frame__corner-fill--tr { clip-path:polygon(100% 0, calc(100% - 14px) 0, 100% 14px); }
+.registered-card-frame__corner-fill--bl { clip-path:polygon(0 100%, 10px 100%, 0 calc(100% - 10px)); }
+.registered-card-frame__corner-fill--br { clip-path:polygon(100% 100%, calc(100% - 10px) 100%, 100% calc(100% - 10px)); }
 .registered-card-frame__patch { position:absolute; pointer-events:none; z-index:1; }
 .registered-card-frame__field { position:absolute; z-index:2; min-width:0; }
 .registered-card-frame__field[data-replaced="true"] { display:flex; }

--- a/web/ui/src/hooks/useManabrewHandScale.js
+++ b/web/ui/src/hooks/useManabrewHandScale.js
@@ -9,9 +9,9 @@ export const MANABREW_HAND_CARD_BASE = {
 export const MANABREW_HAND_FAN_PARAMS = {
   arcRadius: 900,
   maxArcDeg: 30,
-  hoverScale: 1.8,
-  hoverLift: 70,
-  neighborPush: 78,
+  hoverScale: 1.78,
+  hoverLift: 58,
+  neighborPush: 92,
   maxSpread: 90,
   minSpread: 38,
   spreadWidth: 900,

--- a/web/ui/src/styles/effects-and-decisions.css
+++ b/web/ui/src/styles/effects-and-decisions.css
@@ -1550,7 +1550,7 @@ body.ironsmith-exile-animating .ironsmith-inspector-shell .hover-art-stage * {
 }
 
 .hand-reveal-shell {
-  --hand-reveal-y: 0px;
+  --hand-reveal-y: -8px;
   --hand-reveal-scale: 1;
   isolation: isolate;
   display: inline-flex;
@@ -1571,7 +1571,7 @@ body.ironsmith-exile-animating .ironsmith-inspector-shell .hover-art-stage * {
 
 .hand-reveal-shell[data-open="true"] {
   background: transparent;
-  --hand-reveal-y: -12px;
+  --hand-reveal-y: -8px;
 }
 
 .hand-reveal-shell:has(.game-card.hand-card.hovered),
@@ -1828,8 +1828,14 @@ body.ironsmith-exile-animating .ironsmith-inspector-shell .hover-art-stage * {
   --card-scale: 1;
 }
 
-.hand-reveal-shell[data-open="true"] .hand-zone-surface-mobile-fan .game-card.hand-card.hovered,
-.hand-reveal-shell[data-open="true"] .hand-zone-surface-mobile-fan .game-card.hand-card.inspected {
+.hand-reveal-shell .hand-zone-surface-mobile-fan .game-card.hand-card.hovered,
+.hand-reveal-shell .hand-zone-surface-mobile-fan .game-card.hand-card.inspected,
+.hand-reveal-shell .hand-zone-surface-mobile-fan .game-card.hand-card.keyboard-selected {
+  --card-scale: 1.78 !important;
+  --card-translate-y: -118px !important;
+  --card-rotate: 0deg !important;
+  transition: transform 320ms cubic-bezier(0.22, 1, 0.36, 1), opacity 220ms ease;
+  will-change: transform;
   transform:
     translate3d(
       calc(var(--card-translate-x) + var(--card-return-x) + var(--card-jolt-x)),
@@ -1843,18 +1849,135 @@ body.ironsmith-exile-animating .ironsmith-inspector-shell .hover-art-stage * {
   z-index: 50 !important;
 }
 
-.hand-reveal-shell[data-open="true"] .game-card.hand-card.hovered .game-card-surface,
-.hand-reveal-shell[data-open="true"] .game-card.hand-card.inspected .game-card-surface {
+.hand-reveal-shell .game-card.hand-card.hovered .game-card-surface,
+.hand-reveal-shell .game-card.hand-card.inspected .game-card-surface {
   inset: 0 !important;
   height: 100% !important;
   min-height: 100% !important;
 }
 
-.hand-reveal-shell[data-open="true"] .game-card.hand-card.hovered .game-card-surface > img,
-.hand-reveal-shell[data-open="true"] .game-card.hand-card.inspected .game-card-surface > img {
+.hand-reveal-shell .game-card.hand-card.hovered .game-card-surface > img,
+.hand-reveal-shell .game-card.hand-card.inspected .game-card-surface > img {
   inset: 0 !important;
   width: 100% !important;
   height: 100% !important;
+}
+
+/* The hand uses lift/zoom as its focus treatment; suppress the browser's
+   default blue focus ring so it does not draw an extra border around cards. */
+.hand-zone-surface[data-card-navigation-scope="hand"] .game-card.hand-card:focus,
+.hand-zone-surface[data-card-navigation-scope="hand"] .game-card.hand-card:focus-visible {
+  outline: none !important;
+  -webkit-focus-ring-color: transparent;
+}
+
+/* Selection in the hand is communicated by the lift/zoom motion. Do not add
+   the generic playable/inspected blue frame on top of that treatment. */
+[data-card-navigation-scope="hand"] .game-card.hand-card.hovered,
+[data-card-navigation-scope="hand"] .game-card.hand-card.inspected,
+[data-card-navigation-scope="hand"] .game-card.hand-card.keyboard-selected,
+[data-card-navigation-scope="hand"] .game-card.hand-card:hover,
+[data-card-navigation-scope="hand"] .game-card.hand-card:focus {
+  outline: none !important;
+  border-color: transparent !important;
+  box-shadow: none !important;
+}
+
+[data-card-navigation-scope="hand"] .game-card.hand-card.hovered::before,
+[data-card-navigation-scope="hand"] .game-card.hand-card.hovered::after,
+[data-card-navigation-scope="hand"] .game-card.hand-card.inspected::before,
+[data-card-navigation-scope="hand"] .game-card.hand-card.inspected::after,
+[data-card-navigation-scope="hand"] .game-card.hand-card.keyboard-selected::before,
+[data-card-navigation-scope="hand"] .game-card.hand-card.keyboard-selected::after,
+[data-card-navigation-scope="hand"] .game-card.hand-card:hover::before,
+[data-card-navigation-scope="hand"] .game-card.hand-card:hover::after,
+[data-card-navigation-scope="hand"] .game-card.hand-card:focus::before,
+[data-card-navigation-scope="hand"] .game-card.hand-card:focus::after {
+  opacity: 0 !important;
+  animation: none !important;
+}
+
+[data-card-navigation-scope="hand"] .game-card.hand-card:hover .game-card-surface {
+  box-shadow: none !important;
+}
+
+/* While arrows own the interaction, a stationary pointer may still satisfy
+   the browser's :hover selector as cards move beneath it. Keep those cards
+   in their resting layout until the pointer leaves the hand area. */
+[data-card-navigation-scope="hand"][data-keyboard-navigation="true"] .game-card.hand-card:hover:not(.keyboard-selected) {
+  --card-translate-y: 0px !important;
+  z-index: auto !important;
+}
+
+[data-card-navigation-scope="hand"][data-keyboard-navigation="true"] .game-card.hand-card:hover .game-card-surface {
+  box-shadow: none !important;
+}
+
+[data-card-navigation-scope="hand"][data-keyboard-navigation="true"] .hand-layout-item:has(> .game-card.hand-card:hover:not(.keyboard-selected)) {
+  z-index: auto !important;
+}
+
+/* Hand cards use scale/lift as their only highlight. Disable the generic
+   type/playable aura and circuit frame so colored glows cannot return when
+   card state changes. */
+[data-card-navigation-scope="hand"] .game-card.hand-card,
+[data-card-navigation-scope="hand"] .game-card.hand-card .game-card-surface,
+[data-card-navigation-scope="hand"] .hand-layout-item--selected {
+  box-shadow: none !important;
+  filter: none !important;
+  outline: none !important;
+}
+
+[data-card-navigation-scope="hand"] .game-card.hand-card:active,
+[data-card-navigation-scope="hand"] .game-card.hand-card:focus-within,
+[data-card-navigation-scope="hand"] .game-card.hand-card[aria-pressed="true"],
+[data-card-navigation-scope="hand"] .game-card.hand-card.selected,
+[data-card-navigation-scope="hand"] .game-card.hand-card.card-action-available {
+  box-shadow: none !important;
+  outline: none !important;
+  border-color: transparent !important;
+}
+
+[data-card-navigation-scope="hand"] .game-card.hand-card::before,
+[data-card-navigation-scope="hand"] .game-card.hand-card::after,
+[data-card-navigation-scope="hand"] .game-card.hand-card .game-card-surface::before,
+[data-card-navigation-scope="hand"] .game-card.hand-card .game-card-surface::after,
+[data-card-navigation-scope="hand"] .game-card.hand-card .card-circuit-overlay,
+[data-card-navigation-scope="hand"] .game-card.hand-card .card-circuit-edge,
+[data-card-navigation-scope="hand"] .game-card.hand-card .card-circuit-strip-set,
+[data-card-navigation-scope="hand"] .game-card.hand-card > .card-inspector-source-glow,
+[data-card-navigation-scope="hand"] .game-card.hand-card .card-action-border {
+  opacity: 0 !important;
+  animation: none !important;
+  display: none !important;
+}
+
+[data-card-navigation-scope="hand"] .hand-layout-item--selected::before,
+[data-card-navigation-scope="hand"] .hand-layout-item--selected::after {
+  box-shadow: none !important;
+  opacity: 0 !important;
+}
+
+/* Some card PNGs have transparent rounded pixels around their corners. The
+   hand always supplies a black underlay so those pixels never show as white
+   wedges when a card is enlarged. */
+[data-card-navigation-scope="hand"] .game-card.hand-card,
+[data-card-navigation-scope="hand"] .game-card.hand-card .game-card-surface,
+[data-card-navigation-scope="hand"] .game-card.hand-card[data-hand-irregular-corners="true"] .game-card-surface > img {
+  background: #000 !important;
+  background-image: none !important;
+}
+
+[data-card-navigation-scope="hand"] .game-card.hand-card .game-card-surface {
+  overflow: hidden !important;
+}
+
+/* Some legacy scans bake a square, bright pixel wedge outside the printed
+   rounded frame. Clip only that exterior radius: the card art and every
+   genuine frame pixel remain untouched. */
+[data-card-navigation-scope="hand"] .game-card.hand-card .game-card-surface > img {
+  border-radius: 13px !important;
+  clip-path: inset(0 round 13px);
 }
 
 .inspector-oracle-line {


### PR DESCRIPTION
## Summary
- Make hand-card navigation smooth and deterministic across mouse, click, and arrow-key input.
- Keep keyboard and mouse modes exclusive so only one active hand card or inspector detail is shown at a time.
- Add spatial arrow-key navigation for battlefield cards and keep the field inspector synchronized with the focused card.
- Dismiss field inspection when hand inspection becomes active, preventing overlapping card details.
- Repair card-preview corner rendering and remove unwanted hand-card glow/focus effects.

## Validation
- `pnpm exec eslint` passed for all modified component and input-flow files.
- `pnpm run build` reaches Vite but currently fails on the pre-existing missing asset `web/wasm_demo/pkg/verifier_bg.wasm` (outside this PR's changed files).
